### PR TITLE
Replaced use of WET's data tables

### DIFF
--- a/app/sunBurstGraph.js
+++ b/app/sunBurstGraph.js
@@ -48,14 +48,6 @@ export function lowerGraph(model){
     // update the header widths of the table when the table is displayed
     //  so that the header of the table aligns with the body of the table
     const details = d3.select("#lowerTableDetails");
-    let dtTable;
-
-    details.on("toggle", () => {
-        if (details.attr("open") !== null) {
-            dtTable = $("#lowerGraphTable").DataTable();
-            dtTable.columns.adjust();
-        }
-    });
 
     // all the hover tooltips for the graph
     const hoverToolTips = {};
@@ -778,7 +770,6 @@ export function lowerGraph(model){
             .enter()
             .append("th")
                 .attr("class", "text-center lowerTableHeader")
-                .style("width", (d, i) => i < amountLeftIndex ? "150px" : "60px")
                 .style("min-width", (d, i) => i < amountLeftIndex ? "50px" : "40px")
                 .style("border-left", (d, i) => i == amountLeftIndex ? GraphDims.tableSectionBorderLeft : "")
                 .style("border-top", "0px")
@@ -857,11 +848,6 @@ export function lowerGraph(model){
 
                         return "rgba(51,51,51,1)";
                     });
-        }
-
-        // update the header widths
-        if (dtTable !== undefined) {
-            dtTable.columns.adjust();
         }
 
         // ---------------------------------------------------------

--- a/index-fr.html
+++ b/index-fr.html
@@ -321,26 +321,9 @@ What it contains:
                         <details id="lowerTableDetails">
                             <summary id="lowerGraphTableTitle"></summary>
                             <div class="table-responsive mrgn-tp-lg lowerGraphTableContainer">
-                                <table class="wb-tables table table-striped table-hover table-condensed text-center"
+                                <table class="dataTable table table-striped table-hover table-condensed text-center"
                                 aria-live="polite"
-                                id="lowerGraphTable"
-                                data-wb-tables='{
-                                "scrollX": false,
-                                "paging": false,
-                                "ordering" : false,
-                                "searching": false,
-                                "processing": false,
-                                "info": false,
-                                "columns": [
-                                    { "data": "Food Group Level 1"},
-                                    { "data": "Food Group Level 2" },
-                                    { "data": "Food Group Level 3" },
-                                    { "data": "Amount (g)" },
-                                    { "data": "Amount SE" },
-                                    { "data": "% of total intake" },
-                                    { "data": "% SE" }
-                                ]
-                                }'>
+                                id="lowerGraphTable">
                                 </table>
                             </div>
                             <div class="mrgn-tp-md">

--- a/index.html
+++ b/index.html
@@ -321,26 +321,9 @@ What it contains:
                         <details id="lowerTableDetails">
                             <summary id="lowerGraphTableTitle"></summary>
                             <div class="table-responsive mrgn-tp-lg lowerGraphTableContainer">
-                                <table class="wb-tables table table-striped table-hover table-condensed text-center"
+                                <table class="dataTable table table-striped table-hover table-condensed text-center"
                                 aria-live="polite"
-                                id="lowerGraphTable"
-                                data-wb-tables='{
-                                "scrollX": false,
-                                "paging": false,
-                                "ordering" : false,
-                                "searching": false,
-                                "processing": false,
-                                "info": false,
-                                "columns": [
-                                    { "data": "Food Group Level 1"},
-                                    { "data": "Food Group Level 2" },
-                                    { "data": "Food Group Level 3" },
-                                    { "data": "Amount (g)" },
-                                    { "data": "Amount SE" },
-                                    { "data": "% of total intake" },
-                                    { "data": "% SE" }
-                                ]
-                                }'>
+                                id="lowerGraphTable">
                                 </table>
                             </div>
                             <div class="mrgn-tp-md">


### PR DESCRIPTION
- Based on another infobase site:
(https://infobase-dev.com/Stephanie/Food-and-Supplements-tool/nutrient-intakes-supplements.html)
found out that they did not use WET's datatables and instead replaced the `wb-tables` class with `dataTables` class in the HTML

- The headers are shown up and the header columns align with the body