### PR TITLE
Fix tooltip units to be used from the CSV

### DIFF
--- a/app/assets.js
+++ b/app/assets.js
@@ -308,7 +308,7 @@ export const TranslationObj = {
                 "tableTitle": "Absolute ({{ amountUnit }}/day) and relative (%) contribution of 12 food groups to daily {{nutrient}} intake",  
                 "toolTipTitle": "{{- name }}",
                 "toolTip_number": [
-                    "Amount: {{amount}} g"
+                    "Amount: {{amount}} {{ unit }}"
                 ],
                 "toolTip_percentage": [
                     "{{ percentage }}% of total {{- nutrient }} intake."
@@ -399,7 +399,7 @@ export const TranslationObj = {
                 "tableTitle": `${REMPLACER_MOI_AVEC_ARGUMENTS} ({{ amountUnit }}/jour) {{nutrient}}`,   
                 "toolTipTitle": "{{- name }}",
                 "toolTip_number": [
-                    `${REMPLACER_MOI_AVEC_ARGUMENTS} {{amount}} g`
+                    `${REMPLACER_MOI_AVEC_ARGUMENTS} {{amount}} {{ unit }}`
                 ],
                 "toolTip_percentage": [
                     `${REMPLACER_MOI_AVEC_ARGUMENTS} {{ percentage }}%  {{- nutrient }} `

--- a/app/barGraph.js
+++ b/app/barGraph.js
@@ -622,7 +622,8 @@ export function upperGraph(model){
             context: graphType,
             amount: parseFloat(d[1]).toFixed(1),
             percentage: parseFloat(d[1]).toFixed(1),
-            nutrient: d[0]
+            nutrient: d[0],
+            unit: nutrientUnit
         });
         
         // ------- draw the tooltip ------------


### PR DESCRIPTION
- units should be read from the CSV `unit` column instead of assuming it is grams