### PR TITLE
Fix bargraph table not displaying in Firefox

### DIFF
--- a/index-fr.html
+++ b/index-fr.html
@@ -64,7 +64,7 @@ What it contains:
             <section id="wb-lng" class="text-right">
                 <h2 class="wb-inv">Language selection</h2>
                 <ul class="list-inline margin-bottom-none">
-                    <li><a lang="fr" hreflang="fr" href="index.html">English</a></li>
+                    <li><a lang="en" hreflang="en" href="index.html">English</a></li>
                 </ul>
             </section>
             <div class="row">
@@ -254,40 +254,9 @@ What it contains:
                             <details>
                                 <summary id="upperGraphTableTitle"></summary>
                                 <div class="table-responsive mrgn-tp-lg">
-                                    <table class="wb-tables table table-striped table-hover table-condensed text-center"
+                                    <table class="dataTable table table-striped table-hover table-condensed text-center"
                                     aria-live="polite"
-                                    id="upperGraphTable"
-                                    data-wb-tables='{
-                                    "scrollX": false,
-                                    "paging": false,
-                                    "ordering" : false,
-                                    "searching": false,
-                                    "processing": false,
-                                    "info": false,
-                                    "columns": [
-                                        { "data" : "Food group"},
-                                        { "data":"Population age 1+" }, 
-                                        { "data": "Children 1 to 8 y" }, 
-                                        { "data":"Youth & adolescents 9 to 18 y"},
-                                        { "data":"Adult males 19 y +"},
-                                        { "data":"Adult females* 19 y +"},
-                                        { "data":"Population age 1+" }, 
-                                        { "data": "Children 1 to 8 y" }, 
-                                        { "data":"Youth & adolescents 9 to 18 y"},
-                                        { "data":"Adult males 19 y +"},
-                                        { "data":"Adult females* 19 y +"},
-                                        { "data":"Population age 1+" }, 
-                                        { "data": "Children 1 to 8 y" }, 
-                                        { "data":"Youth & adolescents 9 to 18 y"},
-                                        { "data":"Adult males 19 y +"},
-                                        { "data":"Adult females* 19 y +"},
-                                        { "data":"Population age 1+" }, 
-                                        { "data": "Children 1 to 8 y" }, 
-                                        { "data":"Youth & adolescents 9 to 18 y"},
-                                        { "data":"Adult males 19 y +"},
-                                        { "data":"Adult females* 19 y +"}
-                                    ]
-                                    }'>
+                                    id="upperGraphTable">
                                     </table>
                                 </div>
                                 <button type="button" id="upperGraphSaveTable" class="btn btn-sm btn-success mrgn-tp-md">

--- a/index.html
+++ b/index.html
@@ -254,40 +254,9 @@ What it contains:
                             <details>
                                 <summary id="upperGraphTableTitle"></summary>
                                 <div class="table-responsive mrgn-tp-lg">
-                                    <table class="wb-tables table table-striped table-hover table-condensed text-center"
+                                    <table class="dataTable table table-striped table-hover table-condensed text-center"
                                     aria-live="polite"
-                                    id="upperGraphTable"
-                                    data-wb-tables='{
-                                    "scrollX": false,
-                                    "paging": false,
-                                    "ordering" : false,
-                                    "searching": false,
-                                    "processing": false,
-                                    "info": false,
-                                    "columns": [
-                                        { "data" : "Food group"},
-                                        { "data":"Population age 1+" }, 
-                                        { "data": "Children 1 to 8 y" }, 
-                                        { "data":"Youth & adolescents 9 to 18 y"},
-                                        { "data":"Adult males 19 y +"},
-                                        { "data":"Adult females* 19 y +"},
-                                        { "data":"Population age 1+" }, 
-                                        { "data": "Children 1 to 8 y" }, 
-                                        { "data":"Youth & adolescents 9 to 18 y"},
-                                        { "data":"Adult males 19 y +"},
-                                        { "data":"Adult females* 19 y +"},
-                                        { "data":"Population age 1+" }, 
-                                        { "data": "Children 1 to 8 y" }, 
-                                        { "data":"Youth & adolescents 9 to 18 y"},
-                                        { "data":"Adult males 19 y +"},
-                                        { "data":"Adult females* 19 y +"},
-                                        { "data":"Population age 1+" }, 
-                                        { "data": "Children 1 to 8 y" }, 
-                                        { "data":"Youth & adolescents 9 to 18 y"},
-                                        { "data":"Adult males 19 y +"},
-                                        { "data":"Adult females* 19 y +"}
-                                    ]
-                                    }'>
+                                    id="upperGraphTable">
                                     </table>
                                 </div>
                                 <button type="button" id="upperGraphSaveTable" class="btn btn-sm btn-success mrgn-tp-md">


### PR DESCRIPTION
- When using Firefox, the bargraph table in Infobase cannot be displayed. We know that from this previous commit
(fe03700ce3a2280cb2cfc96c8f4005eafb532288), Infobase seem to have trouble rendering WET's data tables and removing the use of WET's data tables from the website's tables seems to allow Infobase to display the table data perfectly fine