### PR TITLE
Fix backslash prefixing single quote in CSV

### DIFF
--- a/app/backend.js
+++ b/app/backend.js
@@ -55,7 +55,7 @@ export class TableTools {
 
             // clean up the text for each cell
             for (let i = 0; i < colLen; ++i) {
-                let cleanedText = `${row[i]}`.replace(/"/g, '\\"').replace(/'/g, "\\'");
+                let cleanedText = `${row[i]}`.replace(/"/g, "'");
                 cleanedText = `"${cleanedText}"`;
                 csvRow.push(cleanedText);
             }


### PR DESCRIPTION
- Before, when the CSV text was generated, all single quotes (') were replaced with a backslash followed by a single quote (\'). Removed this string replacement.
- Also fixed the string replacement for double quotes so that all double quotes will be replaced with a single quote instead so that we will not have this same bug for double quotes