### PR TITLE
French replace decimal with comma

### DIFF
--- a/app/assets.js
+++ b/app/assets.js
@@ -383,10 +383,10 @@ export const TranslationObj = {
                 "tableTitle": "Contribution of 12 food groups to {{ nutrient }} daily {{ amountUnit }}/d and % of total intake",
                 "toolTipTitle": "{{- name }}",
                 "toolTip_number": [
-                    "Amount: {{amount}} {{ unit }}"
+                    "Amount: {{amount, number}} {{ unit }}"
                 ],
                 "toolTip_percentage": [
-                    "{{ percentage }}%"
+                    "{{ percentage, number }}%"
                 ],
                 "tableSubHeadingFirstCol": "Food Group",
                 "tableSubHeadings": ["Amount ({{unit}})", "Amount SE", "% of total intake", "% SE"]
@@ -424,11 +424,11 @@ export const TranslationObj = {
                 "allFoodGroupsLabel": "All Food Groups",
                 "toolTipTitle": "{{- name }}",
                 "toolTipLevel": [
-                    "{{ percentage }}% of {{ nutrient }} intake"
+                    "{{ percentage, number }}% of {{ nutrient }} intake"
                 ],
                 /* If the context number is not between 1-4 */
                 "hoverBoxLevel_other": [ 
-                    "{{ percentage }}% of {{ nutrient }} intake."
+                    "{{ percentage, number }}% of {{ nutrient }} intake."
                 ],
                 "tableHeadings": ["Food Group Level 1", "Food Group Level 2", "Food Group Level 3", "Amount ({{unit}})", "Amount SE", "% of total intake", "% SE"],
                 "tableAllDataHeadings": ["Age-sex Group", "Food Group Level 1", "Food Group Level 2", "Food Group Level 3", "Amount ({{unit}})", "Amount SE", "% of total intake", "% SE"],
@@ -532,10 +532,10 @@ export const TranslationObj = {
                 "tableTitle": `Contribution de 12 groupes d'aliments à l'apport quotidien en {{nutrient}} ({{ amountUnit }}/jour) et % de l'apport total`,   
                 "toolTipTitle": "{{- name }}",
                 "toolTip_number": [
-                    `Quantité: {{amount}} {{ unit }}`
+                    `Quantité: {{amount, number }} {{ unit }}`
                 ],
                 "toolTip_percentage": [
-                    `{{ percentage }}%`
+                    `{{ percentage, number }}%`
                 ],
                 "tableSubHeadingFirstCol": "Groupe d'Aliments",
                 "tableSubHeadings": ["Moyenne ({{unit}})", "ET Moyenne", "% de l'Apport Total", "ET %"]
@@ -572,11 +572,11 @@ export const TranslationObj = {
                 "seeAllGroups": "Afficher tous les groupes",
                 "toolTipTitle": "{{- name }}",
                 "toolTipLevel": [
-                    `{{ percentage }}% de l'apport en {{nutrient}}`
+                    `{{ percentage, number }}% de l'apport en {{nutrient}}`
                 ],
                 /* If the context number is not between 1-4 */
                 "hoverBoxLevel_other": [ 
-                    `{{ percentage }}% de l'apport en {{ nutrient }}`
+                    `{{ percentage, number }}% de l'apport en {{ nutrient }}`
                 ],
                 "tableHeadings": ["Groupe d'Aliments Niveau 1", "Groupe d'Aliments Niveau 2", "Groupe d'Aliments Niveau 3", "Moyenne ({{unit}})", "ET Moyenne", "% de l'Apport Total", "ET %"],
                 "tableAllDataHeadings": ["Groupe Âge-sexe", "Groupe d'Aliments Niveau 1", "Groupe d'Aliments Niveau 2", "Groupe d'Aliments Niveau 3", "Moyenne ({{unit}})", "ET Moyenne", "% de l'Apport Total", "ET %"],

--- a/app/assets.js
+++ b/app/assets.js
@@ -273,6 +273,13 @@ export class Translation {
         if (typeof result !== 'string') return result;
         return he.decode(result);
     }
+
+    // translateNumStr(numStr): Translate a number to its correct
+    //  numeric represented string for different languages
+    // eg. '1.2' -> '1,2' in French
+    static translateNum(num) {
+        return this.translate("Number", {num});
+    }
 }
 
 
@@ -283,6 +290,8 @@ const REMPLACER_MOI_AVEC_ARGUMENTS = `${REMPLACER_MOI} - les arguments du texte:
 export const TranslationObj = {
     en: {
         translation: {
+            Number: "{{num, number}}",
+
             // Names used for the legend
             // Note: Copy the exact food group lv1 name from the food ingredient CSV file
             LegendKeys: {
@@ -430,6 +439,8 @@ export const TranslationObj = {
     },
     fr: { 
         translation: {
+            Number: "{{num, number}}",
+
             // Names used for the legend
             // Note: Copy the exact food group lv1 name from the source CSV files
             LegendKeys: {

--- a/app/assets.js
+++ b/app/assets.js
@@ -277,7 +277,9 @@ export class Translation {
     // translateNumStr(numStr): Translate a number to its correct
     //  numeric represented string for different languages
     // eg. '1.2' -> '1,2' in French
-    static translateNum(num) {
+    static translateNum(numStr) {
+        const num = Number(numStr);
+        if (Number.isNaN(num)) return numStr;
         return this.translate("Number", {num});
     }
 }

--- a/app/backend.js
+++ b/app/backend.js
@@ -269,6 +269,7 @@ export class Model {
 
     // strNumCompare(value1, value): Compare function that gives numbers precedence over strings
     static strNumCompare(value1, value2) {
+        console.log("value1: ", value1, " AND val2: ", value2);
         const num1 = parseFloat(value1);
         const num2 = parseFloat(value2);
         const num1IsNAN = Number.isNaN(num1);

--- a/app/barGraph.js
+++ b/app/barGraph.js
@@ -22,7 +22,6 @@
 
 import { Colours, GraphColours, GraphDims, TextWrap, FontWeight, MousePointer, Translation, SortIconClasses, SortStates } from "./assets.js";
 import { drawWrappedText, drawText } from "./visuals.js";
-import { Model } from "./backend.js";
 
 
 export function upperGraph(model){
@@ -407,16 +406,6 @@ export function upperGraph(model){
         const barGraphTable = reloadData ? model.createBarGraphTable(tableTitleText) : model.barGraphTable;
         const amountLeftIndex = 1;
 
-        // keep track of which column indices refer to numbered columns
-        const numColIndices = [];
-        const compareFuncsLen = barGraphTable.compareFuncs.length;
-
-        for (let i = 0; i < compareFuncsLen; ++i) {
-            if (barGraphTable.compareFuncs[i] == Model.strNumCompare) {
-                numColIndices.push(i);
-            }
-        }
-
         // --------------- draws the table -------------------------
 
         /* Create top-level heading */
@@ -487,19 +476,21 @@ export function upperGraph(model){
             barGraphTableDataRows = barGraphTableDataRows.toSorted((row1, row2) => { return barGraphTable.compareFuncs[sortedColIndex](row2[sortedColIndex], row1[sortedColIndex]) });
         }
 
-        console.log("NumColIndices: ", numColIndices);
-
         // translate the numbers for French
         const barGraphDisplayedTable = [];
         for (const row of barGraphTableDataRows) {
-            for (const colInd of numColIndices) {
-                row[colInd] = Translation.translateNum(row[colInd]);
+            const currentRow = [];
+            const colLen = row.length;
+            for (let i = 0; i < colLen; ++i) {
+                currentRow.push(model.barGraphTable.colIsNumbered[i] ? Translation.translateNum(row[i]) : row[i]);
             }
+
+            barGraphDisplayedTable.push(currentRow);
         }
         
         upperGraphTableBody.selectAll("tr").remove();
 
-        for (const row of barGraphTableDataRows) {
+        for (const row of barGraphDisplayedTable) {
             const newRow = upperGraphTableBody.append("tr")
             .selectAll("td")
             .data(row)

--- a/app/barGraph.js
+++ b/app/barGraph.js
@@ -22,6 +22,7 @@
 
 import { Colours, GraphColours, GraphDims, TextWrap, FontWeight, MousePointer, Translation, SortIconClasses, SortStates } from "./assets.js";
 import { drawWrappedText, drawText } from "./visuals.js";
+import { Model } from "./backend.js";
 
 
 export function upperGraph(model){
@@ -406,6 +407,16 @@ export function upperGraph(model){
         const barGraphTable = reloadData ? model.createBarGraphTable(tableTitleText) : model.barGraphTable;
         const amountLeftIndex = 1;
 
+        // keep track of which column indices refer to numbered columns
+        const numColIndices = [];
+        const compareFuncsLen = barGraphTable.compareFuncs.length;
+
+        for (let i = 0; i < compareFuncsLen; ++i) {
+            if (barGraphTable.compareFuncs[i] == Model.strNumCompare) {
+                numColIndices.push(i);
+            }
+        }
+
         // --------------- draws the table -------------------------
 
         /* Create top-level heading */
@@ -474,6 +485,16 @@ export function upperGraph(model){
             barGraphTableDataRows = barGraphTableDataRows.toSorted((row1, row2) => { return barGraphTable.compareFuncs[sortedColIndex](row1 [sortedColIndex], row2[sortedColIndex]) });
         } else if (hasCompareFunc && sortedColState == SortStates.Descending) {
             barGraphTableDataRows = barGraphTableDataRows.toSorted((row1, row2) => { return barGraphTable.compareFuncs[sortedColIndex](row2[sortedColIndex], row1[sortedColIndex]) });
+        }
+
+        console.log("NumColIndices: ", numColIndices);
+
+        // translate the numbers for French
+        const barGraphDisplayedTable = [];
+        for (const row of barGraphTableDataRows) {
+            for (const colInd of numColIndices) {
+                row[colInd] = Translation.translateNum(row[colInd]);
+            }
         }
         
         upperGraphTableBody.selectAll("tr").remove();

--- a/app/barGraph.js
+++ b/app/barGraph.js
@@ -714,8 +714,8 @@ export function upperGraph(model){
         const lines = Translation.translate("upperGraph.toolTip", { 
             returnObjects: true, 
             context: graphType,
-            amount: parseFloat(d[1]).toFixed(1),
-            percentage: parseFloat(d[1]).toFixed(1),
+            amount: Translation.translateNum(parseFloat(d[1]).toFixed(1)),
+            percentage: Translation.translateNum(parseFloat(d[1]).toFixed(1)),
             nutrient: d[0],
             unit: nutrientUnit
         });

--- a/app/sunBurstGraph.js
+++ b/app/sunBurstGraph.js
@@ -913,10 +913,22 @@ export function lowerGraph(model){
             sunBurstTableDataRows = sunBurstTableDataRows.toSorted((row1, row2) => { return sunBurstTable.compareFuncs[sortedColIndex](row2[sortedColIndex], row1[sortedColIndex]) });
         }
 
+        // translate the numbers for French
+        const sunBurstDisplayedTable = [];
+        for (const row of sunBurstTableDataRows) {
+            const currentRow = [];
+            const colLen = row.length;
+            for (let i = 0; i < colLen; ++i) {
+                currentRow.push(model.sunburstTable.colIsNumbered[i] ? Translation.translateNum(row[i]) : row[i]);
+            }
+
+            sunBurstDisplayedTable.push(currentRow);
+        }
+
         lowerGraphTableBody.selectAll("tr").remove();
 
         // create the rows for the table
-        for (const row of sunBurstTableDataRows) {
+        for (const row of sunBurstDisplayedTable) {
             const newRow = lowerGraphTableBody.append("tr")
                 .selectAll("td")
                 .data(row)


### PR DESCRIPTION
For certain languages like French, decimal numbers use a comma instead of a decimal point. We use `i18next` to handle printing numbers for different languages. This replacement is done in the tables, CSV and the tooltips