### PR TITLE
Fix Sunburst Labels, Infobox and Selection

### DIFF
--- a/assets/assets.js
+++ b/assets/assets.js
@@ -81,7 +81,7 @@ export const GraphDims = Object.freeze({
     lowerGraphInfoBoxWidth: 240,
     lowerGraphInfoBoxHeight: 200,
     lowerGraphArcLabelFontSize: 12,
-    lowerGraphArcPadding: 5,
+    lowerGraphArcPadding: 10,
     lowerGraphChartHeadingFontSize: 20,    
     lowerGraphInfoBoxFontSize: 14, 
     lowerGraphInfoBoxBorderWidth: 10,
@@ -117,6 +117,12 @@ export const FontWeight = {
     Bold: "bold",
     Lighter: "lighter",
     Bolder: "bolder"
+}
+
+// mouse pointers
+export const MousePointer = {
+    Pointer: "pointer",
+    Default: "default"
 }
 
 // default attributes used for different components

--- a/viewController/components/legend.js
+++ b/viewController/components/legend.js
@@ -302,7 +302,7 @@ export class Legend extends RectSvgComponent {
 
     // setupLegendItemMouseEvents(mouseEventFunc, name, colour): Setup the mouse event
     //  for a particular legend item
-    setupLegendItemMouseEvents(mouseEventFunc, name, colour) {
+    setupLegendItemMouseEvents(mouseEventFunc, name, colour, legendItem) {
         if (mouseEventFunc === null) {
             return null;
         }
@@ -316,6 +316,7 @@ export class Legend extends RectSvgComponent {
         let result = new Func(mouseEventFunc.func, args);
         result.setArg("name", name);
         result.setArg("colour", colour);
+        result.setArg("legendItem", legendItem);
 
         return result;
     }
@@ -334,13 +335,6 @@ export class Legend extends RectSvgComponent {
             const name = legendData[0];
             const colour = legendData[1];
 
-            // setup the mouse events
-            const legendItemMouseEnter = this.setupLegendItemMouseEvents(this._legendItemMouseEnter, name, colour);
-            const legendItemMouseClick = this.setupLegendItemMouseEvents(this._legendItemMouseClick, name, colour);
-            const legendItemMouseLeave = this.setupLegendItemMouseEvents(this._legendItemMouseLeave, name, colour);
-            const legendItemMouseOver = this.setupLegendItemMouseEvents(this._legendItemMouseOver, name, colour);
-            const legendItemMouseMove = this.setupLegendItemMouseEvents(this._legendItemMouseMove, name, colour);
-
             const legendItem = new LegendItem({parent: this.group,
                                                x: this.paddingLeft + this.marginLeft,
                                                padding: this.legendItemPadding,
@@ -352,13 +346,18 @@ export class Legend extends RectSvgComponent {
                                                fontSize: this.fontSize,
                                                backgroundColour: this._backgroundColour,
                                                name: name,
-                                               legendColour: colour,
-                                               onMouseEnter: legendItemMouseEnter,
-                                               onMouseClick: legendItemMouseClick,
-                                               onMouseLeave: legendItemMouseLeave,
-                                               onMouseOver: legendItemMouseOver,
-                                               onMouseMove: legendItemMouseMove,
+                                               legendColour: colour
                                             });
+
+            // setup the mouse events
+            const legendItemMouseEnter = this.setupLegendItemMouseEvents(this._legendItemMouseEnter, name, colour, legendItem);
+            const legendItemMouseClick = this.setupLegendItemMouseEvents(this._legendItemMouseClick, name, colour, legendItem);
+            const legendItemMouseLeave = this.setupLegendItemMouseEvents(this._legendItemMouseLeave, name, colour, legendItem);
+            const legendItemMouseOver = this.setupLegendItemMouseEvents(this._legendItemMouseOver, name, colour, legendItem);
+            const legendItemMouseMove = this.setupLegendItemMouseEvents(this._legendItemMouseMove, name, colour, legendItem);
+            
+            legendItem.updateAtts({onMouseEnter: legendItemMouseEnter, onMouseClick: legendItemMouseClick, onMouseLeave: legendItemMouseLeave,
+                                   onMouseOver: legendItemMouseOver, onMouseMove: legendItemMouseMove});
 
             this.legendItems.push(legendItem);
         }

--- a/viewController/components/sunBurstGraph.js
+++ b/viewController/components/sunBurstGraph.js
@@ -208,13 +208,18 @@ export class SunBurst extends Component {
     // Add some extra tolerance length to the computed text length due to
     //  the inaccuracy of the getComputedTextLength on different browsers
     getArcTextLength(elementNode, text) {
-        return elementNode.getComputedTextLength() + 3.2 * text.length;
+        return ViewTools.getTextWidth(text, GraphDims.lowerGraphArcLabelFontSize);
+    }
+
+    // getArcLabel(index): Retrieves the element for the label of the arc
+    getArcLabel(index) {
+        return d3.select(`#arcLabel${index}`);
     }
 
     /* Truncates the label based on the arc's width, replaces letters with ellipsis if too long */
     labelTextFit(d, i){
         const midRadius = this.getArcMiddleRadius(d);
-        const element = d3.select(`#arcLabel${i}`);
+        const element = this.getArcLabel(i);
         if (!element.node()) return;
         const elementNode = element.node();
         const availableLength = this.labelAvailableLength(d, midRadius); 
@@ -238,8 +243,8 @@ export class SunBurst extends Component {
 
         // center text only if the text is not truncated
         let textX = 0;
-        if ((d.x1 - d.x0) < 2 * Math.PI) {
-            textX = (d.x1 - d.x0) / 2 * midRadius - elementNode.getComputedTextLength() / 2;
+        if ((d.x1 - d.x0) < 2 * Math.PI && !textTruncated) {
+            textX = (d.x1 - d.x0) / 2.0 * midRadius - ViewTools.getTextWidth(text, GraphDims.lowerGraphArcLabelFontSize) / 2.0;
         }
 
         if (textX < 0) {
@@ -247,8 +252,8 @@ export class SunBurst extends Component {
         }
 
         if (availableLength > 0) {
-            // console.log("NAME: ", d.data.name, " AND TEXT: ", element.text(), "AVAILA: ", availableLength, "CURRENT LEN: ", this.getArcTextLength(elementNode, text), " Y0: ", d.y0, " AND Y1: ", d.y1, " AND TEXT X: ", textX, " AND TRUNCATED: ", textTruncated);
-            // console.log("MID: ", (d.x1 - d.x0) / 2, " AND ", elementNode.getComputedTextLength() / 2, " AND ", (d.x1 - d.x0) / 2 * midRadius - elementNode.getComputedTextLength() / 2);
+            //console.log("NAME: ", d.data.name, " AND TEXT: ", element.text(), "AVAILA: ", availableLength, "CURRENT LEN: ", this.getArcTextLength(elementNode, text), " Y0: ", d.y0, " AND Y1: ", d.y1, " AND TEXT X: ", textX, " AND TRUNCATED: ", textTruncated);
+            //console.log("MID: ", (d.x1 - d.x0) / 2.0, " AND ", ViewTools.getTextWidth(text, GraphDims.lowerGraphArcLabelFontSize) / 2.0, " AND ", (d.x1 - d.x0) / 2.0 * midRadius - ViewTools.getTextWidth(text, GraphDims.lowerGraphArcLabelFontSize) / 2.0);
         }
 
         element.attr("startOffset", GraphDims.lowerGraphArcPadding + textX);
@@ -667,10 +672,10 @@ export class SunBurst extends Component {
             /* Update food group description box */
             function updateInfoBox(d){
                 let colour = GraphColours[d.data.row[NutrientDataColNames.foodGroupLv1]];
+                colour = colour === undefined ? null : colour;
 
                 let foodGroupName = d.data.name;
                 if (self.mouseOverFoodGroupName !== null && self.mouseOverFoodGroupName == foodGroupName) {
-                    lowerGraphInfoBox.render({atts: {text: "", borderColour: Colours.None}});
                     return;
                 }
 

--- a/viewController/components/textBox.js
+++ b/viewController/components/textBox.js
@@ -1,5 +1,6 @@
 import { RectSvgComponent } from "./component.js";
 import { Colours, DefaultDims, TextWrap, DefaultAttributes } from "../../assets/assets.js";
+import { ViewTools } from "../tools/viewTools.js";
 
 export class TextBox extends RectSvgComponent {
     constructor({parent = null, 

--- a/viewController/tools/viewTools.js
+++ b/viewController/tools/viewTools.js
@@ -1,5 +1,6 @@
 // ViewTools: Class of helper functions used only for the view
 export class ViewTools {
+    WidthCanvas = undefined;
 
     /* Returns selected option given a select html tag selector or element */
     static getSelector(element) {
@@ -9,4 +10,21 @@ export class ViewTools {
 
         return element.property("value");
     }
+
+
+    // getTextWidth(text, fontSize, fontFamily): Retrieves the width of 'text' that is more
+    //      stable than D3's getComputedTextLength
+    // Note: D3's getComputedTextLength requires the text element to be rendered to be
+    //      able to get the text length. If the text element is hidden or not rendered yet, then
+    //      getComputedTextLength will always return 0
+    //
+    // Reference: http://stackoverflow.com/questions/118241/calculate-text-width-with-javascript/21015393#21015393
+    static getTextWidth(text, fontSize, fontFamily) {
+        // if given, use cached canvas for better performance
+        // else, create new canvas
+        var canvas = this.WidthCanvas || (this.WidthCanvas = document.createElement("canvas"));
+        var context = canvas.getContext("2d");
+        context.font = fontSize + 'px ' + fontFamily;
+        return context.measureText(text).width;
+    };
 }

--- a/viewController/viewController.js
+++ b/viewController/viewController.js
@@ -15,6 +15,8 @@ class ViewController extends Component{
         this.updateSunburst = null;
         this.updateBarGraph = null;
 
+        this.nutrientSelectorId = "#upperGraphNutrientSelect";
+
         // === individual elements for the component ===
         this.nutrientSelector = null;
         this.sunBurst = null;
@@ -25,8 +27,8 @@ class ViewController extends Component{
 
     setup(opts = {}) {
         const nutrientOptions = Object.keys(this.model.foodIngredientData.dataGroupedByNutrientAndDemo);
-        this.nutrientSelector = d3.select("#upperGraphNutrientSelect")
-            .on("change", () => { this.redraw(); })
+        this.nutrientSelector = d3.select(this.nutrientSelectorId)
+            .on("change", () => { this.redraw(opts); })
             .selectAll("option")
             .data(nutrientOptions)
             .enter()
@@ -43,7 +45,8 @@ class ViewController extends Component{
     }
 
     redraw(opts = {}) {
-        this.model.nutrient = ViewTools.getSelector(this.nutrientSelector);
+        this.model.nutrient = ViewTools.getSelector(this.nutrientSelectorId);
+
         this.updateBarGraph();
         this.updateSunburst();
 


### PR DESCRIPTION
- reactivate the infobox to be displayed when hovering over the arc section
- use 2D canvas' `measureText` instead of D3's `getComputedTextLength` for measuring text since different browsers may render the website's source code differently and `getComputedTextLength` only works if the element has been rendered. For Firefox, some arcs in the sunburst have not been rendered yet during initialization, resulting in garbled, overlapping text
- Needed to reselect the nutrient selection box for the model to get the latest nutrient