### PR TITLE
Add "Table: " prefix to table titles on the website

### DIFF
--- a/app/assets.js
+++ b/app/assets.js
@@ -330,6 +330,9 @@ export const TranslationObj = {
                 "sourceText": "Data Source: Statistics Canada, 2015 Canadian Community Health Survey - Nutrition, 2015, Share File.",
             },
 
+            // title for the popup tables on the website
+            "popUpTableTitle": "Table: {{title}}",
+
             "upperGraph": {
                 "number": {
                     "graphTitle": "Contribution of 12 food groups to {{ nutrient }} daily {{ amountUnit }}/d and % of total intake",
@@ -452,6 +455,9 @@ export const TranslationObj = {
                 "excludePregnantAndLactating": REMPLACER_MOI,
                 "sourceText": REMPLACER_MOI,
             },
+
+            // title for the popup tables on the website
+            "popUpTableTitle": `${REMPLACER_MOI_AVEC_ARGUMENTS} {{title}}`,
 
             "upperGraph": {
                 "number": {

--- a/app/barGraph.js
+++ b/app/barGraph.js
@@ -495,7 +495,7 @@ export function upperGraph(model){
         }
 
         tableTitleText = Translation.translate("upperGraph.tableTitle", { amountUnit: nutrientUnit, nutrient });
-        upperGraphTableTitle.text(tableTitleText);
+        upperGraphTableTitle.text(Translation.translate("popUpTableTitle", { title: tableTitleText }));
 
         // ---------------------------------------------------------
     }

--- a/app/sunBurstGraph.js
+++ b/app/sunBurstGraph.js
@@ -854,7 +854,7 @@ export function lowerGraph(model){
 
         const titleKeys = getTitleTranslateKeys(ageSexGroup);
         tableTitleText = Translation.translate(`lowerGraph.tableTitle.${titleKeys.ageGroupTranslateKey}.${titleKeys.filterTranslateKey}`, { amountUnit: nutrientUnit, nutrient, ageSexGroup, foodGroup: sunBurstNode.data.name });
-        lowerGraphTableTitle.text(tableTitleText);
+        lowerGraphTableTitle.text(Translation.translate("popUpTableTitle", { title: tableTitleText }));
     }
 
     // getArcColour(treeNode): if a particular tree node in the data does not have a colour, 


### PR DESCRIPTION
- Used to be more clear to distinguish that the popup on the website refers to a table