### PR TITLE
Reset sunburst when clicking on "Show all Groups"

### DIFF
--- a/app/sunBurstGraph.js
+++ b/app/sunBurstGraph.js
@@ -646,8 +646,11 @@ export function lowerGraph(model){
 
         transitionArcs(1000);
         setFilterButtonToLevel2Groups();
+        
+        // Comment out the lines below if we want to get back to the previously clicked arc
+        selectedNodeIndex = 1;
+        selectedNode = null;
 
-        // get back to the previously clicked arc
         arcOnClick(null, selectedNodeIndex);
 
         // update the filter for the table of the sunburst


### PR DESCRIPTION
- When the donut is displayed and the user clicks on **_"Show all Food Groups"_**, the sunburst displays all the food groups instead of the filter for the last clicked food group