### PR TITLE
Fix French translations

### DIFF
--- a/app/assets.js
+++ b/app/assets.js
@@ -445,7 +445,7 @@ export const TranslationObj = {
                 "Nutritional Beverages & Bars": "Boissons et barres nutritionnelles",
                 "Soups - Sauces - Spices & Other Ingredients": "Soupes - sauces - épices et autres ingrédients",
                 "Sweets - Sugars & Savoury Snacks": "Confiserie - sucres et grignotines salées",
-                "All Items": "Toutes les Groupes d'Aliments (réinitialiser)"
+                "All Items": "Tous les groupes d’aliments (réinitialiser)"
             },
 
             // Variable names for the legend
@@ -536,9 +536,9 @@ export const TranslationObj = {
                     },
 
                     "Population1Up": {
-                        "All Items": `Contribution des groupes et sous-groupes d’aliments à l'apport en {{nutrient}} chez les {{ ageSexGroup }}`,
-                        "Filtered Data": `Contribution {{article}} {{ foodGroup }} à l'apport en {{nutrient}} chez les {{ ageSexGroup }}`,
-                        "Filter Only Level 2": `Contribution des sous-groupes de niveau 2 à l'apport en {{nutrient}} chez les {{ ageSexGroup }}`
+                        "All Items": `Contribution des groupes et sous-groupes d’aliments à l'apport en {{nutrient}} chez les Canadiens âgés de 1 an et plus`,
+                        "Filtered Data": `Contribution {{article}} {{ foodGroup }} à l'apport en {{nutrient}} chez les Canadiens âgés de 1 an et plus`,
+                        "Filter Only Level 2": `Contribution des sous-groupes de niveau 2 à l'apport en {{nutrient}} chez les Canadiens âgés de 1 an et plus`
                     }
                 },
                 "tableTitle": {
@@ -549,14 +549,14 @@ export const TranslationObj = {
                     },
 
                     "Population1Up": {
-                        "All Items": `Contribution des groupes et sous-groupes d’aliments à l'apport en {{nutrient}} chez les {{ ageSexGroup }}`,
-                        "Filtered Data": `Contribution {{article}} {{ foodGroup }} à l'apport en {{nutrient}} chez les {{ ageSexGroup }}`,
-                        "Filter Only Level 2": `Contribution des sous-groupes de niveau 2 à l'apport en {{nutrient}} chez les {{ ageSexGroup }}`
+                        "All Items": `Contribution des groupes et sous-groupes d’aliments à l'apport en {{nutrient}} chez les Canadiens âgés de 1 an et plus`,
+                        "Filtered Data": `Contribution {{article}} {{ foodGroup }} à l'apport en {{nutrient}} chez les Canadiens âgés de 1 an et plus`,
+                        "Filter Only Level 2": `Contribution des sous-groupes de niveau 2 à l'apport en {{nutrient}} chez les Canadiens âgés de 1 an et plus`
                     }
                 },
