### PR TITLE
Remove Food Group Level 3 column from the donut graph

### DIFF
--- a/app/assets.js
+++ b/app/assets.js
@@ -234,6 +234,10 @@ SortIconClasses[SortStates.Unsorted] = "fa fa-sort"
 SortIconClasses[SortStates.Ascending] = "fa fa-sort-down"
 SortIconClasses[SortStates.Descending] = "fa fa-sort-up"
 
+// column index for the "Food Group Level 3" column of the sunburst graph's table
+export const LowerGraphFoodGroupLv3ColInd = 2;
+
+
 // Translation: Helper class for doing translations
 export class Translation {
     static register(resources){


### PR DESCRIPTION
- When the donut graph is shown for only the level 2 food groups, the table for the donut graph hides the **"Food Group Level 3"** column.
- The **"Food Group Level 3"** column appears back in the table for displaying all the food groups in the sunburst graph
- This change also affects the downloaded CSV for the tables