### PR TITLE
Remove No Data Available in Table for Bar Graph

### DIFF
--- a/viewController/components/barGraph.js
+++ b/viewController/components/barGraph.js
@@ -460,6 +460,11 @@ export class BarGraph extends Component {
         this.graphType = this.typeIterator.next().value;
     
         const upperGraphTable = d3.select("#upperGraphTable");
+
+        // remove any dummy tables that says "no data available in table" produced by JQuery
+        upperGraphTable.selectAll("thead").remove();
+        upperGraphTable.selectAll("tbody").remove();
+
         this.upperGraphTableHeading = upperGraphTable.append("thead");
         this.upperGraphTableBody = upperGraphTable.append("tbody");
         this.upperGraphTableTitle = d3.select("#upperGraphTableTitle");


### PR DESCRIPTION
- seems like a race condition between **JQuery** initializing its `datatables` and our view adding rows to the table using **D3**. Removed any extra table elements before adding rows in case **JQuery** was faster and loads the _"No Data Available in Table"_