### PR TITLE
Sort nutrient options by alphabetical order

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -23,7 +23,7 @@ function setup(model) {
     const updateBarGraph = upperGraph(model);
     const updateSunburst = lowerGraph(model);
 
-    const nutrientOptions = Object.keys(model.graphNutrientTablesByDemoGroupLv1);
+    const nutrientOptions = Object.keys(model.graphNutrientTablesByDemoGroupLv1).sort(Intl.Collator().compare);
     d3.select(nutrientSelectorId)
         .on("change", () => { update() })
         .selectAll("option")


### PR DESCRIPTION
- We used `Intl.Collator()` to allow sorting of special characters for certain languages

_eg.
**"Énergie"** should come before **"Fer"** instead of after **"Fer"**_