### PR TITLE
Fix hover on legend not working

### DIFF
--- a/viewController/components/barGraph.js
+++ b/viewController/components/barGraph.js
@@ -105,7 +105,7 @@ export class BarGraph extends Component {
     /* Set the opacity of the previously hovered bar's info to be 0 */
     onBarUnHover(d, i){
         this.hideInfoBox();
-        d3.select(`#barHover${i}`).attr("opacity", 0);
+        d3.select(`#barHover${i}`).attr("opacity", 0).style("pointer-events", "none");
     }
 
     // barOnClick(dt): Focus on a particular food group when a bar is clicked

--- a/viewController/components/box.js
+++ b/viewController/components/box.js
@@ -55,14 +55,15 @@ export class Box extends RectSvgComponent {
 
         super.redraw(opts);
 
-        this.background.attr("width", this.width)
-            .attr("height", this.height)
-            .attr("fill", this._backgroundColour);
-
         this.box.attr("y", this.paddingTop)
             .attr("x", this.paddingLeft)
             .attr("width", this.boxWidth)
             .attr("height", this.boxHeight)
             .attr("fill", this.boxColour);
+    }
+
+    setComponentMouseEvents() {
+        super.setComponentMouseEvents();
+        this.setElementMouseEvents(this.box);
     }
 }

--- a/viewController/components/component.js
+++ b/viewController/components/component.js
@@ -313,31 +313,47 @@ export class BackgroundSVGComponent extends SvgComponent {
     redraw(opts = {}) {
         super.redraw(opts);
         this.redrawBackground();
+        this.setMouseEvents();
+    }
 
+    // setMouseEvents(): Sets the mouse events
+    setMouseEvents() {
+        this.setComponentMouseEvents();
+
+        this._onMouseClickChanged = false;
+        this._onMouseEnterChanged = false;
+        this._onMouseLeaveChanged = false;
+        this._onMouseOverChanged = false;
+        this._onMouseMoveChanged = false;
+    }
+
+    // setComponentMouseEvents(): Sets the mouse events for the entire component
+    setComponentMouseEvents() {
+        this.setElementMouseEvents(this.group);
+        this.setElementMouseEvents(this.background);
+    }
+
+    // setElementMouseEvents(element): Sets the mouse events for an element 
+    setElementMouseEvents(element) {
         // add all the mouse events to the background shape
         if (this._onMouseEnter !== null && this._onMouseEnterChanged) {
-            this.group.on("mouseenter", () => { this._onMouseEnter.run() });
-            this._onMouseEnterChanged = false;
+            element.on("mouseenter", () => { this._onMouseEnter.run() });
         }
 
         if (this._onMouseClick !== null && this._onMouseClickChanged) {
-            this.group.on("click", () => { this._onMouseClick.run() });
-            this._onMouseClickChanged = false;
+            element.on("click", () => { this._onMouseClick.run() });
         }
 
         if (this._onMouseLeave !== null && this._onMouseLeaveChanged) {
-            this.group.on("mouseleave", () => { this._onMouseLeave.run() });
-            this._onMouseLeaveChanged = false;
+            element.on("mouseleave", () => { this._onMouseLeave.run() });
         }
 
         if (this._onMouseOver !== null && this._onMouseOverChanged) {
-            this.group.on("mouseover", () => { this._onMouseOver.run() });
-            this._onMouseOverChanged = false;
+            element.on("mouseover", () => { this._onMouseOver.run() });
         }
 
         if (this._onMouseMove !== null && this._onMouseMoveChanged) {
-            this.group.on("mousemove", () => { this._onMouseMove.run() });
-            this._onMouseMoveChanged = false;
+            element.on("mousemove", () => { this._onMouseMove.run() });
         }
     }
 }


### PR DESCRIPTION
- tooltips to the very right of the bar graph are covering part of the legend, causing some entries in the legend not detecting any mouse events.

Image below shows what happens with the hidden feature of the tooltips disabled:
![image](https://github.com/BFSSI-Bioinformatics-Lab/CCHS-food-source-contribution/assets/45087631/b446d25b-80af-4d4d-8c45-5d0770fbb720)