-                "allItems": "Toutes les Groupes d'Aliments",
-                "seeLevel2Groups": "Montre Seulement les Sous-groupes",
-                "seeAllGroups": "Montre Toutes les Groupes d'Aliments",
+                "allItems": "Tous les groupes d’aliments",
+                "seeLevel2Groups": "Afficher sous-groupes uniquement",
+                "seeAllGroups": "Afficher tous les groupes",
                 "toolTipTitle": "{{- name }}",
                 "toolTipLevel": [
                     `{{ percentage }}% de l'apport en {{nutrient}}`

--- a/index-fr.html
+++ b/index-fr.html
@@ -156,75 +156,73 @@ What it contains:
         </nav>
     </header>
     <main property="mainContentOfPage" class="container" typeof="WebPageElement" id="top">
-        <h1 property="name" id="wb-cont">Food source contribution tool (FSCT)<small> <strong>from Health
+        <h1 property="name" id="wb-cont">Outil de contribution des sources alimentaires (OCSA) <small> <strong>de Santé 
             Canada</strong></small></h1>
         <section>
             <p>
-                What foods contribute most to Canadians intake of energy and selected nutrients?	
+                Quels sont les aliments qui contribuent le plus aux apports énergétiques et en nutriments sélectionnés des Canadiens ?	
             </p>
             <p>
-                Explore how different food groups contribute to Canadians’ children, youth and adults intakes of energy and various nutrients using data collected in the 2015 Canadian Community Health Survey – Nutrition (CCHS – Nutrition). This visualization tool complements the Food source contribution tables published on the Government of Canada’s Open Data portal.
+                Explorez la contribution des différents groupes d'aliments aux apports énergétiques et en nutriments des enfants, des jeunes et des adultes canadiens à l'aide des données recueillies dans le cadre de l'Enquête sur la santé dans les collectivités canadiennes - Nutrition (ESCC - Nutrition) de 2015. Cet outil de visualisation complète les tableaux de contribution des sources alimentaires publiés sur le portail de données ouvertes du gouvernement du Canada.
             </p>
             <p>
-                Choose a nutrient from the drop down menu to see how different food groups contribute to intakes of five age-sex groups.
+                Choisissez un nutriment dans le menu déroulant pour voir comment les différents groupes d'aliments contribuent aux apports de cinq groupes d'âge-sexe. 
+            </p>
             <p>
-                Then, explore the data in more detail by selecting an age-sex group and see how more specific food sub-groups contribute to intakes in the graph below. 
+                Ensuite, explorez les données plus en détail en sélectionnant un groupe d'âge-sexe et voyez comment les sous-groupes d'aliments plus spécifiques contribuent aux apports dans le graphique ci-dessous. 
             </p>
         </section>
         <details class="acc-group mrgn-tp-lg">
-            <summary class="wb-toggle tgl-tab">How to use the tool</summary>
+            <summary class="wb-toggle tgl-tab">Comment utiliser l'outil </summary>
             <div class="tgl-panel">
-                The graph at the top of the page compares 
-                how 12 broad food groups contribute to 
-                intake among children, youth & adolescents, 
-                adult females and adult males and the whole 
-                population. 
+                Le diagramme à barres en haut de la page compare la contribution de 12 grands groupes alimentaires 
+                aux apports alimentaires des enfants, des jeunes et des adolescents, 
+                des femmes adultes et des hommes adultes et de l'ensemble de la population.
                 <ol class="mrgn-tp-lg">
                     <li>
-                        Choose a Nutrient by selecting from the 
-                        dropdown menu at the top left hand side 
-                        of the screen.
+                        Choisissez un nutriment dans le menu déroulant 
+                        situé en haut à gauche de l'écran. 
+                        
                     </li>
                     <li class="mrgn-tp-md">
-                        To display a detailed description of what 
-                        is included in each food group, <b>hover over or tab to</b> 
-                         any specific food group in 
-                        the graph or the legend. <b>Click</b> to isolate a 
-                        food group, click again to restore the 
-                        complete graph.
+                        Pour afficher une description détaillée de ce qui 
+                        est inclus dans chaque groupe alimentaire, <b>survolez</b> 
+                        un groupe alimentaire spécifique dans
+                        le graphique ou la légende. <b>Cliquez</b> pour isoler 
+                        un groupe d'aliments, cliquez à nouveau pour 
+                        rétablir le graphique complet.
                     </li>
                     <li class="mrgn-tp-md mrgn-bttm-lg">
-                        Use the <i>“Switch to”</i> 
-                        button to toggle between number and 
-                        percentage of contribution.
+                        Le bouton  <i>“Afficher les”</i> 
+                        permet de basculer entre le nombre et le pourcentage de contribution. 
                     </li>
                 </ol>
 
-                The sunburst diagram at the bottom of the page takes a closer look at how more specific food sub-groups contribute to intakes.  
+                Le diagramme en rayons de soleil en bas de la page permet d'examiner de 
+                plus près comment plus spécifiquement des sous-groupes d'aliments contribuent aux apports.  
 
-                <ol class="mrgn-tp-lg">
+                <ol class="mrgn-tp-lg mrgn-bttm-lg">
                     <li class="mrgn-tp-md">
-                        Select an age-sex group from the drop down menu. 
+                        Sélectionnez un groupe d'âge et de sexe dans le menu déroulant. 
                     </li>
                     <li class="mrgn-tp-md">
-                        Each broad food group is represented in a 
-                        different color and sub-group contribution 
-                        is shown in the outside layers. <b>Hover over</b> a 
-                        food group for more information. 
+                        Chaque grand groupe alimentaire est représenté dans une couleur 
+                        différente et la contribution des sous-groupes est indiquée dans les couches 
+                        extérieures du diagramme. <b>Survolez un</b> groupe alimentaire pour plus d'informations. 
                     </li>
                     <li class="mrgn-tp-md">
-                        Click on the label in the legend to take a closer 
-                        look into a food group. Click again to restore the complete diagram.
+                        Cliquez sur un sous-groupe dans la légende pour examiner de plus 
+                        près un groupe d'aliments. Cliquez à nouveau pour restaurer le diagramme complet.
                     </li>
-                    <li class="mrgn-tp-md mrgn-bttm-lg">
-                        To see the level 2 sub-groups results in ranked order, 
-                        click on the <i>"Show sub-groups only"</i> button. 
-                        To restore the complete graph click on the <i>"Show all Food Groups button"</i>  
+                    <li class="mrgn-tp-md">
+                        Pour voir les résultats des sous-groupes de niveau 2 par ordre de contribution, 
+                        cliquez sur le bouton <i>"Afficher sous-groupes uniquement"</i>. Pour restaurer le graphique 
+                        complet, cliquez sur le bouton <i>"Afficher tous les groupes"</i>.  
                     </li>
                 </ol>
 
-                The graphs and raw data can be downloaded by clicking respectively 
-                on the save graph and download table buttons.
+                Le graphique et les données brutes peuvent être téléchargés en cliquant 
+                respectivement sur les boutons <i>"télécharger le graphique"</i> et <i>"télécharger les données"</i>.
             </div>
         </details>
         <section>
@@ -233,14 +231,14 @@ What it contains:
                 <section id="upper">
                     <div class="form-group-sm form-inline">
                         <label for="nutrientSelect" class="form-label">
-                            Select Nutrient: 
+                            Sélectionner un nutriment:
                         </label>
                         <select class="form-control" name="nutrientSelect" title="Select nutrient" id="upperGraphNutrientSelect"></select>
                     </div>
                     <div class="graphExtra">
                         <div class="upperGraphActions">
-                            <button class="btn btn-info" id="upperGraphSwitchType">Switch to Numbers</button>
-                            <button class="btn btn-success" id="upperGraphSaveGraph">Save graph (png)</button>
+                            <button class="btn btn-info" id="upperGraphSwitchType">Afficher les Nombres</button>
+                            <button class="btn btn-success" id="upperGraphSaveGraph">Télécharger le graphique (png)</button>
                         </div>
                     </div>
                     <div class="row mrgn-tp-lg">
@@ -268,7 +266,7 @@ What it contains:
                                 </div>
                                 <button type="button" id="upperGraphSaveTable" class="btn btn-sm btn-success mrgn-tp-md">
                                     <span class="text-white glyphicon glyphicon-cloud-download px-2"></span>
-                                    Download table (.csv)
+                                    Télécharger le tableau (.csv)
                                 </button>                            
                             </details>
                         </div>
@@ -277,7 +275,7 @@ What it contains:
                 <section id="lower" class="mrgn-tp-xl">
                     <div class="form-group-sm form-inline">
                         <label for="ageSexSelect" class="form-label">
-                            Select age-sex group: 
+                            Sélectionnez un groupe âge-sexe: 
                         </label>
                         <select class="form-control" name="ageSexSelect" title="Select age-sex group" id="lowerGraphAgeSexSelect"></select>
                     </div>
@@ -286,13 +284,13 @@ What it contains:
                             <img class="lowerGraphBtnIcon mrgn-rght-sm">
                             <span></span>
                         </button>
-                        <button class="btn btn-success" id="lowerGraphSaveGraph">Save graph</button>
+                        <button class="btn btn-success" id="lowerGraphSaveGraph">Télécharger le graphique (png)</button>
                     </div>
                     <div class="row mrgn-tp-lg">
                         <figure id="lowerGraph" class="mrgn-tp-xl"></figure>
                     </div>
                     <div class="mrgn-top-md">
-                        <button class="btn btn-info" id="lowerGraphReturnToSelection">Return to Nutrient Selection</button>
+                        <button class="btn btn-info" id="lowerGraphReturnToSelection">Retourner à la sélection des nutriments</button>
                     </div>
                     <div class="col-xs-12 mrgn-tp-md">
                         <details id="lowerTableDetails">
@@ -306,11 +304,11 @@ What it contains:
                             <div class="mrgn-tp-md">
                                 <button type="button" id="lowerGraphSaveTable" class="btn btn-sm btn-success">
                                     <span class="text-white glyphicon glyphicon-cloud-download px-2"></span>
-                                    Download displayed data (.csv)
+                                    Télécharger les données affichées (.csv)
                                 </button>     
                                 <button type="button" id="lowerGraphSaveAllData" class="btn btn-sm btn-success">
                                     <span class="text-white glyphicon glyphicon-cloud-download px-2"></span>
-                                    Download all data (.csv)
+                                    Télécharger toutes les données (.csv)
                                 </button>   
                             </div>                    
                         </details>
@@ -319,128 +317,120 @@ What it contains:
             </div>
             
             <div class="text-right mrgn-tp-lg">
-                <a href="#top">Back To Top<span class="glyphicon glyphicon-chevron-up"></span></a>
+                <a href="#top">Retour au haut de la page<span class="glyphicon glyphicon-chevron-up"></span></a>
             </div>
             <br>
     
             <div class="row" id="notes-section">
                 <section class="alert alert-info barchart-legend">
-                    <h3>Notes & Legend</h3>
+                    <h3>Notes et Légende</h3>
                     <table class="table table-condensed table-responsive">
                         <tbody>
                         <tr >
-                            <td style=" padding-top: 15px; padding-bottom:10px "><strong>Data
-                                Source</strong></td>
-                            <td style=" padding-top: 15px; padding-bottom:10px ">Statistics Canada, Canadian Community Health Survey (CCHS) -
-                                Nutrition, 2015, Share
-                                Files.
+                            <td style=" padding-top: 15px; padding-bottom:10px "><strong>Sources des données</strong></td>
+                            <td style=" padding-top: 15px; padding-bottom:10px ">
+                                Statistique Canada, Enquête sur la santé dans les collectivités canadiennes 2015 - Nutrition, 2015, Fichier partagé.
                             </td>
                         </tr>
                         <tr >
                             <td style="min-width: 180px; padding-top: 15px; padding-bottom:10px">
-                                <strong>Food Source Contribution Table on Open Data</strong></td>
+                                <strong>Tableau de contribution des sources d'alimentation sur les données ouvertes</strong></td>
                             <td style=" padding-top: 15px; padding-bottom:10px ">
                                 <p>
-                                    Data for additional age-sex groups can be found in the Food Source Contribution Table available on the Government of Canada’s Open Data portal
+                                    Les données pour d'autres groupes d'âge et de sexe se trouvent dans le tableau de contribution des sources alimentaires  
+                                    disponible sur le portail de données ouvertes du gouvernement du Canada.
                                 </p>
                             </td>
                         </tr>
                         <tr >
                             <td style="min-width: 180px; padding-top: 15px; padding-bottom:10px">
-                                <strong>Interpretation of data</strong></td>
+                                <strong>Interprétation des données</strong></td>
                             <td style=" padding-top: 15px; padding-bottom:10px ">
                                 <section class="alert alert-warning">
                                     <p>
-                                        Foods that are known to be rich sources of a nutrient may not be a major contributor to population intakes of that nutrient 
-                                        if they are consumed in low amounts. On the other hand, some less nutrient-dense foods may make a large contribution to population 
-                                        intakes simply because they are widely consumed and/or consumed in large amounts.
+                                        Les aliments connus pour être de riches sources d'un nutriment peuvent ne pas contribuer de manière significative 
+                                        aux apports de ce nutriment dans la population s'ils sont consommés en faibles quantités. En revanche, certains aliments 
+                                        moins riches en nutriments peuvent contribuer de manière importante aux apports de la population simplement parce qu'ils sont 
+                                        largement consommés et/ou consommés en grandes quantités.                     
                                     </p>
                                 </section>
                             </td>
                         </tr>
                         <tr >
                             <td style="min-width: 180px; padding-top: 15px; padding-bottom:10px">
-                                <strong>About the graphs and tables</strong></td>
+                                <strong>À propos des diagrammes et des tableaux</strong></td>
                             <td style=" padding-top: 15px; padding-bottom:10px ">
-                                <strong>Recipe Analysis:</strong>
+                                <strong>Analyse de la recette:</strong>
                                 <p>
-                                    The Food Source Contribution Tool food groups were generated by combining foods 
-                                    consumed as a food on its own or as an ingredient. For example, looking at the egg 
-                                    category, the contribution of eggs is based on the total consumption of eggs coming 
-                                    from hard-boiled eggs (food) and eggs used in recipes such as quiches, homemade cakes, 
-                                    etc. The contribution of some ingredients such as eggs, sugar, flour, etc. may be 
-                                    underestimated due to the inability to break down some foods that represent commercial food products.
+                                    Les groupes d'aliments de l'outil de contribution des sources alimentaires ont été générés en combinant les aliments consommés 
+                                    en tant qu'aliment seul ou en tant qu'ingrédient. Par exemple, dans la catégorie des œufs, la contribution des œufs est basée sur 
+                                    la consommation totale d'œufs durs (aliment) et d'œufs utilisés dans des recettes telles que les quiches, les gâteaux maison, etc. 
+                                    La contribution de certains ingrédients tels que les œufs, le sucre, la farine, etc. peut être sous-estimée en raison de l'impossibilité 
+                                    de décomposer certains aliments qui représentent des produits alimentaires commerciaux.
                                 </p>
                                 <p class="mrgn-tp-lg">
-                                    If interested, a second dataset that analysis recipes as a whole along with food consumed on its own is also available on the Government of Canada's Open Data Portal
+                                    Si vous êtes intéressé, un deuxième ensemble de données analysant les recettes dans leur ensemble ainsi que les aliments consommés 
+                                    seuls est également disponible sur le portail de données ouvertes du gouvernement du Canada.
                                 </p>
-                                <strong class="mrgn-tp-lg">Food Groups:</strong>
+                                <strong class="mrgn-tp-lg">Groupes d'aliments:</strong>
                                 <p>
-                                    Estimates were generated for three different levels of food grouping based on the food group list from the Bureau of Nutritional Sciences (BNS) with some modifications. 
+                                    Les estimations ont été générées pour trois niveaux différents de regroupement d’aliments, basé sur la liste des groupes 
+                                    d’aliments du Bureau des sciences de la nutrition (BSN), avec quelques modifications. 
                                 </p>
                                 <strong class="mrgn-tp-lg">Estimates:</strong>
                                 <p>
-                                    All estimates were obtained from the first 24-hour dietary recall. 
-                                </p>
-                                <p class="mrgn-tp-xl">
-                                    For more information please consult the Food Source Contribution Table (FSCT) – User guide. 
+                                    Toutes les estimations ont été obtenues à partir du premier rappel alimentaire de 24 heures. 
                                 </p>
                             </td>
                         </tr>
                         <tr >
                             <td style="min-width: 180px; padding-top: 15px; padding-bottom:10px">
-                                <strong>About the 2015 Canadian Community Health Survey – Nutrition (CCHS –Nutrition)</strong></td>
+                                <strong>À propos de l'Enquête sur la santé dans les collectivités canadiennes - Nutrition (ESCC - Nutrition) de 2015</strong></td>
                             <td style=" padding-top: 15px; padding-bottom:10px ">
                                 <p>
-                                The 2015 CCHS-Nutrition is a nationally representative survey of the nutrition of people in Canada. The survey 
-                                provides detailed information on food consumption using a 24-hour dietary recall for the total sample 
-                                and a repeat sub-sample, dietary supplement intake, physical measurements, household food insecurity, 
-                                and other topics that support the interpretation of the 24-hour recall. The survey excludes those living 
-                                in the three territories, individuals living on reserves, residents of institutions, full‐time members of 
-                                the Canadian Armed Forces and residents of certain remote regions.
-                                </p>
-                                <p class="mrgn-tp-lg">
-                                    For more information on CCHS - Nutrition, please consult the Reference Guide to Understanding and Using the Data
+                                    L'ESCC-Nutrition 2015 est une enquête nationale au sujet de la nutrition des personnes vivant au Canada . L'enquête fournit des informations détaillées sur 
+                                    l’apport alimentaire en utilisant un rappel alimentaire de 24 heures effectué chez l’ensemble du groupe et d’un deuxième rappel effectué auprès d’un échantillon, 
+                                    la consommation de suppléments nutritionnels, les mesures physiques, l’insécurité alimentaire des ménages ainsi que d’autres sujets permettant de mieux interpréter 
+                                    les données des rappels de 24 heures.. L'enquête exclut les personnes vivant dans les trois territoires, les personnes vivant dans les réserves, la population vivant en 
+                                    établissement, les membres à temps plein des Forces armées canadiennes et les résidents de certaines régions éloignées.
                                 </p>
                             </td>
                         </tr>
                         <tr>
                             <td style="min-width: 180px; padding-top: 15px; padding-bottom:10px" id='legend'>
-                                <strong>Legend</strong></td>
+                                <strong>Légende</strong></td>
                             <td style=" padding-top: 15px; padding-bottom:10px ">
                                 <!--<ul style="list-style-type: none">-->
-                                    <p class>
-                                        <strong>E:</strong> Data with a coefficient of variation (CV)
-                                        from 16.6% to 33.3%; interpret with caution.
+                                    <p>
+                                        <strong>E:</strong>Données dont le coefficient de variation (CV) se situe entre 16,6 % à 33,3 %; interpréter avec prudence.
                                     </p>
                                     <p class="mrgn-tp-lg">
-                                        <strong>F:</strong> Data with a CV greater than 33.3%
-                                        with a 95% confidence interval entirely between 0 and 3%;
-                                        interpret with caution.
+                                        <strong>F:</strong> Données dont le CV est supérieur à 33, 3%, avec un intervalle de confiance de 95% pas entièrement 
+                                        compris entre 0 et 3%; supprimées en raison de l'extrême variabilité d'échantillonnage.
                                     </p>
                                     <p class="mrgn-tp-lg">
-                                        <strong>X:</strong> food group with less than 10 eaters; supressed to meet confidentiality requirements
+                                        <strong>X:</strong> groupe d’aliment avec moins de 10 mangeurs ; supprimé pour des raisons de confidentialité.
                                     </p>
                                     <p class="mrgn-tp-lg"><strong>D:</strong> Day</p>
-                                    <p class="mrgn-tp-lg"><strong>DFE:</strong> Dietary folate equivalent</p>
-                                    <p class="mrgn-tp-lg"><strong>g:</strong> Gram</p>
+                                    <p class="mrgn-tp-lg"><strong>EFA:</strong> Équivalent de folate alimentaire</p>
+                                    <p class="mrgn-tp-lg"><strong>g:</strong> Gramme</p>
                                     <p class="mrgn-tp-lg"><strong>kcal:</strong> Kilocalories</p>
-                                    <p class="mrgn-tp-lg"><strong>mcg:</strong> Microgram</p>
-                                    <p class="mrgn-tp-lg"><strong>mg:</strong> Milligram</p>
-                                    <p class="mrgn-tp-lg"><strong>n:</strong> Sample size</p>
-                                    <p class="mrgn-tp-lg"><strong>SE:</strong> Standard Error</p>
+                                    <p class="mrgn-tp-lg"><strong>mcg:</strong> Microgramme</p>
+                                    <p class="mrgn-tp-lg"><strong>mg:</strong> Milligramme</p>
+                                    <p class="mrgn-tp-lg"><strong>n:</strong> Taille de l'échantillon</p>
+                                    <p class="mrgn-tp-lg"><strong>ET:</strong> Erreur type</p>
 
                                     <p class="mrgn-tp-xl">
-                                        <i>* Excludes pregnant and lactating women</i>
+                                        <i>* Exclut les femmes enceintes et allaitantes</i>
                                     </p>
                             </td>
                         </tr>
                         <tr >
                             <td style="min-width: 180px; padding-top: 15px; padding-bottom:10px">
-                                <strong>Suggested citation</strong></td>
+                                <strong>Citation suggérée</strong></td>
                             <td style=" padding-top: 15px; padding-bottom:10px ">
                                 <p>
-                                    Health Canada (2023). Food Source Contribution Table derived from Statistics Canada's 2015 Canadian Community Health Survey, Nutrition, Share file. Ottawa.
+                                    Santé Canada (2023). Tableau de contribution des sources alimentaire dérivé de l'Enquête sur la santé dans les collectivités canadiennes 2015 de Statistique Canada, Nutrition, fichier partagé, Ottawa.
                                 </p>
                             </td>
                         </tr>
@@ -449,7 +439,7 @@ What it contains:
                                 <strong>Correspondence</strong></td>
                             <td style=" padding-top: 15px; padding-bottom:10px ">
                                 <p>
-                                    Bureau of Food Surveillance and Science Integration, Food Directorate, Health Canada, 251 Sir Frederick Banting Driveway, A.L. 2201E, Ottawa, ON K1A 0K9; Email: nutrition.surveillance-nutritionnelle@hc-sc.gc.ca
+                                    Bureau de l'intégration des données, de la science et des connaissances, Direction des aliments, Santé Canada, 251 Sir Frederick Banting Driveway, A.L. 2201E, Ottawa, ON K1A 0K9; Courriel : nutrition.surveillance-nutritionnelle@hc-sc.gc.ca
                                 </p>
                             </td>
                         </tr>
@@ -461,15 +451,15 @@ What it contains:
                 </section>
                 <section class="alert alert-info">
                     <p>
-                        For more information on CCHS - Nutrition, please consult the
+                        Pour plus d'informations, veuillez consulter le
                         <a
                             href="https://www.canada.ca/en/health-canada/services/food-nutrition/food-nutrition-surveillance/health-nutrition-surveys/canadian-community-health-survey-cchs/compendium-data-tables-intakes-energy-nutrients-other-food.html"
                             target="_blank">
-                            Food Source Contribution Table (FSCT) - User guide
+                            Tableau de Contribution des Sources d'Alimentation (TSCA) - Guide de l'Utilisateur. 
                         </a>
-                        and the
-                        <a href="https://www.canada.ca/en/health-canada/services/food-nutrition/food-nutrition-surveillance/health-nutrition-surveys/canadian-community-health-survey-cchs/reference-guide-understanding-using-data-2015.html" target="_blank">Reference
-                            Guide to Understanding and Using the Data
+                        et le
+                        <a href="https://www.canada.ca/en/health-canada/services/food-nutrition/food-nutrition-surveillance/health-nutrition-surveys/canadian-community-health-survey-cchs/reference-guide-understanding-using-data-2015.html" target="_blank">
+                            Guide de référence pour la compréhension et l'utilisation des données
                         </a>.
                     </p>
                 </section>

--- a/index.html
+++ b/index.html
@@ -277,7 +277,7 @@ What it contains:
                 <section id="lower" class="mrgn-tp-xl">
                     <div class="form-group-sm form-inline">
                         <label for="ageSexSelect" class="form-label">
-                            Select age-sex group: 
+                            Select an age-sex group: 
                         </label>
                         <select class="form-control" name="ageSexSelect" title="Select age-sex group" id="lowerGraphAgeSexSelect"></select>
                     </div>
@@ -286,7 +286,7 @@ What it contains:
                             <img class="lowerGraphBtnIcon mrgn-rght-sm">
                             <span></span>
                         </button>
-                        <button class="btn btn-success" id="lowerGraphSaveGraph">Save graph</button>
+                        <button class="btn btn-success" id="lowerGraphSaveGraph">Save graph (png)</button>
                     </div>
                     <div class="row mrgn-tp-lg">
                         <figure id="lowerGraph" class="mrgn-tp-xl"></figure>


### PR DESCRIPTION
- Add back suffix of _"Canadiens âgés de 1 an et plus"_ for the sunburst title when selected _"population aged 1+"_ for the age sex group 
- Replaced _“Toutes les Groupes d'Aliments”_ with _“Tous les groupes d’aliments”_
- Fixed translations for the sunburst toggle buttons
- Translate the age-sex group dropdown and the sunburst save png button

### Note:
- restored back previous French translations from a previous commit