### PR TITLE
Replace Weird Invisible Space in French Table Food Ingredients

### DIFF
--- a/data/Corrected_TABLE_FSCT-data_Food_ingredients CCHS 2015-20240624-fr.csv
+++ b/data/Corrected_TABLE_FSCT-data_Food_ingredients CCHS 2015-20240624-fr.csv
@@ -58,7 +58,7 @@ Calcium,Population 1 an et +,6318,des,Fruits et légumes,des,Légumes incluant p
 Calcium,Population 1 an et +,19327,des,Produits céréaliers,,,,,102.9,1.2,100.6,105.2,mg,12.6,0.1,,1
 Calcium,Population 1 an et +,16168,des,Produits céréaliers,des,Pains,,,69.6,1.1,67.5,71.7,mg,8.5,0.1,,2
 Calcium,Population 1 an et +,6966,des,Produits céréaliers,des,Céréales pour déjeuner,,,15.5,0.5,14.4,16.5,mg,1.9,0.1,,2
-Calcium,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,5.2,0.2,4.8,5.7,mg,0.6,0,,2
+Calcium,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,5.2,0.2,4.8,5.7,mg,0.6,0,,2
 Calcium,Population 1 an et +,14820,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,12.7,0.3,12.1,13.3,mg,1.5,0,,2
 Calcium,Population 1 an et +,8159,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,31.2,0.7,29.7,32.7,mg,3.8,0.1,,3
 Calcium,Population 1 an et +,5962,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,19.3,0.6,18.2,20.4,mg,2.4,0.1,,3
@@ -66,10 +66,10 @@ Calcium,Population 1 an et +,6257,des,Produits céréaliers,des,Pains,des,Autres
 Calcium,Population 1 an et +,2918,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,2.2,0.1,2,2.5,mg,0.3,0,,3
 Calcium,Population 1 an et +,4760,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,10.4,0.5,9.5,11.3,mg,1.3,0.1,,3
 Calcium,Population 1 an et +,2573,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),5,0.3,4.4,5.6,mg,0.6,0,,3
-Calcium,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,2.8,0.2,2.4,3.1,mg,0.3,0,,3
-Calcium,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0.1,0.2,mg,0,0,,3
-Calcium,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.1,mg,0,0,,3
-Calcium,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
+Calcium,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,2.8,0.2,2.4,3.1,mg,0.3,0,,3
+Calcium,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0.1,0.2,mg,0,0,,3
+Calcium,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.1,mg,0,0,,3
+Calcium,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
 Calcium,Population 1 an et +,4543,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,4.7,0.3,4.2,5.2,mg,0.6,0,,3
 Calcium,Population 1 an et +,11102,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,3.9,0.1,3.7,4.1,mg,0.5,0,,3
 Calcium,Population 1 an et +,4598,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,4.1,0.2,3.8,4.4,mg,0.5,0,,3
@@ -172,7 +172,7 @@ Calcium,Hommes adultes 19 ans +,1991,des,Fruits et légumes,des,Légumes incluan
 Calcium,Hommes adultes 19 ans +,6068,des,Produits céréaliers,,,,,113.2,2,109.3,117.1,mg,13.2,0.3,,1
 Calcium,Hommes adultes 19 ans +,5104,des,Produits céréaliers,des,Pains,,,80.3,1.9,76.6,84.1,mg,9.4,0.2,,2
 Calcium,Hommes adultes 19 ans +,1921,des,Produits céréaliers,des,Céréales pour déjeuner,,,14.5,1,12.6,16.4,mg,1.7,0.1,,2
-Calcium,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,5.2,0.4,4.4,6,mg,0.6,0,,2
+Calcium,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,5.2,0.4,4.4,6,mg,0.6,0,,2
 Calcium,Hommes adultes 19 ans +,4551,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,13.2,0.5,12.3,14.1,mg,1.5,0.1,,2
 Calcium,Hommes adultes 19 ans +,2752,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,39.5,1.5,36.6,42.3,mg,4.6,0.2,,3
 Calcium,Hommes adultes 19 ans +,1980,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,21.9,1,19.9,23.9,mg,2.6,0.1,,3
@@ -180,9 +180,9 @@ Calcium,Hommes adultes 19 ans +,1885,des,Produits céréaliers,des,Pains,des,Aut
 Calcium,Hommes adultes 19 ans +,593,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,1.2,0.1,0.9,1.5,mg,0.1,0,,3
 Calcium,Hommes adultes 19 ans +,1481,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,11.5,0.9,9.7,13.3,mg,1.3,0.1,,3
 Calcium,Hommes adultes 19 ans +,523,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),3,0.4,2.3,3.7,mg,0.3,0,,3
-Calcium,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,2.8,0.3,2.2,3.4,mg,0.3,0,,3
-Calcium,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0,0.2,mg,0,0,,3
-Calcium,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.1,mg,0,0,,3
+Calcium,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,2.8,0.3,2.2,3.4,mg,0.3,0,,3
+Calcium,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0,0.2,mg,0,0,,3
+Calcium,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.1,mg,0,0,,3
 Calcium,Hommes adultes 19 ans +,3442,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,4.5,0.2,4.1,4.9,mg,0.5,0,,3
 Calcium,Hommes adultes 19 ans +,1250,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,4.2,0.3,3.5,4.8,mg,0.5,0,,3
 Calcium,Hommes adultes 19 ans +,1449,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,4.5,0.3,3.9,5,mg,0.5,0,,3
@@ -285,7 +285,7 @@ Calcium,Femmes adultes* 19 ans +,2348,des,Fruits et légumes,des,Légumes inclua
 Calcium,Femmes adultes* 19 ans +,6669,des,Produits céréaliers,,,,,85.3,1.6,82.3,88.4,mg,12.2,0.2,,1
 Calcium,Femmes adultes* 19 ans +,5520,des,Produits céréaliers,des,Pains,,,58.8,1.4,56.1,61.5,mg,8.4,0.2,,2
 Calcium,Femmes adultes* 19 ans +,2230,des,Produits céréaliers,des,Céréales pour déjeuner,,,11.8,0.6,10.5,13.1,mg,1.7,0.1,,2
-Calcium,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,3.9,0.3,3.3,4.5,mg,0.6,0,,2
+Calcium,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,3.9,0.3,3.3,4.5,mg,0.6,0,,2
 Calcium,Femmes adultes* 19 ans +,4893,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,10.8,0.5,9.7,11.9,mg,1.5,0.1,,2
 Calcium,Femmes adultes* 19 ans +,2551,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,24.1,1,22.3,26,mg,3.4,0.1,,3
 Calcium,Femmes adultes* 19 ans +,2239,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,19.1,0.8,17.6,20.6,mg,2.7,0.1,,3
@@ -293,10 +293,10 @@ Calcium,Femmes adultes* 19 ans +,1994,des,Produits céréaliers,des,Pains,des,Au
 Calcium,Femmes adultes* 19 ans +,914,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,1.7,0.2,1.2,2.1,mg,0.2,0,,3
 Calcium,Femmes adultes* 19 ans +,1756,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,9.3,0.6,8.2,10.5,mg,1.3,0.1,,3
 Calcium,Femmes adultes* 19 ans +,555,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),2.5,0.3,1.8,3.2,mg,0.4,0,,3
-Calcium,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,1.6,0.2,1.2,2.1,mg,0.2,0,,3
-Calcium,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0,0.1,mg,0,0,,3
-Calcium,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.1,mg,0,0,,3
-Calcium,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
+Calcium,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,1.6,0.2,1.2,2.1,mg,0.2,0,,3
+Calcium,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0,0.1,mg,0,0,,3
+Calcium,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.1,mg,0,0,,3
+Calcium,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
 Calcium,Femmes adultes* 19 ans +,3664,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,3.2,0.2,2.9,3.5,mg,0.5,0,,3
 Calcium,Femmes adultes* 19 ans +,1358,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,3.8,0.5,2.9,4.7,mg,0.5,0.1,,3
 Calcium,Femmes adultes* 19 ans +,1522,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,3.8,0.3,3.3,4.3,mg,0.5,0,,3
@@ -340,119 +340,119 @@ Calcium,Femmes adultes* 19 ans +,1529,des,Confiseries - sucres et grignotines sa
 Calcium,Femmes adultes* 19 ans +,4229,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0.7,0.1,0.6,0.8,mg,0.1,0,,3
 Calcium,Femmes adultes* 19 ans +,773,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.3,0,0.3,0.4,mg,0,0,,3
 Calcium,Femmes adultes* 19 ans +,360,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mg,0,0,,3
-Calcium,Enfants 1 à 8 ans,122,des,Aliments pour bébés,,,,,11.7,3.2,5.4,17.9,mg,1.3,0.3,E,1
-Calcium,Enfants 1 à 8 ans,95,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,F,F,,,mg,F,F,F,2
-Calcium,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparations pour nourrissons,,,4.5,1.3,1.8,7.1,mg,0.5,0.1,E,2
-Calcium,Enfants 1 à 8 ans,2443,des,Boissons (excluant laits),,,,,38.2,1.9,34.5,41.9,mg,4.1,0.2,,1
-Calcium,Enfants 1 à 8 ans,20,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0,mg,0,0,,2
-Calcium,Enfants 1 à 8 ans,141,des,Boissons (excluant laits),du,Café et thé,,,0.3,0.1,0.1,0.4,mg,0,0,E,2
-Calcium,Enfants 1 à 8 ans,,des,Boissons (excluant laits),des,Boissons Énergisantes,,,X,X,,,mg,X,X,<10,2
-Calcium,Enfants 1 à 8 ans,357,des,Boissons (excluant laits),des,Boissons aux fruits,,,3.2,0.4,2.4,4,mg,0.3,0,,2
-Calcium,Enfants 1 à 8 ans,1159,des,Boissons (excluant laits),des,Jus de fruit,,,20.4,1.9,16.8,24.1,mg,2.2,0.2,,2
-Calcium,Enfants 1 à 8 ans,77,des,Boissons (excluant laits),des,Autres boissons,,,1.1,0.3,0.6,1.7,mg,0.1,0,E,2
-Calcium,Enfants 1 à 8 ans,142,des,Boissons (excluant laits),des,Boissons gazeuses,,,0.4,0.1,0.3,0.5,mg,0,0,E,2
-Calcium,Enfants 1 à 8 ans,21,des,Boissons (excluant laits),des,Boissons pour sportifs,,,0,0,0,0,mg,0,0,,2
-Calcium,Enfants 1 à 8 ans,52,des,Boissons (excluant laits),des,Jus de tomates et de légumes,,,0.4,0.1,0.2,0.7,mg,0,0,E,2
-Calcium,Enfants 1 à 8 ans,,des,Boissons (excluant laits),de l',Eau vitaminée,,,X,X,,,mg,X,X,<10,2
-Calcium,Enfants 1 à 8 ans,2344,des,Boissons (excluant laits),de l',Eau,,,12.3,0.4,11.5,13.1,mg,1.3,0,,2
-Calcium,Enfants 1 à 8 ans,,des,Boissons (excluant laits),du,Café et thé,du,Café,X,X,,,mg,X,X,<10,3
-Calcium,Enfants 1 à 8 ans,133,des,Boissons (excluant laits),du,Café et thé,du,Thé,F,F,,,mg,F,F,F,3
-Calcium,Enfants 1 à 8 ans,2436,des,Produits laitiers et Boissons à base de plantes,,,,,635.1,14.4,606.8,663.3,mg,68.7,0.6,,1
-Calcium,Enfants 1 à 8 ans,1632,des,Produits laitiers et Boissons à base de plantes,des,Fromages,,,162.9,7.8,147.7,178.2,mg,17.6,0.7,,2
-Calcium,Enfants 1 à 8 ans,2341,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,412.4,11.7,389.4,435.4,mg,44.6,0.8,,2
-Calcium,Enfants 1 à 8 ans,1032,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,,,59.7,3.2,53.4,66,mg,6.5,0.3,,2
-Calcium,Enfants 1 à 8 ans,1810,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,195.2,8.6,178.2,212.1,mg,21.1,0.9,,3
-Calcium,Enfants 1 à 8 ans,1078,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,120.3,7.5,105.5,135.1,mg,13,0.8,,3
-Calcium,Enfants 1 à 8 ans,854,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,71,8.1,55.1,86.9,mg,7.7,0.8,,3
-Calcium,Enfants 1 à 8 ans,739,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,11.2,1.9,7.6,14.9,mg,1.2,0.2,E,3
-Calcium,Enfants 1 à 8 ans,128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,10.5,1.8,7,13.9,mg,1.1,0.2,E,3
-Calcium,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,4.3,1,2.3,6.3,mg,0.5,0.1,E,3
-Calcium,Enfants 1 à 8 ans,2270,des,Graisses et huiles,,,,,1.2,0.1,1.1,1.4,mg,0.1,0,,1
-Calcium,Enfants 1 à 8 ans,83,des,Graisses et huiles,des,Graisses animales,,,0,0,0,0,mg,0,0,,2
-Calcium,Enfants 1 à 8 ans,657,des,Graisses et huiles,du,Beurre,,,0.4,0,0.3,0.5,mg,0,0,,2
-Calcium,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Margarines,,,0.4,0,0.3,0.4,mg,0,0,,2
-Calcium,Enfants 1 à 8 ans,463,des,Graisses et huiles,des,Sauces pour salade,,,0.4,0.1,0.3,0.5,mg,0,0,E,2
-Calcium,Enfants 1 à 8 ans,1035,des,Graisses et huiles,du,Shortening,,,0,0,0,0,mg,0,0,,2
-Calcium,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Huiles végétales,,,0,0,0,0,mg,0,0,,2
-Calcium,Enfants 1 à 8 ans,298,des,Poissons et fruits de mer,,,,,3.3,0.6,2.2,4.4,mg,0.4,0.1,E,1
-Calcium,Enfants 1 à 8 ans,257,des,Poissons et fruits de mer,des,Poissons,,,2.6,0.5,1.7,3.6,mg,0.3,0.1,E,2
-Calcium,Enfants 1 à 8 ans,50,des,Poissons et fruits de mer,des,Mollusques et crustacés,,,F,F,,,mg,F,F,F,2
-Calcium,Enfants 1 à 8 ans,2428,des,Fruits et légumes,,,,,48.3,1.5,45.3,51.3,mg,5.2,0.2,,1
-Calcium,Enfants 1 à 8 ans,2117,des,Fruits et légumes,des,Fruits,,,20.1,0.8,18.5,21.7,mg,2.2,0.1,,2
-Calcium,Enfants 1 à 8 ans,2235,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,28.2,1.2,25.9,30.5,mg,3,0.1,,2
-Calcium,Enfants 1 à 8 ans,421,des,Fruits et légumes,des,Fruits,des,Agrumes,6.4,0.6,5.3,7.5,mg,0.7,0.1,,3
-Calcium,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pommes,3.2,0.2,2.8,3.6,mg,0.3,0,,3
-Calcium,Enfants 1 à 8 ans,830,des,Fruits et légumes,des,Fruits,des,Baies,3.1,0.3,2.5,3.6,mg,0.3,0,,3
-Calcium,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Bananes,1.5,0.1,1.3,1.6,mg,0.2,0,,3
-Calcium,Enfants 1 à 8 ans,572,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,1.8,0.3,1.2,2.3,mg,0.2,0,E,3
-Calcium,Enfants 1 à 8 ans,260,des,Fruits et légumes,des,Fruits,des,Autres fruits,1.4,0.2,1,1.8,mg,0.2,0,,3
-Calcium,Enfants 1 à 8 ans,219,des,Fruits et légumes,des,Fruits,des,Melons,1.2,0.2,0.9,1.5,mg,0.1,0,E,3
-Calcium,Enfants 1 à 8 ans,133,des,Fruits et légumes,des,Fruits,des,Poires,0.6,0.1,0.4,0.8,mg,0.1,0,E,3
-Calcium,Enfants 1 à 8 ans,118,des,Fruits et légumes,des,Fruits,des,Pêches et nectarines,0.3,0.1,0.2,0.5,mg,0,0,E,3
-Calcium,Enfants 1 à 8 ans,94,des,Fruits et légumes,des,Fruits,des,Ananas,0.3,0.1,0.2,0.5,mg,0,0,E,3
-Calcium,Enfants 1 à 8 ans,37,des,Fruits et légumes,des,Fruits,des,Prunes et pruneaux,0.1,0,0,0.2,mg,0,0,,3
-Calcium,Enfants 1 à 8 ans,47,des,Fruits et légumes,des,Fruits,des,Cerises,F,F,,,mg,F,F,F,3
-Calcium,Enfants 1 à 8 ans,1773,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Autres légumes,12.9,0.6,11.7,14.1,mg,1.4,0.1,,3
-Calcium,Enfants 1 à 8 ans,1068,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes vert foncé,8.4,0.9,6.7,10.1,mg,0.9,0.1,,3
-Calcium,Enfants 1 à 8 ans,875,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes jaune foncé ou orange,3.9,0.4,3.1,4.7,mg,0.4,0,,3
-Calcium,Enfants 1 à 8 ans,1032,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes féculents,3,0.2,2.6,3.5,mg,0.3,0,,3
-Calcium,Enfants 1 à 8 ans,2475,des,Produits céréaliers,,,,,101.6,2.2,97.2,105.9,mg,11,0.3,,1
-Calcium,Enfants 1 à 8 ans,2114,des,Produits céréaliers,des,Pains,,,57.6,1.9,53.9,61.4,mg,6.2,0.2,,2
-Calcium,Enfants 1 à 8 ans,1282,des,Produits céréaliers,des,Céréales pour déjeuner,,,23.9,1.3,21.4,26.4,mg,2.6,0.1,,2
-Calcium,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,6.4,0.4,5.6,7.2,mg,0.7,0,,2
-Calcium,Enfants 1 à 8 ans,2037,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,13.6,0.8,12,15.3,mg,1.5,0.1,,2
-Calcium,Enfants 1 à 8 ans,951,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,22.2,1.3,19.6,24.8,mg,2.4,0.1,,3
-Calcium,Enfants 1 à 8 ans,805,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,14.8,1.3,12.1,17.4,mg,1.6,0.1,,3
-Calcium,Enfants 1 à 8 ans,813,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,14.1,0.9,12.4,15.8,mg,1.5,0.1,,3
-Calcium,Enfants 1 à 8 ans,745,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,6.5,0.6,5.3,7.8,mg,0.7,0.1,,3
-Calcium,Enfants 1 à 8 ans,670,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),12.6,1,10.6,14.5,mg,1.4,0.1,,3
-Calcium,Enfants 1 à 8 ans,728,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,11.4,1,9.4,13.3,mg,1.2,0.1,,3
-Calcium,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,3.1,0.3,2.5,3.7,mg,0.3,0,,3
-Calcium,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0,0.2,mg,0,0,,3
-Calcium,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.1,mg,0,0,,3
-Calcium,Enfants 1 à 8 ans,834,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,7.4,0.8,5.8,9,mg,0.8,0.1,,3
-Calcium,Enfants 1 à 8 ans,654,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,3.4,0.3,2.9,3.8,mg,0.4,0,,3
-Calcium,Enfants 1 à 8 ans,1461,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,2.9,0.2,2.5,3.2,mg,0.3,0,,3
-Calcium,Enfants 1 à 8 ans,2072,de la,Viandes et volailles,,,,,11.3,0.4,10.4,12.1,mg,1.2,0,,1
-Calcium,Enfants 1 à 8 ans,1003,de la,Viandes et volailles,de la,Volaille,,,3.8,0.3,3.3,4.4,mg,0.4,0,,2
-Calcium,Enfants 1 à 8 ans,942,de la,Viandes et volailles,des,Viandes transformées,,,4.8,0.4,4.1,5.6,mg,0.5,0,,2
-Calcium,Enfants 1 à 8 ans,999,de la,Viandes et volailles,de la,Viande rouge,,,2.6,0.2,2.2,3,mg,0.3,0,,2
-Calcium,Enfants 1 à 8 ans,933,de la,Viandes et volailles,de la,Volaille,du,Poulet,3.5,0.3,3,4,mg,0.4,0,,3
-Calcium,Enfants 1 à 8 ans,86,de la,Viandes et volailles,de la,Volaille,de la,Dinde et autres volailles,0.4,0.1,0.1,0.6,mg,0,0,E,3
-Calcium,Enfants 1 à 8 ans,375,de la,Viandes et volailles,des,Viandes transformées,des,Saucisses,2.5,0.3,1.9,3,mg,0.3,0,,3
-Calcium,Enfants 1 à 8 ans,513,de la,Viandes et volailles,des,Viandes transformées,des,Viandes froides,2.2,0.2,1.7,2.6,mg,0.2,0,,3
-Calcium,Enfants 1 à 8 ans,135,de la,Viandes et volailles,des,Viandes transformées,du,Bacon,0.1,0,0,0.2,mg,0,0,,3
-Calcium,Enfants 1 à 8 ans,106,de la,Viandes et volailles,des,Viandes transformées,du,Porc salé,0.1,0,0.1,0.2,mg,0,0,,3
-Calcium,Enfants 1 à 8 ans,779,de la,Viandes et volailles,de la,Viande rouge,du,Bœuf,1.7,0.2,1.4,2.1,mg,0.2,0,,3
-Calcium,Enfants 1 à 8 ans,284,de la,Viandes et volailles,de la,Viande rouge,du,Porc frais,0.6,0.1,0.5,0.8,mg,0.1,0,E,3
-Calcium,Enfants 1 à 8 ans,43,de la,Viandes et volailles,de la,Viande rouge,de l',Agneau - veau et gibiers,F,F,,,mg,F,F,F,3
-Calcium,Enfants 1 à 8 ans,,de la,Viandes et volailles,de la,Viande rouge,des,Abats - foies et pâtés,X,X,,,mg,X,X,<10,3
-Calcium,Enfants 1 à 8 ans,1789,des,Substituts de viande,,,,,15.4,1.3,12.9,17.9,mg,1.7,0.1,,1
-Calcium,Enfants 1 à 8 ans,1450,des,Substituts de viande,des,Œufs,,,6.6,0.4,5.8,7.4,mg,0.7,0,,2
-Calcium,Enfants 1 à 8 ans,210,des,Substituts de viande,des,Légumineuses,,,1.8,0.3,1.3,2.4,mg,0.2,0,E,2
-Calcium,Enfants 1 à 8 ans,749,des,Substituts de viande,des,Noix - graines et beurre d'arachides,,,4.1,0.5,3.1,5,mg,0.4,0.1,,2
-Calcium,Enfants 1 à 8 ans,58,des,Substituts de viande,du,Tofu et produits sans viande,,,F,F,,,mg,F,F,F,2
-Calcium,Enfants 1 à 8 ans,45,des,Boissons et barres nutritionnelles,,,,,3.8,1,1.8,5.8,mg,0.4,0.1,E,1
-Calcium,Enfants 1 à 8 ans,40,des,Boissons et barres nutritionnelles,des,Substituts de repas et boissons nutritionnelles,,,3.4,1,1.5,5.3,mg,0.4,0.1,E,2
-Calcium,Enfants 1 à 8 ans,,des,Boissons et barres nutritionnelles,des,Barres nutritionnelles,,,X,X,,,mg,X,X,<10,2
-Calcium,Enfants 1 à 8 ans,2295,des,Soupes - sauces - Épices et autres ingrédients,,,,,20.4,1.3,17.8,23,mg,2.2,0.1,,1
-Calcium,Enfants 1 à 8 ans,761,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,2.9,0.5,1.8,3.9,mg,0.3,0.1,E,2
-Calcium,Enfants 1 à 8 ans,532,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,2,0.3,1.3,2.6,mg,0.2,0,,2
-Calcium,Enfants 1 à 8 ans,2205,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,15.6,1.2,13.3,17.8,mg,1.7,0.1,,2
-Calcium,Enfants 1 à 8 ans,2106,des,Confiseries - sucres et grignotines salées,,,,,33.9,2.7,28.6,39.2,mg,3.7,0.3,,1
-Calcium,Enfants 1 à 8 ans,1048,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,6.9,0.6,5.6,8.1,mg,0.7,0.1,,2
-Calcium,Enfants 1 à 8 ans,497,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,17.2,1.7,13.9,20.5,mg,1.9,0.2,,2
-Calcium,Enfants 1 à 8 ans,615,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,3.2,0.4,2.4,4.1,mg,0.4,0,,2
-Calcium,Enfants 1 à 8 ans,1642,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,6.6,2.2,2.3,10.9,mg,0.7,0.2,E,2
-Calcium,Enfants 1 à 8 ans,548,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,4.7,0.5,3.7,5.7,mg,0.5,0.1,,3
-Calcium,Enfants 1 à 8 ans,131,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,1.7,0.3,1.1,2.4,mg,0.2,0,E,3
-Calcium,Enfants 1 à 8 ans,557,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0.5,0.1,0.3,0.6,mg,0.1,0,E,3
-Calcium,Enfants 1 à 8 ans,346,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,16.6,1.7,13.3,20,mg,1.8,0.2,,3
-Calcium,Enfants 1 à 8 ans,184,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,F,F,,,mg,F,F,F,3
-Calcium,Enfants 1 à 8 ans,257,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.3,0,0.2,0.4,mg,0,0,,3
-Calcium,Enfants 1 à 8 ans,1341,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0.4,0,0.3,0.4,mg,0,0,,3
-Calcium,Enfants 1 à 8 ans,720,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,F,F,,,mg,F,F,F,3
-Calcium,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,mg,X,X,<10,3
+Calcium,Enfants 1 à 8 ans,122,des,Aliments pour bébés,,,,,11.7,3.2,5.4,17.9,mg,1.3,0.3,E,1
+Calcium,Enfants 1 à 8 ans,95,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,F,F,,,mg,F,F,F,2
+Calcium,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparations pour nourrissons,,,4.5,1.3,1.8,7.1,mg,0.5,0.1,E,2
+Calcium,Enfants 1 à 8 ans,2443,des,Boissons (excluant laits),,,,,38.2,1.9,34.5,41.9,mg,4.1,0.2,,1
+Calcium,Enfants 1 à 8 ans,20,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0,mg,0,0,,2
+Calcium,Enfants 1 à 8 ans,141,des,Boissons (excluant laits),du,Café et thé,,,0.3,0.1,0.1,0.4,mg,0,0,E,2
+Calcium,Enfants 1 à 8 ans,,des,Boissons (excluant laits),des,Boissons Énergisantes,,,X,X,,,mg,X,X,<10,2
+Calcium,Enfants 1 à 8 ans,357,des,Boissons (excluant laits),des,Boissons aux fruits,,,3.2,0.4,2.4,4,mg,0.3,0,,2
+Calcium,Enfants 1 à 8 ans,1159,des,Boissons (excluant laits),des,Jus de fruit,,,20.4,1.9,16.8,24.1,mg,2.2,0.2,,2
+Calcium,Enfants 1 à 8 ans,77,des,Boissons (excluant laits),des,Autres boissons,,,1.1,0.3,0.6,1.7,mg,0.1,0,E,2
+Calcium,Enfants 1 à 8 ans,142,des,Boissons (excluant laits),des,Boissons gazeuses,,,0.4,0.1,0.3,0.5,mg,0,0,E,2
+Calcium,Enfants 1 à 8 ans,21,des,Boissons (excluant laits),des,Boissons pour sportifs,,,0,0,0,0,mg,0,0,,2
+Calcium,Enfants 1 à 8 ans,52,des,Boissons (excluant laits),des,Jus de tomates et de légumes,,,0.4,0.1,0.2,0.7,mg,0,0,E,2
+Calcium,Enfants 1 à 8 ans,,des,Boissons (excluant laits),de l',Eau vitaminée,,,X,X,,,mg,X,X,<10,2
+Calcium,Enfants 1 à 8 ans,2344,des,Boissons (excluant laits),de l',Eau,,,12.3,0.4,11.5,13.1,mg,1.3,0,,2
+Calcium,Enfants 1 à 8 ans,,des,Boissons (excluant laits),du,Café et thé,du,Café,X,X,,,mg,X,X,<10,3
+Calcium,Enfants 1 à 8 ans,133,des,Boissons (excluant laits),du,Café et thé,du,Thé,F,F,,,mg,F,F,F,3
+Calcium,Enfants 1 à 8 ans,2436,des,Produits laitiers et Boissons à base de plantes,,,,,635.1,14.4,606.8,663.3,mg,68.7,0.6,,1
+Calcium,Enfants 1 à 8 ans,1632,des,Produits laitiers et Boissons à base de plantes,des,Fromages,,,162.9,7.8,147.7,178.2,mg,17.6,0.7,,2
+Calcium,Enfants 1 à 8 ans,2341,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,412.4,11.7,389.4,435.4,mg,44.6,0.8,,2
+Calcium,Enfants 1 à 8 ans,1032,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,,,59.7,3.2,53.4,66,mg,6.5,0.3,,2
+Calcium,Enfants 1 à 8 ans,1810,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,195.2,8.6,178.2,212.1,mg,21.1,0.9,,3
+Calcium,Enfants 1 à 8 ans,1078,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,120.3,7.5,105.5,135.1,mg,13,0.8,,3
+Calcium,Enfants 1 à 8 ans,854,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,71,8.1,55.1,86.9,mg,7.7,0.8,,3
+Calcium,Enfants 1 à 8 ans,739,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,11.2,1.9,7.6,14.9,mg,1.2,0.2,E,3
+Calcium,Enfants 1 à 8 ans,128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,10.5,1.8,7,13.9,mg,1.1,0.2,E,3
+Calcium,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,4.3,1,2.3,6.3,mg,0.5,0.1,E,3
+Calcium,Enfants 1 à 8 ans,2270,des,Graisses et huiles,,,,,1.2,0.1,1.1,1.4,mg,0.1,0,,1
+Calcium,Enfants 1 à 8 ans,83,des,Graisses et huiles,des,Graisses animales,,,0,0,0,0,mg,0,0,,2
+Calcium,Enfants 1 à 8 ans,657,des,Graisses et huiles,du,Beurre,,,0.4,0,0.3,0.5,mg,0,0,,2
+Calcium,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Margarines,,,0.4,0,0.3,0.4,mg,0,0,,2
+Calcium,Enfants 1 à 8 ans,463,des,Graisses et huiles,des,Sauces pour salade,,,0.4,0.1,0.3,0.5,mg,0,0,E,2
+Calcium,Enfants 1 à 8 ans,1035,des,Graisses et huiles,du,Shortening,,,0,0,0,0,mg,0,0,,2
+Calcium,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Huiles végétales,,,0,0,0,0,mg,0,0,,2
+Calcium,Enfants 1 à 8 ans,298,des,Poissons et fruits de mer,,,,,3.3,0.6,2.2,4.4,mg,0.4,0.1,E,1
+Calcium,Enfants 1 à 8 ans,257,des,Poissons et fruits de mer,des,Poissons,,,2.6,0.5,1.7,3.6,mg,0.3,0.1,E,2
+Calcium,Enfants 1 à 8 ans,50,des,Poissons et fruits de mer,des,Mollusques et crustacés,,,F,F,,,mg,F,F,F,2
+Calcium,Enfants 1 à 8 ans,2428,des,Fruits et légumes,,,,,48.3,1.5,45.3,51.3,mg,5.2,0.2,,1
+Calcium,Enfants 1 à 8 ans,2117,des,Fruits et légumes,des,Fruits,,,20.1,0.8,18.5,21.7,mg,2.2,0.1,,2
+Calcium,Enfants 1 à 8 ans,2235,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,28.2,1.2,25.9,30.5,mg,3,0.1,,2
+Calcium,Enfants 1 à 8 ans,421,des,Fruits et légumes,des,Fruits,des,Agrumes,6.4,0.6,5.3,7.5,mg,0.7,0.1,,3
+Calcium,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pommes,3.2,0.2,2.8,3.6,mg,0.3,0,,3
+Calcium,Enfants 1 à 8 ans,830,des,Fruits et légumes,des,Fruits,des,Baies,3.1,0.3,2.5,3.6,mg,0.3,0,,3
+Calcium,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Bananes,1.5,0.1,1.3,1.6,mg,0.2,0,,3
+Calcium,Enfants 1 à 8 ans,572,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,1.8,0.3,1.2,2.3,mg,0.2,0,E,3
+Calcium,Enfants 1 à 8 ans,260,des,Fruits et légumes,des,Fruits,des,Autres fruits,1.4,0.2,1,1.8,mg,0.2,0,,3
+Calcium,Enfants 1 à 8 ans,219,des,Fruits et légumes,des,Fruits,des,Melons,1.2,0.2,0.9,1.5,mg,0.1,0,E,3
+Calcium,Enfants 1 à 8 ans,133,des,Fruits et légumes,des,Fruits,des,Poires,0.6,0.1,0.4,0.8,mg,0.1,0,E,3
+Calcium,Enfants 1 à 8 ans,118,des,Fruits et légumes,des,Fruits,des,Pêches et nectarines,0.3,0.1,0.2,0.5,mg,0,0,E,3
+Calcium,Enfants 1 à 8 ans,94,des,Fruits et légumes,des,Fruits,des,Ananas,0.3,0.1,0.2,0.5,mg,0,0,E,3
+Calcium,Enfants 1 à 8 ans,37,des,Fruits et légumes,des,Fruits,des,Prunes et pruneaux,0.1,0,0,0.2,mg,0,0,,3
+Calcium,Enfants 1 à 8 ans,47,des,Fruits et légumes,des,Fruits,des,Cerises,F,F,,,mg,F,F,F,3
+Calcium,Enfants 1 à 8 ans,1773,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Autres légumes,12.9,0.6,11.7,14.1,mg,1.4,0.1,,3
+Calcium,Enfants 1 à 8 ans,1068,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes vert foncé,8.4,0.9,6.7,10.1,mg,0.9,0.1,,3
+Calcium,Enfants 1 à 8 ans,875,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes jaune foncé ou orange,3.9,0.4,3.1,4.7,mg,0.4,0,,3
+Calcium,Enfants 1 à 8 ans,1032,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes féculents,3,0.2,2.6,3.5,mg,0.3,0,,3
+Calcium,Enfants 1 à 8 ans,2475,des,Produits céréaliers,,,,,101.6,2.2,97.2,105.9,mg,11,0.3,,1
+Calcium,Enfants 1 à 8 ans,2114,des,Produits céréaliers,des,Pains,,,57.6,1.9,53.9,61.4,mg,6.2,0.2,,2
+Calcium,Enfants 1 à 8 ans,1282,des,Produits céréaliers,des,Céréales pour déjeuner,,,23.9,1.3,21.4,26.4,mg,2.6,0.1,,2
+Calcium,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,6.4,0.4,5.6,7.2,mg,0.7,0,,2
+Calcium,Enfants 1 à 8 ans,2037,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,13.6,0.8,12,15.3,mg,1.5,0.1,,2
+Calcium,Enfants 1 à 8 ans,951,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,22.2,1.3,19.6,24.8,mg,2.4,0.1,,3
+Calcium,Enfants 1 à 8 ans,805,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,14.8,1.3,12.1,17.4,mg,1.6,0.1,,3
+Calcium,Enfants 1 à 8 ans,813,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,14.1,0.9,12.4,15.8,mg,1.5,0.1,,3
+Calcium,Enfants 1 à 8 ans,745,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,6.5,0.6,5.3,7.8,mg,0.7,0.1,,3
+Calcium,Enfants 1 à 8 ans,670,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),12.6,1,10.6,14.5,mg,1.4,0.1,,3
+Calcium,Enfants 1 à 8 ans,728,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,11.4,1,9.4,13.3,mg,1.2,0.1,,3
+Calcium,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,3.1,0.3,2.5,3.7,mg,0.3,0,,3
+Calcium,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0,0.2,mg,0,0,,3
+Calcium,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.1,mg,0,0,,3
+Calcium,Enfants 1 à 8 ans,834,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,7.4,0.8,5.8,9,mg,0.8,0.1,,3
+Calcium,Enfants 1 à 8 ans,654,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,3.4,0.3,2.9,3.8,mg,0.4,0,,3
+Calcium,Enfants 1 à 8 ans,1461,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,2.9,0.2,2.5,3.2,mg,0.3,0,,3
+Calcium,Enfants 1 à 8 ans,2072,de la,Viandes et volailles,,,,,11.3,0.4,10.4,12.1,mg,1.2,0,,1
+Calcium,Enfants 1 à 8 ans,1003,de la,Viandes et volailles,de la,Volaille,,,3.8,0.3,3.3,4.4,mg,0.4,0,,2
+Calcium,Enfants 1 à 8 ans,942,de la,Viandes et volailles,des,Viandes transformées,,,4.8,0.4,4.1,5.6,mg,0.5,0,,2
+Calcium,Enfants 1 à 8 ans,999,de la,Viandes et volailles,de la,Viande rouge,,,2.6,0.2,2.2,3,mg,0.3,0,,2
+Calcium,Enfants 1 à 8 ans,933,de la,Viandes et volailles,de la,Volaille,du,Poulet,3.5,0.3,3,4,mg,0.4,0,,3
+Calcium,Enfants 1 à 8 ans,86,de la,Viandes et volailles,de la,Volaille,de la,Dinde et autres volailles,0.4,0.1,0.1,0.6,mg,0,0,E,3
+Calcium,Enfants 1 à 8 ans,375,de la,Viandes et volailles,des,Viandes transformées,des,Saucisses,2.5,0.3,1.9,3,mg,0.3,0,,3
+Calcium,Enfants 1 à 8 ans,513,de la,Viandes et volailles,des,Viandes transformées,des,Viandes froides,2.2,0.2,1.7,2.6,mg,0.2,0,,3
+Calcium,Enfants 1 à 8 ans,135,de la,Viandes et volailles,des,Viandes transformées,du,Bacon,0.1,0,0,0.2,mg,0,0,,3
+Calcium,Enfants 1 à 8 ans,106,de la,Viandes et volailles,des,Viandes transformées,du,Porc salé,0.1,0,0.1,0.2,mg,0,0,,3
+Calcium,Enfants 1 à 8 ans,779,de la,Viandes et volailles,de la,Viande rouge,du,Bœuf,1.7,0.2,1.4,2.1,mg,0.2,0,,3
+Calcium,Enfants 1 à 8 ans,284,de la,Viandes et volailles,de la,Viande rouge,du,Porc frais,0.6,0.1,0.5,0.8,mg,0.1,0,E,3
+Calcium,Enfants 1 à 8 ans,43,de la,Viandes et volailles,de la,Viande rouge,de l',Agneau - veau et gibiers,F,F,,,mg,F,F,F,3
+Calcium,Enfants 1 à 8 ans,,de la,Viandes et volailles,de la,Viande rouge,des,Abats - foies et pâtés,X,X,,,mg,X,X,<10,3
+Calcium,Enfants 1 à 8 ans,1789,des,Substituts de viande,,,,,15.4,1.3,12.9,17.9,mg,1.7,0.1,,1
+Calcium,Enfants 1 à 8 ans,1450,des,Substituts de viande,des,Œufs,,,6.6,0.4,5.8,7.4,mg,0.7,0,,2
+Calcium,Enfants 1 à 8 ans,210,des,Substituts de viande,des,Légumineuses,,,1.8,0.3,1.3,2.4,mg,0.2,0,E,2
+Calcium,Enfants 1 à 8 ans,749,des,Substituts de viande,des,Noix - graines et beurre d'arachides,,,4.1,0.5,3.1,5,mg,0.4,0.1,,2
+Calcium,Enfants 1 à 8 ans,58,des,Substituts de viande,du,Tofu et produits sans viande,,,F,F,,,mg,F,F,F,2
+Calcium,Enfants 1 à 8 ans,45,des,Boissons et barres nutritionnelles,,,,,3.8,1,1.8,5.8,mg,0.4,0.1,E,1
+Calcium,Enfants 1 à 8 ans,40,des,Boissons et barres nutritionnelles,des,Substituts de repas et boissons nutritionnelles,,,3.4,1,1.5,5.3,mg,0.4,0.1,E,2
+Calcium,Enfants 1 à 8 ans,,des,Boissons et barres nutritionnelles,des,Barres nutritionnelles,,,X,X,,,mg,X,X,<10,2
+Calcium,Enfants 1 à 8 ans,2295,des,Soupes - sauces - Épices et autres ingrédients,,,,,20.4,1.3,17.8,23,mg,2.2,0.1,,1
+Calcium,Enfants 1 à 8 ans,761,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,2.9,0.5,1.8,3.9,mg,0.3,0.1,E,2
+Calcium,Enfants 1 à 8 ans,532,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,2,0.3,1.3,2.6,mg,0.2,0,,2
+Calcium,Enfants 1 à 8 ans,2205,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,15.6,1.2,13.3,17.8,mg,1.7,0.1,,2
+Calcium,Enfants 1 à 8 ans,2106,des,Confiseries - sucres et grignotines salées,,,,,33.9,2.7,28.6,39.2,mg,3.7,0.3,,1
+Calcium,Enfants 1 à 8 ans,1048,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,6.9,0.6,5.6,8.1,mg,0.7,0.1,,2
+Calcium,Enfants 1 à 8 ans,497,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,17.2,1.7,13.9,20.5,mg,1.9,0.2,,2
+Calcium,Enfants 1 à 8 ans,615,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,3.2,0.4,2.4,4.1,mg,0.4,0,,2
+Calcium,Enfants 1 à 8 ans,1642,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,6.6,2.2,2.3,10.9,mg,0.7,0.2,E,2
+Calcium,Enfants 1 à 8 ans,548,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,4.7,0.5,3.7,5.7,mg,0.5,0.1,,3
+Calcium,Enfants 1 à 8 ans,131,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,1.7,0.3,1.1,2.4,mg,0.2,0,E,3
+Calcium,Enfants 1 à 8 ans,557,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0.5,0.1,0.3,0.6,mg,0.1,0,E,3
+Calcium,Enfants 1 à 8 ans,346,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,16.6,1.7,13.3,20,mg,1.8,0.2,,3
+Calcium,Enfants 1 à 8 ans,184,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,F,F,,,mg,F,F,F,3
+Calcium,Enfants 1 à 8 ans,257,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.3,0,0.2,0.4,mg,0,0,,3
+Calcium,Enfants 1 à 8 ans,1341,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0.4,0,0.3,0.4,mg,0,0,,3
+Calcium,Enfants 1 à 8 ans,720,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,F,F,,,mg,F,F,F,3
+Calcium,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,mg,X,X,<10,3
 Glucides,Population 1 an et +,186,des,Aliments pour bébés,,,,,0.2,0,0.1,0.3,g,0.1,0,,1
 Glucides,Population 1 an et +,154,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0.1,0,0.1,0.2,g,0.1,0,,2
 Glucides,Population 1 an et +,51,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0,0,0,0.1,g,0,0,,2
@@ -512,7 +512,7 @@ Glucides,Population 1 an et +,6318,des,Fruits et légumes,des,Légumes incluant 
 Glucides,Population 1 an et +,19327,des,Produits céréaliers,,,,,95.3,0.9,93.6,96.9,g,42.1,0.3,,1
 Glucides,Population 1 an et +,16168,des,Produits céréaliers,des,Pains,,,41.5,0.6,40.3,42.6,g,18.3,0.2,,2
 Glucides,Population 1 an et +,6966,des,Produits céréaliers,des,Céréales pour déjeuner,,,10.1,0.3,9.5,10.6,g,4.4,0.1,,2
-Glucides,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,6.4,0.2,6,6.8,g,2.8,0.1,,2
+Glucides,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,6.4,0.2,6,6.8,g,2.8,0.1,,2
 Glucides,Population 1 an et +,14820,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,37.3,0.6,36.1,38.6,g,16.5,0.3,,2
 Glucides,Population 1 an et +,8159,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,17.1,0.4,16.3,18,g,7.6,0.2,,3
 Glucides,Population 1 an et +,6257,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,12.3,0.4,11.5,13.2,g,5.5,0.2,,3
@@ -520,10 +520,10 @@ Glucides,Population 1 an et +,5962,des,Produits céréaliers,des,Pains,des,Pains
 Glucides,Population 1 an et +,2918,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,2,0.1,1.8,2.2,g,0.9,0,,3
 Glucides,Population 1 an et +,4760,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,7.4,0.3,6.9,7.9,g,3.3,0.1,,3
 Glucides,Population 1 an et +,2573,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),2.7,0.1,2.4,2.9,g,1.2,0.1,,3
-Glucides,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,2.1,0.1,1.9,2.3,g,0.9,0.1,,3
-Glucides,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.2,0,0.2,0.3,g,0.1,0,,3
-Glucides,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.2,0,0.1,0.2,g,0.1,0,,3
-Glucides,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
+Glucides,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,2.1,0.1,1.9,2.3,g,0.9,0.1,,3
+Glucides,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.2,0,0.2,0.3,g,0.1,0,,3
+Glucides,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.2,0,0.1,0.2,g,0.1,0,,3
+Glucides,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
 Glucides,Population 1 an et +,11102,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,16.4,0.4,15.6,17.2,g,7.2,0.2,,3
 Glucides,Population 1 an et +,4598,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,10.9,0.4,10.1,11.7,g,4.8,0.2,,3
 Glucides,Population 1 an et +,4543,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,10.1,0.3,9.4,10.7,g,4.4,0.2,,3
@@ -626,7 +626,7 @@ Glucides,Hommes adultes 19 ans +,1991,des,Fruits et légumes,des,Légumes inclua
 Glucides,Hommes adultes 19 ans +,6068,des,Produits céréaliers,,,,,107.8,1.6,104.7,110.8,g,42.8,0.5,,1
 Glucides,Hommes adultes 19 ans +,5104,des,Produits céréaliers,des,Pains,,,48.4,1.1,46.2,50.7,g,19.2,0.4,,2
 Glucides,Hommes adultes 19 ans +,1921,des,Produits céréaliers,des,Céréales pour déjeuner,,,10.7,0.5,9.7,11.8,g,4.3,0.2,,2
-Glucides,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,6.3,0.4,5.5,7.1,g,2.5,0.2,,2
+Glucides,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,6.3,0.4,5.5,7.1,g,2.5,0.2,,2
 Glucides,Hommes adultes 19 ans +,4551,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,42.3,1.2,40,44.6,g,16.8,0.4,,2
 Glucides,Hommes adultes 19 ans +,2752,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,21.7,0.9,20,23.5,g,8.6,0.3,,3
 Glucides,Hommes adultes 19 ans +,1885,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,13.7,0.8,12.2,15.3,g,5.5,0.3,,3
@@ -634,9 +634,9 @@ Glucides,Hommes adultes 19 ans +,1980,des,Produits céréaliers,des,Pains,des,Pa
 Glucides,Hommes adultes 19 ans +,593,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,1.6,0.1,1.3,1.9,g,0.6,0.1,,3
 Glucides,Hommes adultes 19 ans +,1481,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,8.8,0.5,7.8,9.8,g,3.5,0.2,,3
 Glucides,Hommes adultes 19 ans +,523,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),1.9,0.2,1.5,2.3,g,0.8,0.1,,3
-Glucides,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,2.2,0.3,1.7,2.7,g,0.9,0.1,,3
-Glucides,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.3,0.1,0.1,0.5,g,0.1,0,E,3
-Glucides,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.2,g,0,0,,3
+Glucides,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,2.2,0.3,1.7,2.7,g,0.9,0.1,,3
+Glucides,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.3,0.1,0.1,0.5,g,0.1,0,E,3
+Glucides,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.2,g,0,0,,3
 Glucides,Hommes adultes 19 ans +,3442,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,19.2,0.8,17.7,20.7,g,7.6,0.3,,3
 Glucides,Hommes adultes 19 ans +,1449,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,12.2,0.7,10.8,13.7,g,4.9,0.3,,3
 Glucides,Hommes adultes 19 ans +,1250,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,10.9,0.7,9.6,12.2,g,4.3,0.3,,3
@@ -739,7 +739,7 @@ Glucides,Femmes adultes* 19 ans +,2348,des,Fruits et légumes,des,Légumes inclu
 Glucides,Femmes adultes* 19 ans +,6669,des,Produits céréaliers,,,,,79.1,1.2,76.6,81.5,g,41.1,0.5,,1
 Glucides,Femmes adultes* 19 ans +,5520,des,Produits céréaliers,des,Pains,,,35.2,0.7,33.7,36.6,g,18.3,0.3,,2
 Glucides,Femmes adultes* 19 ans +,2230,des,Produits céréaliers,des,Céréales pour déjeuner,,,8.2,0.4,7.4,8.9,g,4.2,0.2,,2
-Glucides,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,4.8,0.3,4.2,5.4,g,2.5,0.1,,2
+Glucides,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,4.8,0.3,4.2,5.4,g,2.5,0.1,,2
 Glucides,Femmes adultes* 19 ans +,4893,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,30.9,0.9,29.1,32.8,g,16.1,0.4,,2
 Glucides,Femmes adultes* 19 ans +,2551,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,13.4,0.5,12.4,14.4,g,7,0.3,,3
 Glucides,Femmes adultes* 19 ans +,1994,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,10.3,0.5,9.2,11.3,g,5.3,0.3,,3
@@ -747,10 +747,10 @@ Glucides,Femmes adultes* 19 ans +,2239,des,Produits céréaliers,des,Pains,des,P
 Glucides,Femmes adultes* 19 ans +,914,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,1.6,0.2,1.3,1.9,g,0.8,0.1,,3
 Glucides,Femmes adultes* 19 ans +,1756,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,6.6,0.3,6,7.3,g,3.4,0.2,,3
 Glucides,Femmes adultes* 19 ans +,555,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),1.5,0.1,1.3,1.8,g,0.8,0.1,,3
-Glucides,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,1.2,0.1,0.9,1.5,g,0.6,0.1,,3
-Glucides,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0.1,0.2,g,0.1,0,,3
-Glucides,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.2,g,0.1,0,,3
-Glucides,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
+Glucides,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,1.2,0.1,0.9,1.5,g,0.6,0.1,,3
+Glucides,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0.1,0.2,g,0.1,0,,3
+Glucides,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.2,g,0.1,0,,3
+Glucides,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
 Glucides,Femmes adultes* 19 ans +,3664,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,13.2,0.7,11.9,14.4,g,6.8,0.3,,3
 Glucides,Femmes adultes* 19 ans +,1522,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,9.5,0.5,8.5,10.5,g,5,0.3,,3
 Glucides,Femmes adultes* 19 ans +,1358,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,8.3,0.5,7.3,9.2,g,4.3,0.2,,3
@@ -794,119 +794,119 @@ Glucides,Femmes adultes* 19 ans +,4229,des,Confiseries - sucres et grignotines s
 Glucides,Femmes adultes* 19 ans +,1529,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,3.8,0.3,3.3,4.4,g,2,0.1,,3
 Glucides,Femmes adultes* 19 ans +,773,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,1.1,0.1,0.9,1.3,g,0.6,0.1,,3
 Glucides,Femmes adultes* 19 ans +,360,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0.1,0,0.1,0.1,g,0.1,0,,3
-Glucides,Enfants 1 à 8 ans,122,des,Aliments pour bébés,,,,,1.3,0.3,0.8,1.8,g,0.6,0.1,E,1
-Glucides,Enfants 1 à 8 ans,95,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0.8,0.2,0.4,1.1,g,0.4,0.1,E,2
-Glucides,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0.5,0.1,0.2,0.8,g,0.2,0.1,E,2
-Glucides,Enfants 1 à 8 ans,2443,des,Boissons (excluant laits),,,,,21.2,0.8,19.6,22.8,g,10.1,0.4,,1
-Glucides,Enfants 1 à 8 ans,20,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0.1,g,0,0,,2
-Glucides,Enfants 1 à 8 ans,141,des,Boissons (excluant laits),du,Café et thé,,,0.6,0.1,0.3,0.8,g,0.3,0.1,E,2
-Glucides,Enfants 1 à 8 ans,,des,Boissons (excluant laits),des,Boissons Énergisantes,,,X,X,,,g,X,X,<10,2
-Glucides,Enfants 1 à 8 ans,357,des,Boissons (excluant laits),des,Boissons aux fruits,,,4.4,0.4,3.5,5.3,g,2.1,0.2,,2
-Glucides,Enfants 1 à 8 ans,1159,des,Boissons (excluant laits),des,Jus de fruit,,,13.7,0.6,12.4,14.9,g,6.5,0.3,,2
-Glucides,Enfants 1 à 8 ans,77,des,Boissons (excluant laits),des,Autres boissons,,,0.9,0.2,0.5,1.2,g,0.4,0.1,E,2
-Glucides,Enfants 1 à 8 ans,142,des,Boissons (excluant laits),des,Boissons gazeuses,,,1.5,0.2,1,1.9,g,0.7,0.1,,2
-Glucides,Enfants 1 à 8 ans,21,des,Boissons (excluant laits),des,Boissons pour sportifs,,,0.1,0,0,0.1,g,0,0,,2
-Glucides,Enfants 1 à 8 ans,52,des,Boissons (excluant laits),des,Jus de tomates et de légumes,,,0.1,0,0.1,0.2,g,0.1,0,,2
-Glucides,Enfants 1 à 8 ans,,des,Boissons (excluant laits),de l',Eau vitaminée,,,X,X,,,g,X,X,<10,2
-Glucides,Enfants 1 à 8 ans,2344,des,Boissons (excluant laits),de l',Eau,,,0,0,0,0,g,0,0,,2
-Glucides,Enfants 1 à 8 ans,133,des,Boissons (excluant laits),du,Café et thé,du,Thé,0.6,0.1,0.3,0.8,g,0.3,0.1,E,3
-Glucides,Enfants 1 à 8 ans,,des,Boissons (excluant laits),du,Café et thé,du,Café,X,X,,,g,X,X,<10,3
-Glucides,Enfants 1 à 8 ans,2436,des,Produits laitiers et Boissons à base de plantes,,,,,25.5,0.7,24.2,26.9,g,12.2,0.3,,1
-Glucides,Enfants 1 à 8 ans,1632,des,Produits laitiers et Boissons à base de plantes,des,Fromages,,,1.2,0.1,1.1,1.4,g,0.6,0,,2
-Glucides,Enfants 1 à 8 ans,2341,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,18.5,0.6,17.4,19.6,g,8.9,0.3,,2
-Glucides,Enfants 1 à 8 ans,1032,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,,,5.8,0.3,5.2,6.4,g,2.8,0.1,,2
-Glucides,Enfants 1 à 8 ans,2242,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait nature,15.3,0.5,14.4,16.2,g,7.3,0.2,,3
-Glucides,Enfants 1 à 8 ans,217,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait aromatisé,2.5,0.3,1.9,3.1,g,1.2,0.1,,3
-Glucides,Enfants 1 à 8 ans,128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0.5,0.1,0.3,0.7,g,0.2,0,E,3
-Glucides,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0.3,0.1,0,0.5,g,0.1,0.1,E,3
-Glucides,Enfants 1 à 8 ans,948,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,du,Yogourt aromatisé,5.6,0.3,5,6.2,g,2.7,0.1,,3
-Glucides,Enfants 1 à 8 ans,109,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,du,Yogourt nature,0.2,0,0.1,0.3,g,0.1,0,,3
-Glucides,Enfants 1 à 8 ans,2270,des,Graisses et huiles,,,,,0.2,0,0.2,0.3,g,0.1,0,,1
-Glucides,Enfants 1 à 8 ans,83,des,Graisses et huiles,des,Graisses animales,,,0,0,0,0,g,0,0,,2
-Glucides,Enfants 1 à 8 ans,657,des,Graisses et huiles,du,Beurre,,,0,0,0,0,g,0,0,,2
-Glucides,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Margarines,,,0,0,0,0,g,0,0,,2
-Glucides,Enfants 1 à 8 ans,463,des,Graisses et huiles,des,Sauces pour salade,,,0.2,0,0.1,0.3,g,0.1,0,,2
-Glucides,Enfants 1 à 8 ans,1035,des,Graisses et huiles,du,Shortening,,,0,0,0,0,g,0,0,,2
-Glucides,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Huiles végétales,,,0,0,0,0,g,0,0,,2
-Glucides,Enfants 1 à 8 ans,298,des,Poissons et fruits de mer,,,,,0,0,0,0.1,g,0,0,,1
-Glucides,Enfants 1 à 8 ans,257,des,Poissons et fruits de mer,des,Poissons,,,0,0,0,0,g,0,0,,2
-Glucides,Enfants 1 à 8 ans,50,des,Poissons et fruits de mer,des,Mollusques et crustacés,,,0,0,0,0.1,g,0,0,,2
-Glucides,Enfants 1 à 8 ans,2428,des,Fruits et légumes,,,,,39.9,1.1,37.7,42.1,g,19.1,0.5,,1
-Glucides,Enfants 1 à 8 ans,2117,des,Fruits et légumes,des,Fruits,,,27.3,0.9,25.5,29,g,13,0.4,,2
-Glucides,Enfants 1 à 8 ans,2235,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,12.6,0.5,11.6,13.6,g,6,0.2,,2
-Glucides,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pommes,7.9,0.5,6.9,8.9,g,3.8,0.2,,3
-Glucides,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Bananes,6.6,0.4,5.9,7.4,g,3.2,0.2,,3
-Glucides,Enfants 1 à 8 ans,572,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,3.1,0.5,2.2,4,g,1.5,0.2,,3
-Glucides,Enfants 1 à 8 ans,830,des,Fruits et légumes,des,Fruits,des,Baies,2.5,0.2,2.1,3,g,1.2,0.1,,3
-Glucides,Enfants 1 à 8 ans,421,des,Fruits et légumes,des,Fruits,des,Agrumes,2.1,0.2,1.7,2.4,g,1,0.1,,3
-Glucides,Enfants 1 à 8 ans,219,des,Fruits et légumes,des,Fruits,des,Melons,1.2,0.2,0.9,1.6,g,0.6,0.1,E,3
-Glucides,Enfants 1 à 8 ans,260,des,Fruits et légumes,des,Fruits,des,Autres fruits,1.3,0.2,1,1.6,g,0.6,0.1,,3
-Glucides,Enfants 1 à 8 ans,133,des,Fruits et légumes,des,Fruits,des,Poires,1,0.2,0.7,1.4,g,0.5,0.1,E,3
-Glucides,Enfants 1 à 8 ans,118,des,Fruits et légumes,des,Fruits,des,Pêches et nectarines,0.6,0.1,0.4,0.9,g,0.3,0.1,E,3
-Glucides,Enfants 1 à 8 ans,94,des,Fruits et légumes,des,Fruits,des,Ananas,0.4,0.1,0.2,0.5,g,0.2,0,E,3
-Glucides,Enfants 1 à 8 ans,47,des,Fruits et légumes,des,Fruits,des,Cerises,0.3,0.1,0.1,0.4,g,0.1,0,E,3
-Glucides,Enfants 1 à 8 ans,37,des,Fruits et légumes,des,Fruits,des,Prunes et pruneaux,F,F,,,g,F,F,F,3
-Glucides,Enfants 1 à 8 ans,1032,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes féculents,6.6,0.4,5.8,7.5,g,3.2,0.2,,3
-Glucides,Enfants 1 à 8 ans,1773,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Autres légumes,3.6,0.2,3.3,3.9,g,1.7,0.1,,3
-Glucides,Enfants 1 à 8 ans,1068,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes vert foncé,1.2,0.1,1.1,1.4,g,0.6,0,,3
-Glucides,Enfants 1 à 8 ans,875,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes jaune foncé ou orange,1.2,0.1,0.9,1.4,g,0.6,0.1,,3
-Glucides,Enfants 1 à 8 ans,2475,des,Produits céréaliers,,,,,85.5,1.6,82.3,88.8,g,40.9,0.6,,1
-Glucides,Enfants 1 à 8 ans,2114,des,Produits céréaliers,des,Pains,,,33,1.1,30.8,35.3,g,15.8,0.5,,2
-Glucides,Enfants 1 à 8 ans,1282,des,Produits céréaliers,des,Céréales pour déjeuner,,,11.1,0.5,10.2,12,g,5.3,0.2,,2
-Glucides,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,8.9,0.5,7.9,9.8,g,4.2,0.2,,2
-Glucides,Enfants 1 à 8 ans,2037,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,32.6,1.2,30.3,34.9,g,15.6,0.5,,2
-Glucides,Enfants 1 à 8 ans,951,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,12.4,0.9,10.6,14.2,g,5.9,0.4,,3
-Glucides,Enfants 1 à 8 ans,805,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,9,0.7,7.6,10.5,g,4.3,0.3,,3
-Glucides,Enfants 1 à 8 ans,813,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,7.3,0.4,6.5,8.2,g,3.5,0.2,,3
-Glucides,Enfants 1 à 8 ans,745,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,4.2,0.4,3.4,5,g,2,0.2,,3
-Glucides,Enfants 1 à 8 ans,670,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),5.6,0.4,4.9,6.3,g,2.7,0.2,,3
-Glucides,Enfants 1 à 8 ans,728,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,5.4,0.4,4.7,6.2,g,2.6,0.2,,3
-Glucides,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,2.4,0.2,2,2.8,g,1.1,0.1,,3
-Glucides,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.3,0.1,0.1,0.5,g,0.2,0.1,E,3
-Glucides,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.3,0.1,0,0.5,g,0.1,0.1,E,3
-Glucides,Enfants 1 à 8 ans,1461,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,12.6,0.8,11,14.2,g,6,0.4,,3
-Glucides,Enfants 1 à 8 ans,834,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,11.1,0.8,9.5,12.7,g,5.3,0.4,,3
-Glucides,Enfants 1 à 8 ans,654,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,8.9,0.6,7.6,10.1,g,4.2,0.3,,3
-Glucides,Enfants 1 à 8 ans,2072,de la,Viandes et volailles,,,,,1.2,0.1,1,1.3,g,0.6,0,,1
-Glucides,Enfants 1 à 8 ans,1003,de la,Viandes et volailles,de la,Volaille,,,0,0,0,0.1,g,0,0,,2
-Glucides,Enfants 1 à 8 ans,942,de la,Viandes et volailles,des,Viandes transformées,,,1.1,0.1,0.9,1.3,g,0.5,0,,2
-Glucides,Enfants 1 à 8 ans,999,de la,Viandes et volailles,de la,Viande rouge,,,0,0,0,0,g,0,0,,2
-Glucides,Enfants 1 à 8 ans,933,de la,Viandes et volailles,de la,Volaille,du,Poulet,0,0,0,0.1,g,0,0,,3
-Glucides,Enfants 1 à 8 ans,86,de la,Viandes et volailles,de la,Volaille,de la,Dinde et autres volailles,0,0,0,0,g,0,0,,3
-Glucides,Enfants 1 à 8 ans,375,de la,Viandes et volailles,des,Viandes transformées,des,Saucisses,0.7,0.1,0.5,0.8,g,0.3,0,,3
-Glucides,Enfants 1 à 8 ans,513,de la,Viandes et volailles,des,Viandes transformées,des,Viandes froides,0.4,0,0.3,0.5,g,0.2,0,,3
-Glucides,Enfants 1 à 8 ans,135,de la,Viandes et volailles,des,Viandes transformées,du,Bacon,0,0,0,0,g,0,0,,3
-Glucides,Enfants 1 à 8 ans,106,de la,Viandes et volailles,des,Viandes transformées,du,Porc salé,0,0,0,0,g,0,0,,3
-Glucides,Enfants 1 à 8 ans,779,de la,Viandes et volailles,de la,Viande rouge,du,Bœuf,0,0,0,0,g,0,0,,3
-Glucides,Enfants 1 à 8 ans,43,de la,Viandes et volailles,de la,Viande rouge,de l',Agneau - veau et gibiers,0,0,0,0,g,0,0,,3
-Glucides,Enfants 1 à 8 ans,284,de la,Viandes et volailles,de la,Viande rouge,du,Porc frais,0,0,0,0,g,0,0,,3
-Glucides,Enfants 1 à 8 ans,,de la,Viandes et volailles,de la,Viande rouge,des,Abats - foies et pâtés,X,X,,,g,X,X,<10,3
-Glucides,Enfants 1 à 8 ans,1789,des,Substituts de viande,,,,,2.6,0.3,2.1,3.2,g,1.3,0.1,,1
-Glucides,Enfants 1 à 8 ans,1450,des,Substituts de viande,des,Œufs,,,0.2,0,0.1,0.2,g,0.1,0,,2
-Glucides,Enfants 1 à 8 ans,210,des,Substituts de viande,des,Légumineuses,,,1.2,0.2,0.8,1.6,g,0.6,0.1,E,2
-Glucides,Enfants 1 à 8 ans,749,des,Substituts de viande,des,Noix - graines et beurre d'arachides,,,1.2,0.1,0.9,1.4,g,0.6,0.1,,2
-Glucides,Enfants 1 à 8 ans,58,des,Substituts de viande,du,Tofu et produits sans viande,,,0.1,0,0,0.2,g,0,0,,2
-Glucides,Enfants 1 à 8 ans,45,des,Boissons et barres nutritionnelles,,,,,0.6,0.2,0.3,0.9,g,0.3,0.1,E,1
-Glucides,Enfants 1 à 8 ans,40,des,Boissons et barres nutritionnelles,des,Substituts de repas et boissons nutritionnelles,,,0.6,0.1,0.3,0.9,g,0.3,0.1,E,2
-Glucides,Enfants 1 à 8 ans,,des,Boissons et barres nutritionnelles,des,Barres nutritionnelles,,,X,X,,,g,X,X,<10,2
-Glucides,Enfants 1 à 8 ans,2295,des,Soupes - sauces - Épices et autres ingrédients,,,,,2.7,0.3,2.2,3.2,g,1.3,0.1,,1
-Glucides,Enfants 1 à 8 ans,761,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,1.2,0.2,0.9,1.5,g,0.6,0.1,E,2
-Glucides,Enfants 1 à 8 ans,532,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,1,0.2,0.7,1.4,g,0.5,0.1,E,2
-Glucides,Enfants 1 à 8 ans,2205,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.4,0,0.3,0.5,g,0.2,0,,2
-Glucides,Enfants 1 à 8 ans,2106,des,Confiseries - sucres et grignotines salées,,,,,28.2,1.2,25.9,30.6,g,13.5,0.5,,1
-Glucides,Enfants 1 à 8 ans,1048,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,7.2,0.5,6.3,8.2,g,3.5,0.2,,2
-Glucides,Enfants 1 à 8 ans,497,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,5.9,0.6,4.7,7,g,2.8,0.3,,2
-Glucides,Enfants 1 à 8 ans,615,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,3.9,0.4,3.2,4.6,g,1.9,0.2,,2
-Glucides,Enfants 1 à 8 ans,1642,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,11.2,0.7,9.8,12.7,g,5.4,0.3,,2
-Glucides,Enfants 1 à 8 ans,557,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,4.1,0.4,3.4,4.9,g,2,0.2,,3
-Glucides,Enfants 1 à 8 ans,548,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,2.1,0.2,1.7,2.5,g,1,0.1,,3
-Glucides,Enfants 1 à 8 ans,131,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,1,0.2,0.6,1.3,g,0.5,0.1,E,3
-Glucides,Enfants 1 à 8 ans,346,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,3.3,0.3,2.6,4,g,1.6,0.2,,3
-Glucides,Enfants 1 à 8 ans,184,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,2.6,0.4,1.7,3.4,g,1.2,0.2,,3
-Glucides,Enfants 1 à 8 ans,720,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,5.7,0.5,4.6,6.7,g,2.7,0.2,,3
-Glucides,Enfants 1 à 8 ans,1341,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,4.5,0.3,3.8,5.2,g,2.1,0.2,,3
-Glucides,Enfants 1 à 8 ans,257,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,1.1,0.2,0.7,1.4,g,0.5,0.1,E,3
-Glucides,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,g,X,X,<10,3
+Glucides,Enfants 1 à 8 ans,122,des,Aliments pour bébés,,,,,1.3,0.3,0.8,1.8,g,0.6,0.1,E,1
+Glucides,Enfants 1 à 8 ans,95,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0.8,0.2,0.4,1.1,g,0.4,0.1,E,2
+Glucides,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0.5,0.1,0.2,0.8,g,0.2,0.1,E,2
+Glucides,Enfants 1 à 8 ans,2443,des,Boissons (excluant laits),,,,,21.2,0.8,19.6,22.8,g,10.1,0.4,,1
+Glucides,Enfants 1 à 8 ans,20,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0.1,g,0,0,,2
+Glucides,Enfants 1 à 8 ans,141,des,Boissons (excluant laits),du,Café et thé,,,0.6,0.1,0.3,0.8,g,0.3,0.1,E,2
+Glucides,Enfants 1 à 8 ans,,des,Boissons (excluant laits),des,Boissons Énergisantes,,,X,X,,,g,X,X,<10,2
+Glucides,Enfants 1 à 8 ans,357,des,Boissons (excluant laits),des,Boissons aux fruits,,,4.4,0.4,3.5,5.3,g,2.1,0.2,,2
+Glucides,Enfants 1 à 8 ans,1159,des,Boissons (excluant laits),des,Jus de fruit,,,13.7,0.6,12.4,14.9,g,6.5,0.3,,2
+Glucides,Enfants 1 à 8 ans,77,des,Boissons (excluant laits),des,Autres boissons,,,0.9,0.2,0.5,1.2,g,0.4,0.1,E,2
+Glucides,Enfants 1 à 8 ans,142,des,Boissons (excluant laits),des,Boissons gazeuses,,,1.5,0.2,1,1.9,g,0.7,0.1,,2
+Glucides,Enfants 1 à 8 ans,21,des,Boissons (excluant laits),des,Boissons pour sportifs,,,0.1,0,0,0.1,g,0,0,,2
+Glucides,Enfants 1 à 8 ans,52,des,Boissons (excluant laits),des,Jus de tomates et de légumes,,,0.1,0,0.1,0.2,g,0.1,0,,2
+Glucides,Enfants 1 à 8 ans,,des,Boissons (excluant laits),de l',Eau vitaminée,,,X,X,,,g,X,X,<10,2
+Glucides,Enfants 1 à 8 ans,2344,des,Boissons (excluant laits),de l',Eau,,,0,0,0,0,g,0,0,,2
+Glucides,Enfants 1 à 8 ans,133,des,Boissons (excluant laits),du,Café et thé,du,Thé,0.6,0.1,0.3,0.8,g,0.3,0.1,E,3
+Glucides,Enfants 1 à 8 ans,,des,Boissons (excluant laits),du,Café et thé,du,Café,X,X,,,g,X,X,<10,3
+Glucides,Enfants 1 à 8 ans,2436,des,Produits laitiers et Boissons à base de plantes,,,,,25.5,0.7,24.2,26.9,g,12.2,0.3,,1
+Glucides,Enfants 1 à 8 ans,1632,des,Produits laitiers et Boissons à base de plantes,des,Fromages,,,1.2,0.1,1.1,1.4,g,0.6,0,,2
+Glucides,Enfants 1 à 8 ans,2341,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,18.5,0.6,17.4,19.6,g,8.9,0.3,,2
+Glucides,Enfants 1 à 8 ans,1032,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,,,5.8,0.3,5.2,6.4,g,2.8,0.1,,2
+Glucides,Enfants 1 à 8 ans,2242,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait nature,15.3,0.5,14.4,16.2,g,7.3,0.2,,3
+Glucides,Enfants 1 à 8 ans,217,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait aromatisé,2.5,0.3,1.9,3.1,g,1.2,0.1,,3
+Glucides,Enfants 1 à 8 ans,128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0.5,0.1,0.3,0.7,g,0.2,0,E,3
+Glucides,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0.3,0.1,0,0.5,g,0.1,0.1,E,3
+Glucides,Enfants 1 à 8 ans,948,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,du,Yogourt aromatisé,5.6,0.3,5,6.2,g,2.7,0.1,,3
+Glucides,Enfants 1 à 8 ans,109,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,du,Yogourt nature,0.2,0,0.1,0.3,g,0.1,0,,3
+Glucides,Enfants 1 à 8 ans,2270,des,Graisses et huiles,,,,,0.2,0,0.2,0.3,g,0.1,0,,1
+Glucides,Enfants 1 à 8 ans,83,des,Graisses et huiles,des,Graisses animales,,,0,0,0,0,g,0,0,,2
+Glucides,Enfants 1 à 8 ans,657,des,Graisses et huiles,du,Beurre,,,0,0,0,0,g,0,0,,2
+Glucides,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Margarines,,,0,0,0,0,g,0,0,,2
+Glucides,Enfants 1 à 8 ans,463,des,Graisses et huiles,des,Sauces pour salade,,,0.2,0,0.1,0.3,g,0.1,0,,2
+Glucides,Enfants 1 à 8 ans,1035,des,Graisses et huiles,du,Shortening,,,0,0,0,0,g,0,0,,2
+Glucides,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Huiles végétales,,,0,0,0,0,g,0,0,,2
+Glucides,Enfants 1 à 8 ans,298,des,Poissons et fruits de mer,,,,,0,0,0,0.1,g,0,0,,1
+Glucides,Enfants 1 à 8 ans,257,des,Poissons et fruits de mer,des,Poissons,,,0,0,0,0,g,0,0,,2
+Glucides,Enfants 1 à 8 ans,50,des,Poissons et fruits de mer,des,Mollusques et crustacés,,,0,0,0,0.1,g,0,0,,2
+Glucides,Enfants 1 à 8 ans,2428,des,Fruits et légumes,,,,,39.9,1.1,37.7,42.1,g,19.1,0.5,,1
+Glucides,Enfants 1 à 8 ans,2117,des,Fruits et légumes,des,Fruits,,,27.3,0.9,25.5,29,g,13,0.4,,2
+Glucides,Enfants 1 à 8 ans,2235,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,12.6,0.5,11.6,13.6,g,6,0.2,,2
+Glucides,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pommes,7.9,0.5,6.9,8.9,g,3.8,0.2,,3
+Glucides,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Bananes,6.6,0.4,5.9,7.4,g,3.2,0.2,,3
+Glucides,Enfants 1 à 8 ans,572,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,3.1,0.5,2.2,4,g,1.5,0.2,,3
+Glucides,Enfants 1 à 8 ans,830,des,Fruits et légumes,des,Fruits,des,Baies,2.5,0.2,2.1,3,g,1.2,0.1,,3
+Glucides,Enfants 1 à 8 ans,421,des,Fruits et légumes,des,Fruits,des,Agrumes,2.1,0.2,1.7,2.4,g,1,0.1,,3
+Glucides,Enfants 1 à 8 ans,219,des,Fruits et légumes,des,Fruits,des,Melons,1.2,0.2,0.9,1.6,g,0.6,0.1,E,3
+Glucides,Enfants 1 à 8 ans,260,des,Fruits et légumes,des,Fruits,des,Autres fruits,1.3,0.2,1,1.6,g,0.6,0.1,,3
+Glucides,Enfants 1 à 8 ans,133,des,Fruits et légumes,des,Fruits,des,Poires,1,0.2,0.7,1.4,g,0.5,0.1,E,3
+Glucides,Enfants 1 à 8 ans,118,des,Fruits et légumes,des,Fruits,des,Pêches et nectarines,0.6,0.1,0.4,0.9,g,0.3,0.1,E,3
+Glucides,Enfants 1 à 8 ans,94,des,Fruits et légumes,des,Fruits,des,Ananas,0.4,0.1,0.2,0.5,g,0.2,0,E,3
+Glucides,Enfants 1 à 8 ans,47,des,Fruits et légumes,des,Fruits,des,Cerises,0.3,0.1,0.1,0.4,g,0.1,0,E,3
+Glucides,Enfants 1 à 8 ans,37,des,Fruits et légumes,des,Fruits,des,Prunes et pruneaux,F,F,,,g,F,F,F,3
+Glucides,Enfants 1 à 8 ans,1032,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes féculents,6.6,0.4,5.8,7.5,g,3.2,0.2,,3
+Glucides,Enfants 1 à 8 ans,1773,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Autres légumes,3.6,0.2,3.3,3.9,g,1.7,0.1,,3
+Glucides,Enfants 1 à 8 ans,1068,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes vert foncé,1.2,0.1,1.1,1.4,g,0.6,0,,3
+Glucides,Enfants 1 à 8 ans,875,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes jaune foncé ou orange,1.2,0.1,0.9,1.4,g,0.6,0.1,,3
+Glucides,Enfants 1 à 8 ans,2475,des,Produits céréaliers,,,,,85.5,1.6,82.3,88.8,g,40.9,0.6,,1
+Glucides,Enfants 1 à 8 ans,2114,des,Produits céréaliers,des,Pains,,,33,1.1,30.8,35.3,g,15.8,0.5,,2
+Glucides,Enfants 1 à 8 ans,1282,des,Produits céréaliers,des,Céréales pour déjeuner,,,11.1,0.5,10.2,12,g,5.3,0.2,,2
+Glucides,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,8.9,0.5,7.9,9.8,g,4.2,0.2,,2
+Glucides,Enfants 1 à 8 ans,2037,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,32.6,1.2,30.3,34.9,g,15.6,0.5,,2
+Glucides,Enfants 1 à 8 ans,951,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,12.4,0.9,10.6,14.2,g,5.9,0.4,,3
+Glucides,Enfants 1 à 8 ans,805,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,9,0.7,7.6,10.5,g,4.3,0.3,,3
+Glucides,Enfants 1 à 8 ans,813,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,7.3,0.4,6.5,8.2,g,3.5,0.2,,3
+Glucides,Enfants 1 à 8 ans,745,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,4.2,0.4,3.4,5,g,2,0.2,,3
+Glucides,Enfants 1 à 8 ans,670,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),5.6,0.4,4.9,6.3,g,2.7,0.2,,3
+Glucides,Enfants 1 à 8 ans,728,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,5.4,0.4,4.7,6.2,g,2.6,0.2,,3
+Glucides,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,2.4,0.2,2,2.8,g,1.1,0.1,,3
+Glucides,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.3,0.1,0.1,0.5,g,0.2,0.1,E,3
+Glucides,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.3,0.1,0,0.5,g,0.1,0.1,E,3
+Glucides,Enfants 1 à 8 ans,1461,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,12.6,0.8,11,14.2,g,6,0.4,,3
+Glucides,Enfants 1 à 8 ans,834,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,11.1,0.8,9.5,12.7,g,5.3,0.4,,3
+Glucides,Enfants 1 à 8 ans,654,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,8.9,0.6,7.6,10.1,g,4.2,0.3,,3
+Glucides,Enfants 1 à 8 ans,2072,de la,Viandes et volailles,,,,,1.2,0.1,1,1.3,g,0.6,0,,1
+Glucides,Enfants 1 à 8 ans,1003,de la,Viandes et volailles,de la,Volaille,,,0,0,0,0.1,g,0,0,,2
+Glucides,Enfants 1 à 8 ans,942,de la,Viandes et volailles,des,Viandes transformées,,,1.1,0.1,0.9,1.3,g,0.5,0,,2
+Glucides,Enfants 1 à 8 ans,999,de la,Viandes et volailles,de la,Viande rouge,,,0,0,0,0,g,0,0,,2
+Glucides,Enfants 1 à 8 ans,933,de la,Viandes et volailles,de la,Volaille,du,Poulet,0,0,0,0.1,g,0,0,,3
+Glucides,Enfants 1 à 8 ans,86,de la,Viandes et volailles,de la,Volaille,de la,Dinde et autres volailles,0,0,0,0,g,0,0,,3
+Glucides,Enfants 1 à 8 ans,375,de la,Viandes et volailles,des,Viandes transformées,des,Saucisses,0.7,0.1,0.5,0.8,g,0.3,0,,3
+Glucides,Enfants 1 à 8 ans,513,de la,Viandes et volailles,des,Viandes transformées,des,Viandes froides,0.4,0,0.3,0.5,g,0.2,0,,3
+Glucides,Enfants 1 à 8 ans,135,de la,Viandes et volailles,des,Viandes transformées,du,Bacon,0,0,0,0,g,0,0,,3
+Glucides,Enfants 1 à 8 ans,106,de la,Viandes et volailles,des,Viandes transformées,du,Porc salé,0,0,0,0,g,0,0,,3
+Glucides,Enfants 1 à 8 ans,779,de la,Viandes et volailles,de la,Viande rouge,du,Bœuf,0,0,0,0,g,0,0,,3
+Glucides,Enfants 1 à 8 ans,43,de la,Viandes et volailles,de la,Viande rouge,de l',Agneau - veau et gibiers,0,0,0,0,g,0,0,,3
+Glucides,Enfants 1 à 8 ans,284,de la,Viandes et volailles,de la,Viande rouge,du,Porc frais,0,0,0,0,g,0,0,,3
+Glucides,Enfants 1 à 8 ans,,de la,Viandes et volailles,de la,Viande rouge,des,Abats - foies et pâtés,X,X,,,g,X,X,<10,3
+Glucides,Enfants 1 à 8 ans,1789,des,Substituts de viande,,,,,2.6,0.3,2.1,3.2,g,1.3,0.1,,1
+Glucides,Enfants 1 à 8 ans,1450,des,Substituts de viande,des,Œufs,,,0.2,0,0.1,0.2,g,0.1,0,,2
+Glucides,Enfants 1 à 8 ans,210,des,Substituts de viande,des,Légumineuses,,,1.2,0.2,0.8,1.6,g,0.6,0.1,E,2
+Glucides,Enfants 1 à 8 ans,749,des,Substituts de viande,des,Noix - graines et beurre d'arachides,,,1.2,0.1,0.9,1.4,g,0.6,0.1,,2
+Glucides,Enfants 1 à 8 ans,58,des,Substituts de viande,du,Tofu et produits sans viande,,,0.1,0,0,0.2,g,0,0,,2
+Glucides,Enfants 1 à 8 ans,45,des,Boissons et barres nutritionnelles,,,,,0.6,0.2,0.3,0.9,g,0.3,0.1,E,1
+Glucides,Enfants 1 à 8 ans,40,des,Boissons et barres nutritionnelles,des,Substituts de repas et boissons nutritionnelles,,,0.6,0.1,0.3,0.9,g,0.3,0.1,E,2
+Glucides,Enfants 1 à 8 ans,,des,Boissons et barres nutritionnelles,des,Barres nutritionnelles,,,X,X,,,g,X,X,<10,2
+Glucides,Enfants 1 à 8 ans,2295,des,Soupes - sauces - Épices et autres ingrédients,,,,,2.7,0.3,2.2,3.2,g,1.3,0.1,,1
+Glucides,Enfants 1 à 8 ans,761,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,1.2,0.2,0.9,1.5,g,0.6,0.1,E,2
+Glucides,Enfants 1 à 8 ans,532,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,1,0.2,0.7,1.4,g,0.5,0.1,E,2
+Glucides,Enfants 1 à 8 ans,2205,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.4,0,0.3,0.5,g,0.2,0,,2
+Glucides,Enfants 1 à 8 ans,2106,des,Confiseries - sucres et grignotines salées,,,,,28.2,1.2,25.9,30.6,g,13.5,0.5,,1
+Glucides,Enfants 1 à 8 ans,1048,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,7.2,0.5,6.3,8.2,g,3.5,0.2,,2
+Glucides,Enfants 1 à 8 ans,497,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,5.9,0.6,4.7,7,g,2.8,0.3,,2
+Glucides,Enfants 1 à 8 ans,615,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,3.9,0.4,3.2,4.6,g,1.9,0.2,,2
+Glucides,Enfants 1 à 8 ans,1642,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,11.2,0.7,9.8,12.7,g,5.4,0.3,,2
+Glucides,Enfants 1 à 8 ans,557,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,4.1,0.4,3.4,4.9,g,2,0.2,,3
+Glucides,Enfants 1 à 8 ans,548,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,2.1,0.2,1.7,2.5,g,1,0.1,,3
+Glucides,Enfants 1 à 8 ans,131,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,1,0.2,0.6,1.3,g,0.5,0.1,E,3
+Glucides,Enfants 1 à 8 ans,346,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,3.3,0.3,2.6,4,g,1.6,0.2,,3
+Glucides,Enfants 1 à 8 ans,184,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,2.6,0.4,1.7,3.4,g,1.2,0.2,,3
+Glucides,Enfants 1 à 8 ans,720,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,5.7,0.5,4.6,6.7,g,2.7,0.2,,3
+Glucides,Enfants 1 à 8 ans,1341,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,4.5,0.3,3.8,5.2,g,2.1,0.2,,3
+Glucides,Enfants 1 à 8 ans,257,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,1.1,0.2,0.7,1.4,g,0.5,0.1,E,3
+Glucides,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,g,X,X,<10,3
 Fibres alimentaires,Population 1 an et +,186,des,Aliments pour bébés,,,,,0,0,0,0,g,0.1,0,,1
 Fibres alimentaires,Population 1 an et +,154,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0,g,0.1,0,,2
 Fibres alimentaires,Population 1 an et +,51,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0,0,0,0,g,0,0,,2
@@ -966,7 +966,7 @@ Fibres alimentaires,Population 1 an et +,6318,des,Fruits et légumes,des,Légume
 Fibres alimentaires,Population 1 an et +,19327,des,Produits céréaliers,,,,,6.7,0.1,6.5,6.8,g,39.7,0.4,,1
 Fibres alimentaires,Population 1 an et +,16168,des,Produits céréaliers,des,Pains,,,3.5,0.1,3.4,3.6,g,20.8,0.3,,2
 Fibres alimentaires,Population 1 an et +,6966,des,Produits céréaliers,des,Céréales pour déjeuner,,,1.3,0,1.2,1.4,g,7.6,0.3,,2
-Fibres alimentaires,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.3,0,0.3,0.4,g,2,0.1,,2
+Fibres alimentaires,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.3,0,0.3,0.4,g,2,0.1,,2
 Fibres alimentaires,Population 1 an et +,14820,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,1.6,0,1.5,1.6,g,9.3,0.2,,2
 Fibres alimentaires,Population 1 an et +,5962,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,1.4,0,1.3,1.4,g,8.1,0.2,,3
 Fibres alimentaires,Population 1 an et +,6257,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,1,0,0.9,1.1,g,6,0.3,,3
@@ -974,10 +974,10 @@ Fibres alimentaires,Population 1 an et +,8159,des,Produits céréaliers,des,Pain
 Fibres alimentaires,Population 1 an et +,2918,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.1,0,0.1,0.1,g,0.7,0,,3
 Fibres alimentaires,Population 1 an et +,4760,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,1.1,0,1,1.2,g,6.7,0.3,,3
 Fibres alimentaires,Population 1 an et +,2573,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.2,0,0.1,0.2,g,1,0,,3
-Fibres alimentaires,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.2,0,0.2,0.2,g,1.1,0.1,,3
-Fibres alimentaires,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0.1,0,,3
-Fibres alimentaires,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
+Fibres alimentaires,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.2,0,0.2,0.2,g,1.1,0.1,,3
+Fibres alimentaires,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0.1,0,,3
+Fibres alimentaires,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
 Fibres alimentaires,Population 1 an et +,11102,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.8,0,0.8,0.9,g,4.8,0.1,,3
 Fibres alimentaires,Population 1 an et +,4543,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.5,0,0.5,0.5,g,3,0.1,,3
 Fibres alimentaires,Population 1 an et +,4598,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0.3,0,0.2,0.3,g,1.6,0.1,,3
@@ -1080,7 +1080,7 @@ Fibres alimentaires,Hommes adultes 19 ans +,1991,des,Fruits et légumes,des,Lég
 Fibres alimentaires,Hommes adultes 19 ans +,6068,des,Produits céréaliers,,,,,7.6,0.1,7.3,7.8,g,41.1,0.6,,1
 Fibres alimentaires,Hommes adultes 19 ans +,5104,des,Produits céréaliers,des,Pains,,,4,0.1,3.8,4.2,g,21.9,0.6,,2
 Fibres alimentaires,Hommes adultes 19 ans +,1921,des,Produits céréaliers,des,Céréales pour déjeuner,,,1.4,0.1,1.2,1.5,g,7.6,0.4,,2
-Fibres alimentaires,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.3,0,0.3,0.4,g,1.9,0.2,,2
+Fibres alimentaires,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.3,0,0.3,0.4,g,1.9,0.2,,2
 Fibres alimentaires,Hommes adultes 19 ans +,4551,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,1.8,0.1,1.7,1.9,g,9.7,0.3,,2
 Fibres alimentaires,Hommes adultes 19 ans +,1980,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,1.5,0.1,1.4,1.7,g,8.4,0.4,,3
 Fibres alimentaires,Hommes adultes 19 ans +,2752,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,1.2,0,1.2,1.3,g,6.8,0.3,,3
@@ -1088,9 +1088,9 @@ Fibres alimentaires,Hommes adultes 19 ans +,1885,des,Produits céréaliers,des,P
 Fibres alimentaires,Hommes adultes 19 ans +,593,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.1,0,0.1,0.1,g,0.5,0.1,,3
 Fibres alimentaires,Hommes adultes 19 ans +,1481,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,1.3,0.1,1.1,1.4,g,7,0.4,,3
 Fibres alimentaires,Hommes adultes 19 ans +,523,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.1,0,0.1,0.1,g,0.6,0.1,,3
-Fibres alimentaires,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.2,0,0.1,0.3,g,1.1,0.1,,3
-Fibres alimentaires,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.2,0,0.1,0.3,g,1.1,0.1,,3
+Fibres alimentaires,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
 Fibres alimentaires,Hommes adultes 19 ans +,3442,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.9,0,0.9,1,g,5.1,0.2,,3
 Fibres alimentaires,Hommes adultes 19 ans +,1250,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.5,0,0.5,0.6,g,3,0.2,,3
 Fibres alimentaires,Hommes adultes 19 ans +,1449,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0.3,0,0.3,0.3,g,1.6,0.1,,3
@@ -1193,7 +1193,7 @@ Fibres alimentaires,Femmes adultes* 19 ans +,2348,des,Fruits et légumes,des,Lé
 Fibres alimentaires,Femmes adultes* 19 ans +,6669,des,Produits céréaliers,,,,,5.9,0.1,5.7,6.2,g,37.1,0.6,,1
 Fibres alimentaires,Femmes adultes* 19 ans +,5520,des,Produits céréaliers,des,Pains,,,3.1,0.1,3,3.3,g,19.6,0.5,,2
 Fibres alimentaires,Femmes adultes* 19 ans +,2230,des,Produits céréaliers,des,Céréales pour déjeuner,,,1.2,0.1,1,1.4,g,7.5,0.5,,2
-Fibres alimentaires,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.2,0,0.2,0.3,g,1.5,0.1,,2
+Fibres alimentaires,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.2,0,0.2,0.3,g,1.5,0.1,,2
 Fibres alimentaires,Femmes adultes* 19 ans +,4893,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,1.4,0,1.3,1.4,g,8.5,0.3,,2
 Fibres alimentaires,Femmes adultes* 19 ans +,2239,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,1.3,0.1,1.2,1.5,g,8.4,0.3,,3
 Fibres alimentaires,Femmes adultes* 19 ans +,1994,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,0.9,0.1,0.7,1,g,5.4,0.4,,3
@@ -1201,10 +1201,10 @@ Fibres alimentaires,Femmes adultes* 19 ans +,2551,des,Produits céréaliers,des,
 Fibres alimentaires,Femmes adultes* 19 ans +,914,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.1,0,0.1,0.1,g,0.7,0.1,,3
 Fibres alimentaires,Femmes adultes* 19 ans +,1756,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,1.1,0.1,1,1.3,g,7,0.5,,3
 Fibres alimentaires,Femmes adultes* 19 ans +,555,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.1,0,0.1,0.1,g,0.6,0.1,,3
-Fibres alimentaires,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.1,g,0.7,0.1,,3
-Fibres alimentaires,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
+Fibres alimentaires,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.1,g,0.7,0.1,,3
+Fibres alimentaires,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
 Fibres alimentaires,Femmes adultes* 19 ans +,3664,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.7,0,0.6,0.8,g,4.4,0.2,,3
 Fibres alimentaires,Femmes adultes* 19 ans +,1358,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.4,0,0.4,0.5,g,2.6,0.2,,3
 Fibres alimentaires,Femmes adultes* 19 ans +,1522,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0.2,0,0.2,0.3,g,1.6,0.1,,3
@@ -1248,119 +1248,119 @@ Fibres alimentaires,Femmes adultes* 19 ans +,1529,des,Confiseries - sucres et gr
 Fibres alimentaires,Femmes adultes* 19 ans +,773,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0.1,0,,3
 Fibres alimentaires,Femmes adultes* 19 ans +,360,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
 Fibres alimentaires,Femmes adultes* 19 ans +,4229,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Enfants 1 à 8 ans,122,des,Aliments pour bébés,,,,,0.1,0,0,0.1,g,0.6,0.2,,1
-Fibres alimentaires,Enfants 1 à 8 ans,95,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0.1,0,0,0.1,g,0.6,0.2,,2
-Fibres alimentaires,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0,0,0,0,g,0,0,,2
-Fibres alimentaires,Enfants 1 à 8 ans,2443,des,Boissons (excluant laits),,,,,0.4,0,0.3,0.4,g,2.7,0.1,,1
-Fibres alimentaires,Enfants 1 à 8 ans,20,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0,g,0,0,,2
-Fibres alimentaires,Enfants 1 à 8 ans,141,des,Boissons (excluant laits),du,Café et thé,,,0,0,0,0,g,0,0,,2
-Fibres alimentaires,Enfants 1 à 8 ans,,des,Boissons (excluant laits),des,Boissons Énergisantes,,,X,X,,,g,X,X,<10,2
-Fibres alimentaires,Enfants 1 à 8 ans,357,des,Boissons (excluant laits),des,Boissons aux fruits,,,0,0,0,0,g,0.2,0,,2
-Fibres alimentaires,Enfants 1 à 8 ans,1159,des,Boissons (excluant laits),des,Jus de fruit,,,0.3,0,0.3,0.3,g,2.1,0.1,,2
-Fibres alimentaires,Enfants 1 à 8 ans,77,des,Boissons (excluant laits),des,Autres boissons,,,0,0,0,0.1,g,0.3,0.1,,2
-Fibres alimentaires,Enfants 1 à 8 ans,142,des,Boissons (excluant laits),des,Boissons gazeuses,,,0,0,0,0,g,0,0,,2
-Fibres alimentaires,Enfants 1 à 8 ans,21,des,Boissons (excluant laits),des,Boissons pour sportifs,,,0,0,0,0,g,0,0,,2
-Fibres alimentaires,Enfants 1 à 8 ans,52,des,Boissons (excluant laits),des,Jus de tomates et de légumes,,,0,0,0,0,g,0.1,0,,2
-Fibres alimentaires,Enfants 1 à 8 ans,,des,Boissons (excluant laits),de l',Eau vitaminée,,,X,X,,,g,X,X,<10,2
-Fibres alimentaires,Enfants 1 à 8 ans,2344,des,Boissons (excluant laits),de l',Eau,,,0,0,0,0,g,0,0,,2
-Fibres alimentaires,Enfants 1 à 8 ans,133,des,Boissons (excluant laits),du,Café et thé,du,Thé,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Enfants 1 à 8 ans,,des,Boissons (excluant laits),du,Café et thé,du,Café,X,X,,,g,X,X,<10,3
-Fibres alimentaires,Enfants 1 à 8 ans,2436,des,Produits laitiers et Boissons à base de plantes,,,,,0.2,0,0.2,0.2,g,1.5,0.1,,1
-Fibres alimentaires,Enfants 1 à 8 ans,1632,des,Produits laitiers et Boissons à base de plantes,des,Fromages,,,0,0,0,0,g,0,0,,2
-Fibres alimentaires,Enfants 1 à 8 ans,2341,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,0.2,0,0.1,0.2,g,1.1,0.1,,2
-Fibres alimentaires,Enfants 1 à 8 ans,1032,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,,,0,0,0,0.1,g,0.3,0.1,,2
-Fibres alimentaires,Enfants 1 à 8 ans,1810,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,0.1,0,0,0.1,g,0.5,0.1,,3
-Fibres alimentaires,Enfants 1 à 8 ans,854,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,0,0,0,0.1,g,0.3,0.1,,3
-Fibres alimentaires,Enfants 1 à 8 ans,128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0,0,0,0,g,0.2,0,,3
-Fibres alimentaires,Enfants 1 à 8 ans,1078,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,0,0,0,0,g,0.1,0,,3
-Fibres alimentaires,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Enfants 1 à 8 ans,739,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Enfants 1 à 8 ans,2270,des,Graisses et huiles,,,,,0,0,0,0,g,0,0,,1
-Fibres alimentaires,Enfants 1 à 8 ans,83,des,Graisses et huiles,des,Graisses animales,,,0,0,0,0,g,0,0,,2
-Fibres alimentaires,Enfants 1 à 8 ans,657,des,Graisses et huiles,du,Beurre,,,0,0,0,0,g,0,0,,2
-Fibres alimentaires,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Margarines,,,0,0,0,0,g,0,0,,2
-Fibres alimentaires,Enfants 1 à 8 ans,463,des,Graisses et huiles,des,Sauces pour salade,,,0,0,0,0,g,0,0,,2
-Fibres alimentaires,Enfants 1 à 8 ans,1035,des,Graisses et huiles,du,Shortening,,,0,0,0,0,g,0,0,,2
-Fibres alimentaires,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Huiles végétales,,,0,0,0,0,g,0,0,,2
-Fibres alimentaires,Enfants 1 à 8 ans,298,des,Poissons et fruits de mer,,,,,0,0,0,0,g,0,0,,1
-Fibres alimentaires,Enfants 1 à 8 ans,257,des,Poissons et fruits de mer,des,Poissons,,,0,0,0,0,g,0,0,,2
-Fibres alimentaires,Enfants 1 à 8 ans,50,des,Poissons et fruits de mer,des,Mollusques et crustacés,,,0,0,0,0,g,0,0,,2
-Fibres alimentaires,Enfants 1 à 8 ans,2428,des,Fruits et légumes,,,,,5.7,0.2,5.3,6,g,41.8,0.8,,1
-Fibres alimentaires,Enfants 1 à 8 ans,2117,des,Fruits et légumes,des,Fruits,,,3.4,0.1,3.2,3.6,g,25,0.7,,2
-Fibres alimentaires,Enfants 1 à 8 ans,2235,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,2.3,0.1,2.1,2.4,g,16.7,0.5,,2
-Fibres alimentaires,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pommes,1,0.1,0.9,1.1,g,7.4,0.4,,3
-Fibres alimentaires,Enfants 1 à 8 ans,830,des,Fruits et légumes,des,Fruits,des,Baies,0.6,0.1,0.5,0.8,g,4.7,0.4,E,3
-Fibres alimentaires,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Bananes,0.5,0,0.4,0.6,g,3.7,0.2,,3
-Fibres alimentaires,Enfants 1 à 8 ans,421,des,Fruits et légumes,des,Fruits,des,Agrumes,0.3,0,0.3,0.4,g,2.3,0.2,,3
-Fibres alimentaires,Enfants 1 à 8 ans,260,des,Fruits et légumes,des,Fruits,des,Autres fruits,0.3,0,0.2,0.3,g,1.9,0.3,,3
-Fibres alimentaires,Enfants 1 à 8 ans,133,des,Fruits et légumes,des,Fruits,des,Poires,0.2,0,0.1,0.3,g,1.5,0.3,,3
-Fibres alimentaires,Enfants 1 à 8 ans,572,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,0.2,0,0.1,0.2,g,1.4,0.2,,3
-Fibres alimentaires,Enfants 1 à 8 ans,118,des,Fruits et légumes,des,Fruits,des,Pêches et nectarines,0.1,0,0.1,0.2,g,0.8,0.1,,3
-Fibres alimentaires,Enfants 1 à 8 ans,219,des,Fruits et légumes,des,Fruits,des,Melons,0.1,0,0.1,0.1,g,0.6,0.1,,3
-Fibres alimentaires,Enfants 1 à 8 ans,94,des,Fruits et légumes,des,Fruits,des,Ananas,0,0,0,0,g,0.3,0.1,,3
-Fibres alimentaires,Enfants 1 à 8 ans,47,des,Fruits et légumes,des,Fruits,des,Cerises,0,0,0,0.1,g,0.2,0.1,,3
-Fibres alimentaires,Enfants 1 à 8 ans,37,des,Fruits et légumes,des,Fruits,des,Prunes et pruneaux,0,0,0,0,g,0.2,0.1,,3
-Fibres alimentaires,Enfants 1 à 8 ans,1773,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Autres légumes,0.9,0,0.8,1,g,6.6,0.3,,3
-Fibres alimentaires,Enfants 1 à 8 ans,1032,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes féculents,0.6,0,0.5,0.7,g,4.3,0.3,,3
-Fibres alimentaires,Enfants 1 à 8 ans,1068,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes vert foncé,0.5,0,0.4,0.5,g,3.5,0.2,,3
-Fibres alimentaires,Enfants 1 à 8 ans,875,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes jaune foncé ou orange,0.3,0,0.3,0.4,g,2.4,0.2,,3
-Fibres alimentaires,Enfants 1 à 8 ans,2475,des,Produits céréaliers,,,,,5.4,0.1,5.2,5.6,g,40,0.7,,1
-Fibres alimentaires,Enfants 1 à 8 ans,2114,des,Produits céréaliers,des,Pains,,,2.6,0.1,2.4,2.8,g,19,0.6,,2
-Fibres alimentaires,Enfants 1 à 8 ans,1282,des,Produits céréaliers,des,Céréales pour déjeuner,,,1.1,0.1,1,1.2,g,8.3,0.4,,2
-Fibres alimentaires,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.4,0,0.4,0.4,g,2.9,0.2,,2
-Fibres alimentaires,Enfants 1 à 8 ans,2037,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,1.3,0.1,1.2,1.4,g,9.8,0.4,,2
-Fibres alimentaires,Enfants 1 à 8 ans,813,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,1,0.1,0.9,1.1,g,7.4,0.4,,3
-Fibres alimentaires,Enfants 1 à 8 ans,951,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,0.8,0.1,0.6,0.9,g,5.6,0.4,,3
-Fibres alimentaires,Enfants 1 à 8 ans,805,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,0.6,0.1,0.5,0.7,g,4.6,0.5,E,3
-Fibres alimentaires,Enfants 1 à 8 ans,745,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.2,0,0.2,0.3,g,1.5,0.2,,3
-Fibres alimentaires,Enfants 1 à 8 ans,728,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.8,0.1,0.6,0.9,g,5.6,0.4,,3
-Fibres alimentaires,Enfants 1 à 8 ans,670,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.4,0,0.3,0.4,g,2.6,0.2,,3
-Fibres alimentaires,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.2,0,0.1,0.2,g,1.3,0.1,,3
-Fibres alimentaires,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0.1,0,,3
-Fibres alimentaires,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Enfants 1 à 8 ans,1461,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.6,0,0.5,0.7,g,4.4,0.3,,3
-Fibres alimentaires,Enfants 1 à 8 ans,834,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.6,0,0.5,0.6,g,4.1,0.3,,3
-Fibres alimentaires,Enfants 1 à 8 ans,654,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0.2,0,0.2,0.2,g,1.3,0.1,,3
-Fibres alimentaires,Enfants 1 à 8 ans,2072,de la,Viandes et volailles,,,,,0,0,0,0,g,0.1,0,,1
-Fibres alimentaires,Enfants 1 à 8 ans,1003,de la,Viandes et volailles,de la,Volaille,,,0,0,0,0,g,0,0,,2
-Fibres alimentaires,Enfants 1 à 8 ans,942,de la,Viandes et volailles,des,Viandes transformées,,,0,0,0,0,g,0.1,0,,2
-Fibres alimentaires,Enfants 1 à 8 ans,999,de la,Viandes et volailles,de la,Viande rouge,,,0,0,0,0,g,0,0,,2
-Fibres alimentaires,Enfants 1 à 8 ans,933,de la,Viandes et volailles,de la,Volaille,du,Poulet,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Enfants 1 à 8 ans,86,de la,Viandes et volailles,de la,Volaille,de la,Dinde et autres volailles,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Enfants 1 à 8 ans,375,de la,Viandes et volailles,des,Viandes transformées,des,Saucisses,0,0,0,0,g,0.1,0,,3
-Fibres alimentaires,Enfants 1 à 8 ans,135,de la,Viandes et volailles,des,Viandes transformées,du,Bacon,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Enfants 1 à 8 ans,106,de la,Viandes et volailles,des,Viandes transformées,du,Porc salé,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Enfants 1 à 8 ans,513,de la,Viandes et volailles,des,Viandes transformées,des,Viandes froides,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Enfants 1 à 8 ans,779,de la,Viandes et volailles,de la,Viande rouge,du,Bœuf,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Enfants 1 à 8 ans,43,de la,Viandes et volailles,de la,Viande rouge,de l',Agneau - veau et gibiers,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Enfants 1 à 8 ans,284,de la,Viandes et volailles,de la,Viande rouge,du,Porc frais,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Enfants 1 à 8 ans,,de la,Viandes et volailles,de la,Viande rouge,des,Abats - foies et pâtés,X,X,,,g,X,X,<10,3
-Fibres alimentaires,Enfants 1 à 8 ans,1789,des,Substituts de viande,,,,,0.7,0.1,0.6,0.8,g,5.1,0.5,,1
-Fibres alimentaires,Enfants 1 à 8 ans,1450,des,Substituts de viande,des,Œufs,,,0,0,0,0,g,0,0,,2
-Fibres alimentaires,Enfants 1 à 8 ans,210,des,Substituts de viande,des,Légumineuses,,,0.3,0,0.2,0.4,g,2.2,0.3,,2
-Fibres alimentaires,Enfants 1 à 8 ans,749,des,Substituts de viande,des,Noix - graines et beurre d'arachides,,,0.3,0,0.3,0.4,g,2.6,0.3,,2
-Fibres alimentaires,Enfants 1 à 8 ans,58,des,Substituts de viande,du,Tofu et produits sans viande,,,0,0,0,0.1,g,0.4,0.1,,2
-Fibres alimentaires,Enfants 1 à 8 ans,45,des,Boissons et barres nutritionnelles,,,,,0,0,0,0.1,g,0.2,0.1,,1
-Fibres alimentaires,Enfants 1 à 8 ans,40,des,Boissons et barres nutritionnelles,des,Substituts de repas et boissons nutritionnelles,,,0,0,0,0,g,0.2,0.1,,2
-Fibres alimentaires,Enfants 1 à 8 ans,,des,Boissons et barres nutritionnelles,des,Barres nutritionnelles,,,X,X,,,g,X,X,<10,2
-Fibres alimentaires,Enfants 1 à 8 ans,2295,des,Soupes - sauces - Épices et autres ingrédients,,,,,0.3,0,0.3,0.4,g,2.5,0.2,,1
-Fibres alimentaires,Enfants 1 à 8 ans,761,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.1,0,0.1,0.1,g,0.6,0.1,,2
-Fibres alimentaires,Enfants 1 à 8 ans,532,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0.1,0,0.1,0.2,g,0.9,0.1,,2
-Fibres alimentaires,Enfants 1 à 8 ans,2205,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.1,0,0.1,0.2,g,1.1,0.1,,2
-Fibres alimentaires,Enfants 1 à 8 ans,2106,des,Confiseries - sucres et grignotines salées,,,,,0.7,0,0.7,0.8,g,5.4,0.3,,1
-Fibres alimentaires,Enfants 1 à 8 ans,1048,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,0.2,0,0.2,0.2,g,1.4,0.1,,2
-Fibres alimentaires,Enfants 1 à 8 ans,497,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,0.1,0,0.1,0.1,g,0.7,0.1,,2
-Fibres alimentaires,Enfants 1 à 8 ans,615,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0.3,0,0.3,0.4,g,2.5,0.2,,2
-Fibres alimentaires,Enfants 1 à 8 ans,1642,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.1,0,0.1,0.1,g,0.8,0.1,,2
-Fibres alimentaires,Enfants 1 à 8 ans,548,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0.1,0,0.1,0.2,g,1,0.1,,3
-Fibres alimentaires,Enfants 1 à 8 ans,557,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0.1,0,0,0.1,g,0.4,0.1,,3
-Fibres alimentaires,Enfants 1 à 8 ans,131,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Enfants 1 à 8 ans,346,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.1,0,0.1,0.1,g,0.6,0.1,,3
-Fibres alimentaires,Enfants 1 à 8 ans,184,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0.1,0,,3
-Fibres alimentaires,Enfants 1 à 8 ans,720,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.1,0,0.1,0.1,g,0.7,0.1,,3
-Fibres alimentaires,Enfants 1 à 8 ans,257,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0.1,0,,3
-Fibres alimentaires,Enfants 1 à 8 ans,1341,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,g,X,X,<10,3
+Fibres alimentaires,Enfants 1 à 8 ans,122,des,Aliments pour bébés,,,,,0.1,0,0,0.1,g,0.6,0.2,,1
+Fibres alimentaires,Enfants 1 à 8 ans,95,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0.1,0,0,0.1,g,0.6,0.2,,2
+Fibres alimentaires,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0,0,0,0,g,0,0,,2
+Fibres alimentaires,Enfants 1 à 8 ans,2443,des,Boissons (excluant laits),,,,,0.4,0,0.3,0.4,g,2.7,0.1,,1
+Fibres alimentaires,Enfants 1 à 8 ans,20,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0,g,0,0,,2
+Fibres alimentaires,Enfants 1 à 8 ans,141,des,Boissons (excluant laits),du,Café et thé,,,0,0,0,0,g,0,0,,2
+Fibres alimentaires,Enfants 1 à 8 ans,,des,Boissons (excluant laits),des,Boissons Énergisantes,,,X,X,,,g,X,X,<10,2
+Fibres alimentaires,Enfants 1 à 8 ans,357,des,Boissons (excluant laits),des,Boissons aux fruits,,,0,0,0,0,g,0.2,0,,2
+Fibres alimentaires,Enfants 1 à 8 ans,1159,des,Boissons (excluant laits),des,Jus de fruit,,,0.3,0,0.3,0.3,g,2.1,0.1,,2
+Fibres alimentaires,Enfants 1 à 8 ans,77,des,Boissons (excluant laits),des,Autres boissons,,,0,0,0,0.1,g,0.3,0.1,,2
+Fibres alimentaires,Enfants 1 à 8 ans,142,des,Boissons (excluant laits),des,Boissons gazeuses,,,0,0,0,0,g,0,0,,2
+Fibres alimentaires,Enfants 1 à 8 ans,21,des,Boissons (excluant laits),des,Boissons pour sportifs,,,0,0,0,0,g,0,0,,2
+Fibres alimentaires,Enfants 1 à 8 ans,52,des,Boissons (excluant laits),des,Jus de tomates et de légumes,,,0,0,0,0,g,0.1,0,,2
+Fibres alimentaires,Enfants 1 à 8 ans,,des,Boissons (excluant laits),de l',Eau vitaminée,,,X,X,,,g,X,X,<10,2
+Fibres alimentaires,Enfants 1 à 8 ans,2344,des,Boissons (excluant laits),de l',Eau,,,0,0,0,0,g,0,0,,2
+Fibres alimentaires,Enfants 1 à 8 ans,133,des,Boissons (excluant laits),du,Café et thé,du,Thé,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Enfants 1 à 8 ans,,des,Boissons (excluant laits),du,Café et thé,du,Café,X,X,,,g,X,X,<10,3
+Fibres alimentaires,Enfants 1 à 8 ans,2436,des,Produits laitiers et Boissons à base de plantes,,,,,0.2,0,0.2,0.2,g,1.5,0.1,,1
+Fibres alimentaires,Enfants 1 à 8 ans,1632,des,Produits laitiers et Boissons à base de plantes,des,Fromages,,,0,0,0,0,g,0,0,,2
+Fibres alimentaires,Enfants 1 à 8 ans,2341,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,0.2,0,0.1,0.2,g,1.1,0.1,,2
+Fibres alimentaires,Enfants 1 à 8 ans,1032,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,,,0,0,0,0.1,g,0.3,0.1,,2
+Fibres alimentaires,Enfants 1 à 8 ans,1810,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,0.1,0,0,0.1,g,0.5,0.1,,3
+Fibres alimentaires,Enfants 1 à 8 ans,854,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,0,0,0,0.1,g,0.3,0.1,,3
+Fibres alimentaires,Enfants 1 à 8 ans,128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0,0,0,0,g,0.2,0,,3
+Fibres alimentaires,Enfants 1 à 8 ans,1078,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,0,0,0,0,g,0.1,0,,3
+Fibres alimentaires,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Enfants 1 à 8 ans,739,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Enfants 1 à 8 ans,2270,des,Graisses et huiles,,,,,0,0,0,0,g,0,0,,1
+Fibres alimentaires,Enfants 1 à 8 ans,83,des,Graisses et huiles,des,Graisses animales,,,0,0,0,0,g,0,0,,2
+Fibres alimentaires,Enfants 1 à 8 ans,657,des,Graisses et huiles,du,Beurre,,,0,0,0,0,g,0,0,,2
+Fibres alimentaires,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Margarines,,,0,0,0,0,g,0,0,,2
+Fibres alimentaires,Enfants 1 à 8 ans,463,des,Graisses et huiles,des,Sauces pour salade,,,0,0,0,0,g,0,0,,2
+Fibres alimentaires,Enfants 1 à 8 ans,1035,des,Graisses et huiles,du,Shortening,,,0,0,0,0,g,0,0,,2
+Fibres alimentaires,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Huiles végétales,,,0,0,0,0,g,0,0,,2
+Fibres alimentaires,Enfants 1 à 8 ans,298,des,Poissons et fruits de mer,,,,,0,0,0,0,g,0,0,,1
+Fibres alimentaires,Enfants 1 à 8 ans,257,des,Poissons et fruits de mer,des,Poissons,,,0,0,0,0,g,0,0,,2
+Fibres alimentaires,Enfants 1 à 8 ans,50,des,Poissons et fruits de mer,des,Mollusques et crustacés,,,0,0,0,0,g,0,0,,2
+Fibres alimentaires,Enfants 1 à 8 ans,2428,des,Fruits et légumes,,,,,5.7,0.2,5.3,6,g,41.8,0.8,,1
+Fibres alimentaires,Enfants 1 à 8 ans,2117,des,Fruits et légumes,des,Fruits,,,3.4,0.1,3.2,3.6,g,25,0.7,,2
+Fibres alimentaires,Enfants 1 à 8 ans,2235,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,2.3,0.1,2.1,2.4,g,16.7,0.5,,2
+Fibres alimentaires,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pommes,1,0.1,0.9,1.1,g,7.4,0.4,,3
+Fibres alimentaires,Enfants 1 à 8 ans,830,des,Fruits et légumes,des,Fruits,des,Baies,0.6,0.1,0.5,0.8,g,4.7,0.4,E,3
+Fibres alimentaires,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Bananes,0.5,0,0.4,0.6,g,3.7,0.2,,3
+Fibres alimentaires,Enfants 1 à 8 ans,421,des,Fruits et légumes,des,Fruits,des,Agrumes,0.3,0,0.3,0.4,g,2.3,0.2,,3
+Fibres alimentaires,Enfants 1 à 8 ans,260,des,Fruits et légumes,des,Fruits,des,Autres fruits,0.3,0,0.2,0.3,g,1.9,0.3,,3
+Fibres alimentaires,Enfants 1 à 8 ans,133,des,Fruits et légumes,des,Fruits,des,Poires,0.2,0,0.1,0.3,g,1.5,0.3,,3
+Fibres alimentaires,Enfants 1 à 8 ans,572,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,0.2,0,0.1,0.2,g,1.4,0.2,,3
+Fibres alimentaires,Enfants 1 à 8 ans,118,des,Fruits et légumes,des,Fruits,des,Pêches et nectarines,0.1,0,0.1,0.2,g,0.8,0.1,,3
+Fibres alimentaires,Enfants 1 à 8 ans,219,des,Fruits et légumes,des,Fruits,des,Melons,0.1,0,0.1,0.1,g,0.6,0.1,,3
+Fibres alimentaires,Enfants 1 à 8 ans,94,des,Fruits et légumes,des,Fruits,des,Ananas,0,0,0,0,g,0.3,0.1,,3
+Fibres alimentaires,Enfants 1 à 8 ans,47,des,Fruits et légumes,des,Fruits,des,Cerises,0,0,0,0.1,g,0.2,0.1,,3
+Fibres alimentaires,Enfants 1 à 8 ans,37,des,Fruits et légumes,des,Fruits,des,Prunes et pruneaux,0,0,0,0,g,0.2,0.1,,3
+Fibres alimentaires,Enfants 1 à 8 ans,1773,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Autres légumes,0.9,0,0.8,1,g,6.6,0.3,,3
+Fibres alimentaires,Enfants 1 à 8 ans,1032,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes féculents,0.6,0,0.5,0.7,g,4.3,0.3,,3
+Fibres alimentaires,Enfants 1 à 8 ans,1068,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes vert foncé,0.5,0,0.4,0.5,g,3.5,0.2,,3
+Fibres alimentaires,Enfants 1 à 8 ans,875,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes jaune foncé ou orange,0.3,0,0.3,0.4,g,2.4,0.2,,3
+Fibres alimentaires,Enfants 1 à 8 ans,2475,des,Produits céréaliers,,,,,5.4,0.1,5.2,5.6,g,40,0.7,,1
+Fibres alimentaires,Enfants 1 à 8 ans,2114,des,Produits céréaliers,des,Pains,,,2.6,0.1,2.4,2.8,g,19,0.6,,2
+Fibres alimentaires,Enfants 1 à 8 ans,1282,des,Produits céréaliers,des,Céréales pour déjeuner,,,1.1,0.1,1,1.2,g,8.3,0.4,,2
+Fibres alimentaires,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.4,0,0.4,0.4,g,2.9,0.2,,2
+Fibres alimentaires,Enfants 1 à 8 ans,2037,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,1.3,0.1,1.2,1.4,g,9.8,0.4,,2
+Fibres alimentaires,Enfants 1 à 8 ans,813,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,1,0.1,0.9,1.1,g,7.4,0.4,,3
+Fibres alimentaires,Enfants 1 à 8 ans,951,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,0.8,0.1,0.6,0.9,g,5.6,0.4,,3
+Fibres alimentaires,Enfants 1 à 8 ans,805,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,0.6,0.1,0.5,0.7,g,4.6,0.5,E,3
+Fibres alimentaires,Enfants 1 à 8 ans,745,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.2,0,0.2,0.3,g,1.5,0.2,,3
+Fibres alimentaires,Enfants 1 à 8 ans,728,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.8,0.1,0.6,0.9,g,5.6,0.4,,3
+Fibres alimentaires,Enfants 1 à 8 ans,670,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.4,0,0.3,0.4,g,2.6,0.2,,3
+Fibres alimentaires,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.2,0,0.1,0.2,g,1.3,0.1,,3
+Fibres alimentaires,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0.1,0,,3
+Fibres alimentaires,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Enfants 1 à 8 ans,1461,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.6,0,0.5,0.7,g,4.4,0.3,,3
+Fibres alimentaires,Enfants 1 à 8 ans,834,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.6,0,0.5,0.6,g,4.1,0.3,,3
+Fibres alimentaires,Enfants 1 à 8 ans,654,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0.2,0,0.2,0.2,g,1.3,0.1,,3
+Fibres alimentaires,Enfants 1 à 8 ans,2072,de la,Viandes et volailles,,,,,0,0,0,0,g,0.1,0,,1
+Fibres alimentaires,Enfants 1 à 8 ans,1003,de la,Viandes et volailles,de la,Volaille,,,0,0,0,0,g,0,0,,2
+Fibres alimentaires,Enfants 1 à 8 ans,942,de la,Viandes et volailles,des,Viandes transformées,,,0,0,0,0,g,0.1,0,,2
+Fibres alimentaires,Enfants 1 à 8 ans,999,de la,Viandes et volailles,de la,Viande rouge,,,0,0,0,0,g,0,0,,2
+Fibres alimentaires,Enfants 1 à 8 ans,933,de la,Viandes et volailles,de la,Volaille,du,Poulet,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Enfants 1 à 8 ans,86,de la,Viandes et volailles,de la,Volaille,de la,Dinde et autres volailles,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Enfants 1 à 8 ans,375,de la,Viandes et volailles,des,Viandes transformées,des,Saucisses,0,0,0,0,g,0.1,0,,3
+Fibres alimentaires,Enfants 1 à 8 ans,135,de la,Viandes et volailles,des,Viandes transformées,du,Bacon,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Enfants 1 à 8 ans,106,de la,Viandes et volailles,des,Viandes transformées,du,Porc salé,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Enfants 1 à 8 ans,513,de la,Viandes et volailles,des,Viandes transformées,des,Viandes froides,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Enfants 1 à 8 ans,779,de la,Viandes et volailles,de la,Viande rouge,du,Bœuf,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Enfants 1 à 8 ans,43,de la,Viandes et volailles,de la,Viande rouge,de l',Agneau - veau et gibiers,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Enfants 1 à 8 ans,284,de la,Viandes et volailles,de la,Viande rouge,du,Porc frais,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Enfants 1 à 8 ans,,de la,Viandes et volailles,de la,Viande rouge,des,Abats - foies et pâtés,X,X,,,g,X,X,<10,3
+Fibres alimentaires,Enfants 1 à 8 ans,1789,des,Substituts de viande,,,,,0.7,0.1,0.6,0.8,g,5.1,0.5,,1
+Fibres alimentaires,Enfants 1 à 8 ans,1450,des,Substituts de viande,des,Œufs,,,0,0,0,0,g,0,0,,2
+Fibres alimentaires,Enfants 1 à 8 ans,210,des,Substituts de viande,des,Légumineuses,,,0.3,0,0.2,0.4,g,2.2,0.3,,2
+Fibres alimentaires,Enfants 1 à 8 ans,749,des,Substituts de viande,des,Noix - graines et beurre d'arachides,,,0.3,0,0.3,0.4,g,2.6,0.3,,2
+Fibres alimentaires,Enfants 1 à 8 ans,58,des,Substituts de viande,du,Tofu et produits sans viande,,,0,0,0,0.1,g,0.4,0.1,,2
+Fibres alimentaires,Enfants 1 à 8 ans,45,des,Boissons et barres nutritionnelles,,,,,0,0,0,0.1,g,0.2,0.1,,1
+Fibres alimentaires,Enfants 1 à 8 ans,40,des,Boissons et barres nutritionnelles,des,Substituts de repas et boissons nutritionnelles,,,0,0,0,0,g,0.2,0.1,,2
+Fibres alimentaires,Enfants 1 à 8 ans,,des,Boissons et barres nutritionnelles,des,Barres nutritionnelles,,,X,X,,,g,X,X,<10,2
+Fibres alimentaires,Enfants 1 à 8 ans,2295,des,Soupes - sauces - Épices et autres ingrédients,,,,,0.3,0,0.3,0.4,g,2.5,0.2,,1
+Fibres alimentaires,Enfants 1 à 8 ans,761,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.1,0,0.1,0.1,g,0.6,0.1,,2
+Fibres alimentaires,Enfants 1 à 8 ans,532,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0.1,0,0.1,0.2,g,0.9,0.1,,2
+Fibres alimentaires,Enfants 1 à 8 ans,2205,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.1,0,0.1,0.2,g,1.1,0.1,,2
+Fibres alimentaires,Enfants 1 à 8 ans,2106,des,Confiseries - sucres et grignotines salées,,,,,0.7,0,0.7,0.8,g,5.4,0.3,,1
+Fibres alimentaires,Enfants 1 à 8 ans,1048,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,0.2,0,0.2,0.2,g,1.4,0.1,,2
+Fibres alimentaires,Enfants 1 à 8 ans,497,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,0.1,0,0.1,0.1,g,0.7,0.1,,2
+Fibres alimentaires,Enfants 1 à 8 ans,615,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0.3,0,0.3,0.4,g,2.5,0.2,,2
+Fibres alimentaires,Enfants 1 à 8 ans,1642,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.1,0,0.1,0.1,g,0.8,0.1,,2
+Fibres alimentaires,Enfants 1 à 8 ans,548,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0.1,0,0.1,0.2,g,1,0.1,,3
+Fibres alimentaires,Enfants 1 à 8 ans,557,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0.1,0,0,0.1,g,0.4,0.1,,3
+Fibres alimentaires,Enfants 1 à 8 ans,131,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Enfants 1 à 8 ans,346,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.1,0,0.1,0.1,g,0.6,0.1,,3
+Fibres alimentaires,Enfants 1 à 8 ans,184,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0.1,0,,3
+Fibres alimentaires,Enfants 1 à 8 ans,720,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.1,0,0.1,0.1,g,0.7,0.1,,3
+Fibres alimentaires,Enfants 1 à 8 ans,257,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0.1,0,,3
+Fibres alimentaires,Enfants 1 à 8 ans,1341,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,g,X,X,<10,3
 Énergie,Population 1 an et +,186,des,Aliments pour bébés,,,,,1.2,0.2,0.7,1.6,kcal,0.1,0,E,1
 Énergie,Population 1 an et +,154,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0.8,0.2,0.4,1.1,kcal,0,0,E,2
 Énergie,Population 1 an et +,51,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0.4,0.1,0.2,0.7,kcal,0,0,E,2
@@ -1420,7 +1420,7 @@ Fibres alimentaires,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines
 Énergie,Population 1 an et +,19327,des,Produits céréaliers,,,,,512.8,4.6,503.7,521.9,kcal,27.6,0.2,,1
 Énergie,Population 1 an et +,16168,des,Produits céréaliers,des,Pains,,,233.6,3.4,226.9,240.3,kcal,12.6,0.2,,2
 Énergie,Population 1 an et +,6966,des,Produits céréaliers,des,Céréales pour déjeuner,,,50.8,1.4,48,53.6,kcal,2.7,0.1,,2
-Énergie,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,41.5,1.4,38.8,44.3,kcal,2.2,0.1,,2
+Énergie,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,41.5,1.4,38.8,44.3,kcal,2.2,0.1,,2
 Énergie,Population 1 an et +,14820,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,186.9,3.2,180.7,193.1,kcal,10,0.2,,2
 Énergie,Population 1 an et +,8159,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,93.8,2.4,89.1,98.4,kcal,5,0.1,,3
 Énergie,Population 1 an et +,6257,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,70.8,2.5,65.9,75.7,kcal,3.8,0.1,,3
@@ -1428,10 +1428,10 @@ Fibres alimentaires,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines
 Énergie,Population 1 an et +,2918,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,13.2,0.7,11.9,14.5,kcal,0.7,0,,3
 Énergie,Population 1 an et +,4760,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,38.3,1.4,35.7,41,kcal,2.1,0.1,,3
 Énergie,Population 1 an et +,2573,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),12.5,0.6,11.3,13.6,kcal,0.7,0,,3
-Énergie,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,12.6,0.7,11.2,14,kcal,0.7,0,,3
-Énergie,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,1.6,0.3,1,2.2,kcal,0.1,0,E,3
-Énergie,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,1.1,0.2,0.7,1.5,kcal,0.1,0,E,3
-Énergie,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,kcal,X,X,<10,3
+Énergie,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,12.6,0.7,11.2,14,kcal,0.7,0,,3
+Énergie,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,1.6,0.3,1,2.2,kcal,0.1,0,E,3
+Énergie,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,1.1,0.2,0.7,1.5,kcal,0.1,0,E,3
+Énergie,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,kcal,X,X,<10,3
 Énergie,Population 1 an et +,11102,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,83.2,2.1,79,87.4,kcal,4.5,0.1,,3
 Énergie,Population 1 an et +,4543,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,53.1,1.8,49.5,56.7,kcal,2.9,0.1,,3
 Énergie,Population 1 an et +,4598,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,50.6,1.8,47.1,54.2,kcal,2.7,0.1,,3
@@ -1534,7 +1534,7 @@ Fibres alimentaires,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines
 Énergie,Hommes adultes 19 ans +,6068,des,Produits céréaliers,,,,,577.3,8.6,560.4,594.1,kcal,26.7,0.4,,1
 Énergie,Hommes adultes 19 ans +,5104,des,Produits céréaliers,des,Pains,,,270.9,6.6,257.9,283.8,kcal,12.5,0.3,,2
 Énergie,Hommes adultes 19 ans +,1921,des,Produits céréaliers,des,Céréales pour déjeuner,,,54.5,2.8,49,60.1,kcal,2.5,0.1,,2
-Énergie,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,41,2.6,35.9,46,kcal,1.9,0.1,,2
+Énergie,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,41,2.6,35.9,46,kcal,1.9,0.1,,2
 Énergie,Hommes adultes 19 ans +,4551,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,210.9,5.8,199.5,222.3,kcal,9.8,0.3,,2
 Énergie,Hommes adultes 19 ans +,2752,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,119.2,4.9,109.7,128.8,kcal,5.5,0.2,,3
 Énergie,Hommes adultes 19 ans +,1885,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,78.3,4.6,69.2,87.3,kcal,3.6,0.2,,3
@@ -1542,9 +1542,9 @@ Fibres alimentaires,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines
 Énergie,Hommes adultes 19 ans +,593,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,9.9,0.9,8.2,11.7,kcal,0.5,0,,3
 Énergie,Hommes adultes 19 ans +,1481,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,45.7,2.7,40.4,50.9,kcal,2.1,0.1,,3
 Énergie,Hommes adultes 19 ans +,523,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),8.9,0.9,7.1,10.6,kcal,0.4,0,,3
-Énergie,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,13.6,1.6,10.5,16.6,kcal,0.6,0.1,,3
-Énergie,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.9,0.3,0.3,1.5,kcal,0,0,E,3
-Énergie,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,F,F,,,kcal,F,F,F,3
+Énergie,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,13.6,1.6,10.5,16.6,kcal,0.6,0.1,,3
+Énergie,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.9,0.3,0.3,1.5,kcal,0,0,E,3
+Énergie,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,F,F,,,kcal,F,F,F,3
 Énergie,Hommes adultes 19 ans +,3442,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,97.3,4,89.4,105.2,kcal,4.5,0.2,,3
 Énergie,Hommes adultes 19 ans +,1250,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,56.7,3.4,50,63.5,kcal,2.6,0.2,,3
 Énergie,Hommes adultes 19 ans +,1449,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,56.9,3.4,50.2,63.6,kcal,2.6,0.2,,3
@@ -1647,7 +1647,7 @@ Fibres alimentaires,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines
 Énergie,Femmes adultes* 19 ans +,6669,des,Produits céréaliers,,,,,424.7,6.7,411.6,437.8,kcal,26.8,0.3,,1
 Énergie,Femmes adultes* 19 ans +,5520,des,Produits céréaliers,des,Pains,,,197.3,4.2,189.1,205.4,kcal,12.5,0.2,,2
 Énergie,Femmes adultes* 19 ans +,2230,des,Produits céréaliers,des,Céréales pour déjeuner,,,41.2,1.8,37.6,44.7,kcal,2.6,0.1,,2
-Énergie,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,31.6,2,27.7,35.5,kcal,2,0.1,,2
+Énergie,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,31.6,2,27.7,35.5,kcal,2,0.1,,2
 Énergie,Femmes adultes* 19 ans +,4893,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,154.6,4.7,145.3,163.9,kcal,9.8,0.3,,2
 Énergie,Femmes adultes* 19 ans +,2551,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,73.1,2.8,67.5,78.6,kcal,4.6,0.2,,3
 Énergie,Femmes adultes* 19 ans +,1994,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,59,3.1,52.8,65.1,kcal,3.7,0.2,,3
@@ -1655,10 +1655,10 @@ Fibres alimentaires,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines
 Énergie,Femmes adultes* 19 ans +,914,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,10.2,1,8.2,12.3,kcal,0.6,0.1,,3
 Énergie,Femmes adultes* 19 ans +,1756,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,34.2,1.7,30.7,37.6,kcal,2.2,0.1,,3
 Énergie,Femmes adultes* 19 ans +,555,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),7,0.6,5.8,8.3,kcal,0.4,0,,3
-Énergie,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,7.2,0.8,5.7,8.8,kcal,0.5,0,,3
-Énergie,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.9,0.2,0.4,1.3,kcal,0.1,0,E,3
-Énergie,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.9,0.3,0.3,1.6,kcal,0.1,0,E,3
-Énergie,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,kcal,X,X,<10,3
+Énergie,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,7.2,0.8,5.7,8.8,kcal,0.5,0,,3
+Énergie,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.9,0.2,0.4,1.3,kcal,0.1,0,E,3
+Énergie,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.9,0.3,0.3,1.6,kcal,0.1,0,E,3
+Énergie,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,kcal,X,X,<10,3
 Énergie,Femmes adultes* 19 ans +,3664,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,66.7,3.3,60.2,73.3,kcal,4.2,0.2,,3
 Énergie,Femmes adultes* 19 ans +,1358,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,43.6,2.5,38.7,48.5,kcal,2.8,0.2,,3
 Énergie,Femmes adultes* 19 ans +,1522,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,44.3,2.4,39.6,49.1,kcal,2.8,0.2,,3
@@ -1702,119 +1702,119 @@ Fibres alimentaires,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines
 Énergie,Femmes adultes* 19 ans +,1529,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,15.7,1.2,13.4,18.1,kcal,1,0.1,,3
 Énergie,Femmes adultes* 19 ans +,773,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,4.3,0.4,3.6,5.1,kcal,0.3,0,,3
 Énergie,Femmes adultes* 19 ans +,360,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0.2,0,0.2,0.3,kcal,0,0,,3
-Énergie,Enfants 1 à 8 ans,122,des,Aliments pour bébés,,,,,8.5,1.8,5,12.1,kcal,0.6,0.1,E,1
-Énergie,Enfants 1 à 8 ans,95,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,3.8,0.8,2.2,5.4,kcal,0.2,0.1,E,2
-Énergie,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparations pour nourrissons,,,4.7,1.3,2.2,7.3,kcal,0.3,0.1,E,2
-Énergie,Enfants 1 à 8 ans,2443,des,Boissons (excluant laits),,,,,87.3,3.4,80.6,94,kcal,5.7,0.2,,1
-Énergie,Enfants 1 à 8 ans,20,des,Boissons (excluant laits),de l',Alcool,,,F,F,,,kcal,F,F,F,2
-Énergie,Enfants 1 à 8 ans,141,des,Boissons (excluant laits),du,Café et thé,,,2.3,0.6,1.1,3.4,kcal,0.1,0,E,2
-Énergie,Enfants 1 à 8 ans,,des,Boissons (excluant laits),des,Boissons Énergisantes,,,X,X,,,kcal,X,X,<10,2
-Énergie,Enfants 1 à 8 ans,357,des,Boissons (excluant laits),des,Boissons aux fruits,,,17.2,1.8,13.7,20.6,kcal,1.1,0.1,,2
-Énergie,Enfants 1 à 8 ans,1159,des,Boissons (excluant laits),des,Jus de fruit,,,56.7,2.6,51.7,61.8,kcal,3.7,0.2,,2
-Énergie,Enfants 1 à 8 ans,77,des,Boissons (excluant laits),des,Autres boissons,,,3.9,0.8,2.3,5.6,kcal,0.3,0.1,E,2
-Énergie,Enfants 1 à 8 ans,142,des,Boissons (excluant laits),des,Boissons gazeuses,,,5.7,0.8,4,7.3,kcal,0.4,0.1,,2
-Énergie,Enfants 1 à 8 ans,21,des,Boissons (excluant laits),des,Boissons pour sportifs,,,0.3,0.1,0.1,0.6,kcal,0,0,E,2
-Énergie,Enfants 1 à 8 ans,52,des,Boissons (excluant laits),des,Jus de tomates et de légumes,,,0.6,0.2,0.3,1,kcal,0,0,E,2
-Énergie,Enfants 1 à 8 ans,,des,Boissons (excluant laits),de l',Eau vitaminée,,,X,X,,,kcal,X,X,<10,2
-Énergie,Enfants 1 à 8 ans,2344,des,Boissons (excluant laits),de l',Eau,,,0,0,0,0.1,kcal,0,0,,2
-Énergie,Enfants 1 à 8 ans,133,des,Boissons (excluant laits),du,Café et thé,du,Thé,2.2,0.6,1.1,3.4,kcal,0.1,0,E,3
-Énergie,Enfants 1 à 8 ans,,des,Boissons (excluant laits),du,Café et thé,du,Café,X,X,,,kcal,X,X,<10,3
-Énergie,Enfants 1 à 8 ans,2436,des,Produits laitiers et Boissons à base de plantes,,,,,308.2,7.1,294.2,322.2,kcal,20.1,0.4,,1
-Énergie,Enfants 1 à 8 ans,1632,des,Produits laitiers et Boissons à base de plantes,des,Fromages,,,80.3,4,72.5,88.2,kcal,5.2,0.2,,2
-Énergie,Enfants 1 à 8 ans,2341,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,188.1,5.3,177.7,198.5,kcal,12.3,0.3,,2
-Énergie,Enfants 1 à 8 ans,1032,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,,,39.7,2,35.7,43.7,kcal,2.6,0.1,,2
-Énergie,Enfants 1 à 8 ans,1810,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,84.4,3.7,77.1,91.6,kcal,5.5,0.2,,3
-Énergie,Enfants 1 à 8 ans,1078,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,65.2,4.1,57.2,73.2,kcal,4.3,0.3,,3
-Énergie,Enfants 1 à 8 ans,854,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,26.8,2.9,21,32.5,kcal,1.7,0.2,,3
-Énergie,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,5.1,1,3.1,7.1,kcal,0.3,0.1,E,3
-Énergie,Enfants 1 à 8 ans,128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,3.4,0.6,2.3,4.6,kcal,0.2,0,E,3
-Énergie,Enfants 1 à 8 ans,739,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,3.2,0.5,2.2,4.2,kcal,0.2,0,,3
-Énergie,Enfants 1 à 8 ans,2270,des,Graisses et huiles,,,,,102.9,3.3,96.5,109.3,kcal,6.7,0.2,,1
-Énergie,Enfants 1 à 8 ans,83,des,Graisses et huiles,des,Graisses animales,,,1.6,0.4,0.8,2.5,kcal,0.1,0,E,2
-Énergie,Enfants 1 à 8 ans,657,des,Graisses et huiles,du,Beurre,,,13.3,1.2,10.9,15.6,kcal,0.9,0.1,,2
-Énergie,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Margarines,,,25.7,1.4,23,28.4,kcal,1.7,0.1,,2
-Énergie,Enfants 1 à 8 ans,463,des,Graisses et huiles,des,Sauces pour salade,,,9.9,0.9,8.3,11.6,kcal,0.6,0.1,,2
-Énergie,Enfants 1 à 8 ans,1035,des,Graisses et huiles,du,Shortening,,,24.9,1.7,21.6,28.2,kcal,1.6,0.1,,2
-Énergie,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Huiles végétales,,,27.5,1.7,24.2,30.8,kcal,1.8,0.1,,2
-Énergie,Enfants 1 à 8 ans,298,des,Poissons et fruits de mer,,,,,11.4,1.9,7.7,15,kcal,0.7,0.1,E,1
-Énergie,Enfants 1 à 8 ans,257,des,Poissons et fruits de mer,des,Poissons,,,10.5,1.8,6.9,14,kcal,0.7,0.1,E,2
-Énergie,Enfants 1 à 8 ans,50,des,Poissons et fruits de mer,des,Mollusques et crustacés,,,0.9,0.2,0.4,1.4,kcal,0.1,0,E,2
-Énergie,Enfants 1 à 8 ans,2428,des,Fruits et légumes,,,,,170.6,4.7,161.3,179.9,kcal,11.1,0.3,,1
-Énergie,Enfants 1 à 8 ans,2117,des,Fruits et légumes,des,Fruits,,,108,3.6,100.8,115.1,kcal,7.1,0.2,,2
-Énergie,Enfants 1 à 8 ans,2235,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,62.6,2.5,57.6,67.6,kcal,4.1,0.2,,2
-Énergie,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pommes,29.8,1.9,26,33.6,kcal,1.9,0.1,,3
-Énergie,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Bananes,25.9,1.5,22.9,28.8,kcal,1.7,0.1,,3
-Énergie,Enfants 1 à 8 ans,572,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,11.8,1.8,8.3,15.2,kcal,0.8,0.1,,3
-Énergie,Enfants 1 à 8 ans,830,des,Fruits et légumes,des,Fruits,des,Baies,10.4,0.9,8.6,12.3,kcal,0.7,0.1,,3
-Énergie,Enfants 1 à 8 ans,421,des,Fruits et légumes,des,Fruits,des,Agrumes,8.3,0.7,6.9,9.7,kcal,0.5,0,,3
-Énergie,Enfants 1 à 8 ans,260,des,Fruits et légumes,des,Fruits,des,Autres fruits,7.1,1,5.2,9.1,kcal,0.5,0.1,,3
-Énergie,Enfants 1 à 8 ans,219,des,Fruits et légumes,des,Fruits,des,Melons,5,0.7,3.7,6.3,kcal,0.3,0,,3
-Énergie,Enfants 1 à 8 ans,133,des,Fruits et légumes,des,Fruits,des,Poires,3.9,0.7,2.5,5.2,kcal,0.3,0,E,3
-Énergie,Enfants 1 à 8 ans,118,des,Fruits et légumes,des,Fruits,des,Pêches et nectarines,2.6,0.5,1.7,3.5,kcal,0.2,0,E,3
-Énergie,Enfants 1 à 8 ans,47,des,Fruits et légumes,des,Fruits,des,Cerises,1.1,0.3,0.4,1.8,kcal,0.1,0,E,3
-Énergie,Enfants 1 à 8 ans,94,des,Fruits et légumes,des,Fruits,des,Ananas,1.4,0.3,0.8,1.9,kcal,0.1,0,E,3
-Énergie,Enfants 1 à 8 ans,37,des,Fruits et légumes,des,Fruits,des,Prunes et pruneaux,F,F,,,kcal,F,F,F,3
-Énergie,Enfants 1 à 8 ans,1032,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes féculents,32.8,2.1,28.6,37,kcal,2.1,0.1,,3
-Énergie,Enfants 1 à 8 ans,1773,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Autres légumes,18.2,0.9,16.4,20,kcal,1.2,0.1,,3
-Énergie,Enfants 1 à 8 ans,1068,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes vert foncé,6.5,0.5,5.6,7.5,kcal,0.4,0,,3
-Énergie,Enfants 1 à 8 ans,875,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes jaune foncé ou orange,5.1,0.5,4.1,6.1,kcal,0.3,0,,3
-Énergie,Enfants 1 à 8 ans,2475,des,Produits céréaliers,,,,,468.6,9.1,450.7,486.4,kcal,30.6,0.5,,1
-Énergie,Enfants 1 à 8 ans,2114,des,Produits céréaliers,des,Pains,,,191.5,6.5,178.7,204.3,kcal,12.5,0.4,,2
-Énergie,Enfants 1 à 8 ans,1282,des,Produits céréaliers,des,Céréales pour déjeuner,,,55,2.2,50.6,59.4,kcal,3.6,0.1,,2
-Énergie,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,56.6,3.1,50.5,62.8,kcal,3.7,0.2,,2
-Énergie,Enfants 1 à 8 ans,2037,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,165.5,6,153.6,177.3,kcal,10.8,0.4,,2
-Énergie,Enfants 1 à 8 ans,951,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,67.6,4.8,58.1,77.1,kcal,4.4,0.3,,3
-Énergie,Enfants 1 à 8 ans,805,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,51.7,4,43.8,59.6,kcal,3.4,0.3,,3
-Énergie,Enfants 1 à 8 ans,813,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,41.2,2.5,36.3,46,kcal,2.7,0.2,,3
-Énergie,Enfants 1 à 8 ans,745,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,31,2.8,25.5,36.6,kcal,2,0.2,,3
-Énergie,Enfants 1 à 8 ans,728,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,28.4,2,24.5,32.2,kcal,1.9,0.1,,3
-Énergie,Enfants 1 à 8 ans,670,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),26.6,1.7,23.3,29.9,kcal,1.7,0.1,,3
-Énergie,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,14.2,1.2,11.8,16.7,kcal,0.9,0.1,,3
-Énergie,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,2.1,0.7,0.7,3.4,kcal,0.1,0,E,3
-Énergie,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,F,F,,,kcal,F,F,F,3
-Énergie,Enfants 1 à 8 ans,1461,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,64.2,4.2,56,72.5,kcal,4.2,0.3,,3
-Énergie,Enfants 1 à 8 ans,834,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,60.1,4.3,51.6,68.6,kcal,3.9,0.3,,3
-Énergie,Enfants 1 à 8 ans,654,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,41.1,2.9,35.4,46.9,kcal,2.7,0.2,,3
-Énergie,Enfants 1 à 8 ans,2072,de la,Viandes et volailles,,,,,132,4.9,122.4,141.5,kcal,8.6,0.3,,1
-Énergie,Enfants 1 à 8 ans,1003,de la,Viandes et volailles,de la,Volaille,,,47.6,3.3,41,54.2,kcal,3.1,0.2,,2
-Énergie,Enfants 1 à 8 ans,942,de la,Viandes et volailles,des,Viandes transformées,,,42.6,2.9,36.8,48.4,kcal,2.8,0.2,,2
-Énergie,Enfants 1 à 8 ans,999,de la,Viandes et volailles,de la,Viande rouge,,,41.8,2.6,36.7,46.8,kcal,2.7,0.2,,2
-Énergie,Enfants 1 à 8 ans,933,de la,Viandes et volailles,de la,Volaille,du,Poulet,45.5,3.3,39,52.1,kcal,3,0.2,,3
-Énergie,Enfants 1 à 8 ans,86,de la,Viandes et volailles,de la,Volaille,de la,Dinde et autres volailles,F,F,,,kcal,F,F,F,3
-Énergie,Enfants 1 à 8 ans,375,de la,Viandes et volailles,des,Viandes transformées,des,Saucisses,22.5,2.5,17.6,27.5,kcal,1.5,0.2,,3
-Énergie,Enfants 1 à 8 ans,513,de la,Viandes et volailles,des,Viandes transformées,des,Viandes froides,14.6,1.4,11.9,17.3,kcal,1,0.1,,3
-Énergie,Enfants 1 à 8 ans,135,de la,Viandes et volailles,des,Viandes transformées,du,Bacon,2.6,0.5,1.6,3.6,kcal,0.2,0,E,3
-Énergie,Enfants 1 à 8 ans,106,de la,Viandes et volailles,des,Viandes transformées,du,Porc salé,2.9,0.6,1.6,4.1,kcal,0.2,0,E,3
-Énergie,Enfants 1 à 8 ans,779,de la,Viandes et volailles,de la,Viande rouge,du,Bœuf,28.6,2.2,24.3,32.8,kcal,1.9,0.1,,3
-Énergie,Enfants 1 à 8 ans,284,de la,Viandes et volailles,de la,Viande rouge,du,Porc frais,10.7,1.5,7.6,13.7,kcal,0.7,0.1,,3
-Énergie,Enfants 1 à 8 ans,43,de la,Viandes et volailles,de la,Viande rouge,de l',Agneau - veau et gibiers,F,F,,,kcal,F,F,F,3
-Énergie,Enfants 1 à 8 ans,,de la,Viandes et volailles,de la,Viande rouge,des,Abats - foies et pâtés,X,X,,,kcal,X,X,<10,3
-Énergie,Enfants 1 à 8 ans,1789,des,Substituts de viande,,,,,61.9,3.9,54.2,69.7,kcal,4,0.2,,1
-Énergie,Enfants 1 à 8 ans,1450,des,Substituts de viande,des,Œufs,,,21.1,1.2,18.8,23.4,kcal,1.4,0.1,,2
-Énergie,Enfants 1 à 8 ans,210,des,Substituts de viande,des,Légumineuses,,,7.6,1.3,5.1,10.1,kcal,0.5,0.1,E,2
-Énergie,Enfants 1 à 8 ans,749,des,Substituts de viande,des,Noix - graines et beurre d'arachides,,,30.5,3.2,24.2,36.8,kcal,2,0.2,,2
-Énergie,Enfants 1 à 8 ans,58,des,Substituts de viande,du,Tofu et produits sans viande,,,2.8,0.8,1.1,4.5,kcal,0.2,0.1,E,2
-Énergie,Enfants 1 à 8 ans,45,des,Boissons et barres nutritionnelles,,,,,4.3,1,2.3,6.3,kcal,0.3,0.1,E,1
-Énergie,Enfants 1 à 8 ans,40,des,Boissons et barres nutritionnelles,des,Substituts de repas et boissons nutritionnelles,,,4,1,2,6,kcal,0.3,0.1,E,2
-Énergie,Enfants 1 à 8 ans,,des,Boissons et barres nutritionnelles,des,Barres nutritionnelles,,,X,X,,,kcal,X,X,<10,2
-Énergie,Enfants 1 à 8 ans,2295,des,Soupes - sauces - Épices et autres ingrédients,,,,,17.7,1.6,14.4,20.9,kcal,1.2,0.1,,1
-Énergie,Enfants 1 à 8 ans,761,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,8.5,1.2,6.1,10.8,kcal,0.6,0.1,,2
-Énergie,Enfants 1 à 8 ans,532,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,6.9,1,4.9,8.8,kcal,0.4,0.1,,2
-Énergie,Enfants 1 à 8 ans,2205,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,2.4,0.2,2,2.7,kcal,0.2,0,,2
-Énergie,Enfants 1 à 8 ans,2106,des,Confiseries - sucres et grignotines salées,,,,,157.8,6.6,144.8,170.8,kcal,10.3,0.4,,1
-Énergie,Enfants 1 à 8 ans,1048,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,40.6,2.6,35.5,45.7,kcal,2.7,0.2,,2
-Énergie,Enfants 1 à 8 ans,497,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,37.3,3.4,30.5,44,kcal,2.4,0.2,,2
-Énergie,Enfants 1 à 8 ans,615,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,32.3,2.9,26.5,38,kcal,2.1,0.2,,2
-Énergie,Enfants 1 à 8 ans,1642,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,47.7,3.2,41.4,53.9,kcal,3.1,0.2,,2
-Énergie,Enfants 1 à 8 ans,557,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,17.7,1.7,14.5,21,kcal,1.2,0.1,,3
-Énergie,Enfants 1 à 8 ans,548,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,17.6,1.6,14.4,20.8,kcal,1.1,0.1,,3
-Énergie,Enfants 1 à 8 ans,131,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,5.3,0.9,3.5,7,kcal,0.3,0.1,E,3
-Énergie,Enfants 1 à 8 ans,346,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,26.9,2.8,21.4,32.4,kcal,1.8,0.2,,3
-Énergie,Enfants 1 à 8 ans,184,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,10.4,1.7,7.1,13.7,kcal,0.7,0.1,,3
-Énergie,Enfants 1 à 8 ans,720,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,26.1,2.4,21.4,30.8,kcal,1.7,0.2,,3
-Énergie,Enfants 1 à 8 ans,1341,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,17.4,1.3,14.7,20,kcal,1.1,0.1,,3
-Énergie,Enfants 1 à 8 ans,257,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,4.2,0.6,2.9,5.4,kcal,0.3,0,,3
-Énergie,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,kcal,X,X,<10,3
+Énergie,Enfants 1 à 8 ans,122,des,Aliments pour bébés,,,,,8.5,1.8,5,12.1,kcal,0.6,0.1,E,1
+Énergie,Enfants 1 à 8 ans,95,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,3.8,0.8,2.2,5.4,kcal,0.2,0.1,E,2
+Énergie,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparations pour nourrissons,,,4.7,1.3,2.2,7.3,kcal,0.3,0.1,E,2
+Énergie,Enfants 1 à 8 ans,2443,des,Boissons (excluant laits),,,,,87.3,3.4,80.6,94,kcal,5.7,0.2,,1
+Énergie,Enfants 1 à 8 ans,20,des,Boissons (excluant laits),de l',Alcool,,,F,F,,,kcal,F,F,F,2
+Énergie,Enfants 1 à 8 ans,141,des,Boissons (excluant laits),du,Café et thé,,,2.3,0.6,1.1,3.4,kcal,0.1,0,E,2
+Énergie,Enfants 1 à 8 ans,,des,Boissons (excluant laits),des,Boissons Énergisantes,,,X,X,,,kcal,X,X,<10,2
+Énergie,Enfants 1 à 8 ans,357,des,Boissons (excluant laits),des,Boissons aux fruits,,,17.2,1.8,13.7,20.6,kcal,1.1,0.1,,2
+Énergie,Enfants 1 à 8 ans,1159,des,Boissons (excluant laits),des,Jus de fruit,,,56.7,2.6,51.7,61.8,kcal,3.7,0.2,,2
+Énergie,Enfants 1 à 8 ans,77,des,Boissons (excluant laits),des,Autres boissons,,,3.9,0.8,2.3,5.6,kcal,0.3,0.1,E,2
+Énergie,Enfants 1 à 8 ans,142,des,Boissons (excluant laits),des,Boissons gazeuses,,,5.7,0.8,4,7.3,kcal,0.4,0.1,,2
+Énergie,Enfants 1 à 8 ans,21,des,Boissons (excluant laits),des,Boissons pour sportifs,,,0.3,0.1,0.1,0.6,kcal,0,0,E,2
+Énergie,Enfants 1 à 8 ans,52,des,Boissons (excluant laits),des,Jus de tomates et de légumes,,,0.6,0.2,0.3,1,kcal,0,0,E,2
+Énergie,Enfants 1 à 8 ans,,des,Boissons (excluant laits),de l',Eau vitaminée,,,X,X,,,kcal,X,X,<10,2
+Énergie,Enfants 1 à 8 ans,2344,des,Boissons (excluant laits),de l',Eau,,,0,0,0,0.1,kcal,0,0,,2
+Énergie,Enfants 1 à 8 ans,133,des,Boissons (excluant laits),du,Café et thé,du,Thé,2.2,0.6,1.1,3.4,kcal,0.1,0,E,3
+Énergie,Enfants 1 à 8 ans,,des,Boissons (excluant laits),du,Café et thé,du,Café,X,X,,,kcal,X,X,<10,3
+Énergie,Enfants 1 à 8 ans,2436,des,Produits laitiers et Boissons à base de plantes,,,,,308.2,7.1,294.2,322.2,kcal,20.1,0.4,,1
+Énergie,Enfants 1 à 8 ans,1632,des,Produits laitiers et Boissons à base de plantes,des,Fromages,,,80.3,4,72.5,88.2,kcal,5.2,0.2,,2
+Énergie,Enfants 1 à 8 ans,2341,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,188.1,5.3,177.7,198.5,kcal,12.3,0.3,,2
+Énergie,Enfants 1 à 8 ans,1032,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,,,39.7,2,35.7,43.7,kcal,2.6,0.1,,2
+Énergie,Enfants 1 à 8 ans,1810,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,84.4,3.7,77.1,91.6,kcal,5.5,0.2,,3
+Énergie,Enfants 1 à 8 ans,1078,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,65.2,4.1,57.2,73.2,kcal,4.3,0.3,,3
+Énergie,Enfants 1 à 8 ans,854,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,26.8,2.9,21,32.5,kcal,1.7,0.2,,3
+Énergie,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,5.1,1,3.1,7.1,kcal,0.3,0.1,E,3
+Énergie,Enfants 1 à 8 ans,128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,3.4,0.6,2.3,4.6,kcal,0.2,0,E,3
+Énergie,Enfants 1 à 8 ans,739,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,3.2,0.5,2.2,4.2,kcal,0.2,0,,3
+Énergie,Enfants 1 à 8 ans,2270,des,Graisses et huiles,,,,,102.9,3.3,96.5,109.3,kcal,6.7,0.2,,1
+Énergie,Enfants 1 à 8 ans,83,des,Graisses et huiles,des,Graisses animales,,,1.6,0.4,0.8,2.5,kcal,0.1,0,E,2
+Énergie,Enfants 1 à 8 ans,657,des,Graisses et huiles,du,Beurre,,,13.3,1.2,10.9,15.6,kcal,0.9,0.1,,2
+Énergie,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Margarines,,,25.7,1.4,23,28.4,kcal,1.7,0.1,,2
+Énergie,Enfants 1 à 8 ans,463,des,Graisses et huiles,des,Sauces pour salade,,,9.9,0.9,8.3,11.6,kcal,0.6,0.1,,2
+Énergie,Enfants 1 à 8 ans,1035,des,Graisses et huiles,du,Shortening,,,24.9,1.7,21.6,28.2,kcal,1.6,0.1,,2
+Énergie,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Huiles végétales,,,27.5,1.7,24.2,30.8,kcal,1.8,0.1,,2
+Énergie,Enfants 1 à 8 ans,298,des,Poissons et fruits de mer,,,,,11.4,1.9,7.7,15,kcal,0.7,0.1,E,1
+Énergie,Enfants 1 à 8 ans,257,des,Poissons et fruits de mer,des,Poissons,,,10.5,1.8,6.9,14,kcal,0.7,0.1,E,2
+Énergie,Enfants 1 à 8 ans,50,des,Poissons et fruits de mer,des,Mollusques et crustacés,,,0.9,0.2,0.4,1.4,kcal,0.1,0,E,2
+Énergie,Enfants 1 à 8 ans,2428,des,Fruits et légumes,,,,,170.6,4.7,161.3,179.9,kcal,11.1,0.3,,1
+Énergie,Enfants 1 à 8 ans,2117,des,Fruits et légumes,des,Fruits,,,108,3.6,100.8,115.1,kcal,7.1,0.2,,2
+Énergie,Enfants 1 à 8 ans,2235,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,62.6,2.5,57.6,67.6,kcal,4.1,0.2,,2
+Énergie,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pommes,29.8,1.9,26,33.6,kcal,1.9,0.1,,3
+Énergie,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Bananes,25.9,1.5,22.9,28.8,kcal,1.7,0.1,,3
+Énergie,Enfants 1 à 8 ans,572,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,11.8,1.8,8.3,15.2,kcal,0.8,0.1,,3
+Énergie,Enfants 1 à 8 ans,830,des,Fruits et légumes,des,Fruits,des,Baies,10.4,0.9,8.6,12.3,kcal,0.7,0.1,,3
+Énergie,Enfants 1 à 8 ans,421,des,Fruits et légumes,des,Fruits,des,Agrumes,8.3,0.7,6.9,9.7,kcal,0.5,0,,3
+Énergie,Enfants 1 à 8 ans,260,des,Fruits et légumes,des,Fruits,des,Autres fruits,7.1,1,5.2,9.1,kcal,0.5,0.1,,3
+Énergie,Enfants 1 à 8 ans,219,des,Fruits et légumes,des,Fruits,des,Melons,5,0.7,3.7,6.3,kcal,0.3,0,,3
+Énergie,Enfants 1 à 8 ans,133,des,Fruits et légumes,des,Fruits,des,Poires,3.9,0.7,2.5,5.2,kcal,0.3,0,E,3
+Énergie,Enfants 1 à 8 ans,118,des,Fruits et légumes,des,Fruits,des,Pêches et nectarines,2.6,0.5,1.7,3.5,kcal,0.2,0,E,3
+Énergie,Enfants 1 à 8 ans,47,des,Fruits et légumes,des,Fruits,des,Cerises,1.1,0.3,0.4,1.8,kcal,0.1,0,E,3
+Énergie,Enfants 1 à 8 ans,94,des,Fruits et légumes,des,Fruits,des,Ananas,1.4,0.3,0.8,1.9,kcal,0.1,0,E,3
+Énergie,Enfants 1 à 8 ans,37,des,Fruits et légumes,des,Fruits,des,Prunes et pruneaux,F,F,,,kcal,F,F,F,3
+Énergie,Enfants 1 à 8 ans,1032,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes féculents,32.8,2.1,28.6,37,kcal,2.1,0.1,,3
+Énergie,Enfants 1 à 8 ans,1773,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Autres légumes,18.2,0.9,16.4,20,kcal,1.2,0.1,,3
+Énergie,Enfants 1 à 8 ans,1068,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes vert foncé,6.5,0.5,5.6,7.5,kcal,0.4,0,,3
+Énergie,Enfants 1 à 8 ans,875,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes jaune foncé ou orange,5.1,0.5,4.1,6.1,kcal,0.3,0,,3
+Énergie,Enfants 1 à 8 ans,2475,des,Produits céréaliers,,,,,468.6,9.1,450.7,486.4,kcal,30.6,0.5,,1
+Énergie,Enfants 1 à 8 ans,2114,des,Produits céréaliers,des,Pains,,,191.5,6.5,178.7,204.3,kcal,12.5,0.4,,2
+Énergie,Enfants 1 à 8 ans,1282,des,Produits céréaliers,des,Céréales pour déjeuner,,,55,2.2,50.6,59.4,kcal,3.6,0.1,,2
+Énergie,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,56.6,3.1,50.5,62.8,kcal,3.7,0.2,,2
+Énergie,Enfants 1 à 8 ans,2037,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,165.5,6,153.6,177.3,kcal,10.8,0.4,,2
+Énergie,Enfants 1 à 8 ans,951,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,67.6,4.8,58.1,77.1,kcal,4.4,0.3,,3
+Énergie,Enfants 1 à 8 ans,805,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,51.7,4,43.8,59.6,kcal,3.4,0.3,,3
+Énergie,Enfants 1 à 8 ans,813,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,41.2,2.5,36.3,46,kcal,2.7,0.2,,3
+Énergie,Enfants 1 à 8 ans,745,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,31,2.8,25.5,36.6,kcal,2,0.2,,3
+Énergie,Enfants 1 à 8 ans,728,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,28.4,2,24.5,32.2,kcal,1.9,0.1,,3
+Énergie,Enfants 1 à 8 ans,670,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),26.6,1.7,23.3,29.9,kcal,1.7,0.1,,3
+Énergie,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,14.2,1.2,11.8,16.7,kcal,0.9,0.1,,3
+Énergie,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,2.1,0.7,0.7,3.4,kcal,0.1,0,E,3
+Énergie,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,F,F,,,kcal,F,F,F,3
+Énergie,Enfants 1 à 8 ans,1461,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,64.2,4.2,56,72.5,kcal,4.2,0.3,,3
+Énergie,Enfants 1 à 8 ans,834,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,60.1,4.3,51.6,68.6,kcal,3.9,0.3,,3
+Énergie,Enfants 1 à 8 ans,654,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,41.1,2.9,35.4,46.9,kcal,2.7,0.2,,3
+Énergie,Enfants 1 à 8 ans,2072,de la,Viandes et volailles,,,,,132,4.9,122.4,141.5,kcal,8.6,0.3,,1
+Énergie,Enfants 1 à 8 ans,1003,de la,Viandes et volailles,de la,Volaille,,,47.6,3.3,41,54.2,kcal,3.1,0.2,,2
+Énergie,Enfants 1 à 8 ans,942,de la,Viandes et volailles,des,Viandes transformées,,,42.6,2.9,36.8,48.4,kcal,2.8,0.2,,2
+Énergie,Enfants 1 à 8 ans,999,de la,Viandes et volailles,de la,Viande rouge,,,41.8,2.6,36.7,46.8,kcal,2.7,0.2,,2
+Énergie,Enfants 1 à 8 ans,933,de la,Viandes et volailles,de la,Volaille,du,Poulet,45.5,3.3,39,52.1,kcal,3,0.2,,3
+Énergie,Enfants 1 à 8 ans,86,de la,Viandes et volailles,de la,Volaille,de la,Dinde et autres volailles,F,F,,,kcal,F,F,F,3
+Énergie,Enfants 1 à 8 ans,375,de la,Viandes et volailles,des,Viandes transformées,des,Saucisses,22.5,2.5,17.6,27.5,kcal,1.5,0.2,,3
+Énergie,Enfants 1 à 8 ans,513,de la,Viandes et volailles,des,Viandes transformées,des,Viandes froides,14.6,1.4,11.9,17.3,kcal,1,0.1,,3
+Énergie,Enfants 1 à 8 ans,135,de la,Viandes et volailles,des,Viandes transformées,du,Bacon,2.6,0.5,1.6,3.6,kcal,0.2,0,E,3
+Énergie,Enfants 1 à 8 ans,106,de la,Viandes et volailles,des,Viandes transformées,du,Porc salé,2.9,0.6,1.6,4.1,kcal,0.2,0,E,3
+Énergie,Enfants 1 à 8 ans,779,de la,Viandes et volailles,de la,Viande rouge,du,Bœuf,28.6,2.2,24.3,32.8,kcal,1.9,0.1,,3
+Énergie,Enfants 1 à 8 ans,284,de la,Viandes et volailles,de la,Viande rouge,du,Porc frais,10.7,1.5,7.6,13.7,kcal,0.7,0.1,,3
+Énergie,Enfants 1 à 8 ans,43,de la,Viandes et volailles,de la,Viande rouge,de l',Agneau - veau et gibiers,F,F,,,kcal,F,F,F,3
+Énergie,Enfants 1 à 8 ans,,de la,Viandes et volailles,de la,Viande rouge,des,Abats - foies et pâtés,X,X,,,kcal,X,X,<10,3
+Énergie,Enfants 1 à 8 ans,1789,des,Substituts de viande,,,,,61.9,3.9,54.2,69.7,kcal,4,0.2,,1
+Énergie,Enfants 1 à 8 ans,1450,des,Substituts de viande,des,Œufs,,,21.1,1.2,18.8,23.4,kcal,1.4,0.1,,2
+Énergie,Enfants 1 à 8 ans,210,des,Substituts de viande,des,Légumineuses,,,7.6,1.3,5.1,10.1,kcal,0.5,0.1,E,2
+Énergie,Enfants 1 à 8 ans,749,des,Substituts de viande,des,Noix - graines et beurre d'arachides,,,30.5,3.2,24.2,36.8,kcal,2,0.2,,2
+Énergie,Enfants 1 à 8 ans,58,des,Substituts de viande,du,Tofu et produits sans viande,,,2.8,0.8,1.1,4.5,kcal,0.2,0.1,E,2
+Énergie,Enfants 1 à 8 ans,45,des,Boissons et barres nutritionnelles,,,,,4.3,1,2.3,6.3,kcal,0.3,0.1,E,1
+Énergie,Enfants 1 à 8 ans,40,des,Boissons et barres nutritionnelles,des,Substituts de repas et boissons nutritionnelles,,,4,1,2,6,kcal,0.3,0.1,E,2
+Énergie,Enfants 1 à 8 ans,,des,Boissons et barres nutritionnelles,des,Barres nutritionnelles,,,X,X,,,kcal,X,X,<10,2
+Énergie,Enfants 1 à 8 ans,2295,des,Soupes - sauces - Épices et autres ingrédients,,,,,17.7,1.6,14.4,20.9,kcal,1.2,0.1,,1
+Énergie,Enfants 1 à 8 ans,761,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,8.5,1.2,6.1,10.8,kcal,0.6,0.1,,2
+Énergie,Enfants 1 à 8 ans,532,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,6.9,1,4.9,8.8,kcal,0.4,0.1,,2
+Énergie,Enfants 1 à 8 ans,2205,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,2.4,0.2,2,2.7,kcal,0.2,0,,2
+Énergie,Enfants 1 à 8 ans,2106,des,Confiseries - sucres et grignotines salées,,,,,157.8,6.6,144.8,170.8,kcal,10.3,0.4,,1
+Énergie,Enfants 1 à 8 ans,1048,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,40.6,2.6,35.5,45.7,kcal,2.7,0.2,,2
+Énergie,Enfants 1 à 8 ans,497,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,37.3,3.4,30.5,44,kcal,2.4,0.2,,2
+Énergie,Enfants 1 à 8 ans,615,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,32.3,2.9,26.5,38,kcal,2.1,0.2,,2
+Énergie,Enfants 1 à 8 ans,1642,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,47.7,3.2,41.4,53.9,kcal,3.1,0.2,,2
+Énergie,Enfants 1 à 8 ans,557,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,17.7,1.7,14.5,21,kcal,1.2,0.1,,3
+Énergie,Enfants 1 à 8 ans,548,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,17.6,1.6,14.4,20.8,kcal,1.1,0.1,,3
+Énergie,Enfants 1 à 8 ans,131,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,5.3,0.9,3.5,7,kcal,0.3,0.1,E,3
+Énergie,Enfants 1 à 8 ans,346,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,26.9,2.8,21.4,32.4,kcal,1.8,0.2,,3
+Énergie,Enfants 1 à 8 ans,184,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,10.4,1.7,7.1,13.7,kcal,0.7,0.1,,3
+Énergie,Enfants 1 à 8 ans,720,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,26.1,2.4,21.4,30.8,kcal,1.7,0.2,,3
+Énergie,Enfants 1 à 8 ans,1341,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,17.4,1.3,14.7,20,kcal,1.1,0.1,,3
+Énergie,Enfants 1 à 8 ans,257,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,4.2,0.6,2.9,5.4,kcal,0.3,0,,3
+Énergie,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,kcal,X,X,<10,3
 Folate,Population 1 an et +,186,des,Aliments pour bébés,,,,,0.1,0,0,0.1,mcg (ÉFA),0,0,,1
 Folate,Population 1 an et +,154,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0.1,0,0,0.1,mcg (ÉFA),0,0,,2
 Folate,Population 1 an et +,51,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0,0,0,0,mcg (ÉFA),0,0,,2
@@ -1874,7 +1874,7 @@ Folate,Population 1 an et +,6318,des,Fruits et légumes,des,Légumes incluant po
 Folate,Population 1 an et +,19327,des,Produits céréaliers,,,,,220.1,2.5,215.1,225.1,mcg (ÉFA),54.9,0.4,,1
 Folate,Population 1 an et +,16168,des,Produits céréaliers,des,Pains,,,103.9,1.8,100.4,107.4,mcg (ÉFA),25.9,0.4,,2
 Folate,Population 1 an et +,6966,des,Produits céréaliers,des,Céréales pour déjeuner,,,15.8,0.5,14.9,16.8,mcg (ÉFA),3.9,0.1,,2
-Folate,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,6.5,0.2,6,6.9,mcg (ÉFA),1.6,0.1,,2
+Folate,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,6.5,0.2,6,6.9,mcg (ÉFA),1.6,0.1,,2
 Folate,Population 1 an et +,14820,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,93.9,1.9,90.1,97.7,mcg (ÉFA),23.4,0.4,,2
 Folate,Population 1 an et +,8159,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,57.4,1.5,54.5,60.3,mcg (ÉFA),14.3,0.4,,3
 Folate,Population 1 an et +,6257,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,29.6,1.1,27.3,31.8,mcg (ÉFA),7.4,0.3,,3
@@ -1882,10 +1882,10 @@ Folate,Population 1 an et +,5962,des,Produits céréaliers,des,Pains,des,Pains e
 Folate,Population 1 an et +,2918,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,4.6,0.2,4.2,5.1,mcg (ÉFA),1.2,0.1,,3
 Folate,Population 1 an et +,4760,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,10.6,0.4,9.7,11.5,mcg (ÉFA),2.6,0.1,,3
 Folate,Population 1 an et +,2573,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),5.2,0.2,4.7,5.7,mcg (ÉFA),1.3,0.1,,3
-Folate,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.3,0.1,0.2,0.4,mcg (ÉFA),0.1,0,E,3
-Folate,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.4,0,0.4,0.5,mcg (ÉFA),0.1,0,,3
-Folate,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.2,0,0.1,0.3,mcg (ÉFA),0.1,0,,3
-Folate,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mcg (ÉFA),X,X,<10,3
+Folate,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.3,0.1,0.2,0.4,mcg (ÉFA),0.1,0,E,3
+Folate,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.4,0,0.4,0.5,mcg (ÉFA),0.1,0,,3
+Folate,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.2,0,0.1,0.3,mcg (ÉFA),0.1,0,,3
+Folate,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mcg (ÉFA),X,X,<10,3
 Folate,Population 1 an et +,11102,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,49.3,1.3,46.6,51.9,mcg (ÉFA),12.3,0.3,,3
 Folate,Population 1 an et +,4543,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,41.3,1.5,38.4,44.2,mcg (ÉFA),10.3,0.3,,3
 Folate,Population 1 an et +,4598,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,3.3,0.3,2.8,3.9,mcg (ÉFA),0.8,0.1,,3
@@ -1988,7 +1988,7 @@ Folate,Hommes adultes 19 ans +,1991,des,Fruits et légumes,des,Légumes incluant
 Folate,Hommes adultes 19 ans +,6068,des,Produits céréaliers,,,,,251.7,4.7,242.4,261,mcg (ÉFA),55.2,0.6,,1
 Folate,Hommes adultes 19 ans +,5104,des,Produits céréaliers,des,Pains,,,123.5,3.6,116.5,130.5,mcg (ÉFA),27.1,0.7,,2
 Folate,Hommes adultes 19 ans +,1921,des,Produits céréaliers,des,Céréales pour déjeuner,,,16.2,0.9,14.5,18,mcg (ÉFA),3.6,0.2,,2
-Folate,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,6,0.4,5.2,6.7,mcg (ÉFA),1.3,0.1,,2
+Folate,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,6,0.4,5.2,6.7,mcg (ÉFA),1.3,0.1,,2
 Folate,Hommes adultes 19 ans +,4551,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,106,3.4,99.3,112.8,mcg (ÉFA),23.3,0.6,,2
 Folate,Hommes adultes 19 ans +,2752,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,72.9,3,67.1,78.8,mcg (ÉFA),16,0.6,,3
 Folate,Hommes adultes 19 ans +,1885,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,33.1,2.1,29,37.2,mcg (ÉFA),7.3,0.4,,3
@@ -1996,9 +1996,9 @@ Folate,Hommes adultes 19 ans +,1980,des,Produits céréaliers,des,Pains,des,Pain
 Folate,Hommes adultes 19 ans +,593,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,3.7,0.4,2.9,4.4,mcg (ÉFA),0.8,0.1,,3
 Folate,Hommes adultes 19 ans +,1481,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,12.6,0.8,11,14.3,mcg (ÉFA),2.8,0.2,,3
 Folate,Hommes adultes 19 ans +,523,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),3.6,0.4,2.9,4.3,mcg (ÉFA),0.8,0.1,,3
-Folate,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.3,0.1,0.1,0.5,mcg (ÉFA),0.1,0,E,3
-Folate,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.5,0.1,0.4,0.7,mcg (ÉFA),0.1,0,E,3
-Folate,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,F,F,,,mcg (ÉFA),F,F,F,3
+Folate,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.3,0.1,0.1,0.5,mcg (ÉFA),0.1,0,E,3
+Folate,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.5,0.1,0.4,0.7,mcg (ÉFA),0.1,0,E,3
+Folate,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,F,F,,,mcg (ÉFA),F,F,F,3
 Folate,Hommes adultes 19 ans +,3442,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,57.7,2.5,52.7,62.7,mcg (ÉFA),12.7,0.5,,3
 Folate,Hommes adultes 19 ans +,1250,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,44.3,2.8,38.8,49.8,mcg (ÉFA),9.7,0.6,,3
 Folate,Hommes adultes 19 ans +,1449,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,4,0.6,2.8,5.3,mcg (ÉFA),0.9,0.1,,3
@@ -2101,7 +2101,7 @@ Folate,Femmes adultes* 19 ans +,2348,des,Fruits et légumes,des,Légumes incluan
 Folate,Femmes adultes* 19 ans +,6669,des,Produits céréaliers,,,,,177.9,3.7,170.6,185.2,mcg (ÉFA),50.5,0.7,,1
 Folate,Femmes adultes* 19 ans +,5520,des,Produits céréaliers,des,Pains,,,85,2.1,80.9,89.2,mcg (ÉFA),24.2,0.6,,2
 Folate,Femmes adultes* 19 ans +,2230,des,Produits céréaliers,des,Céréales pour déjeuner,,,12.4,0.6,11.1,13.6,mcg (ÉFA),3.5,0.2,,2
-Folate,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,5.3,0.4,4.6,6.1,mcg (ÉFA),1.5,0.1,,2
+Folate,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,5.3,0.4,4.6,6.1,mcg (ÉFA),1.5,0.1,,2
 Folate,Femmes adultes* 19 ans +,4893,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,75.1,3,69.2,81.1,mcg (ÉFA),21.3,0.7,,2
 Folate,Femmes adultes* 19 ans +,2551,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,44.7,1.8,41.3,48.2,mcg (ÉFA),12.7,0.5,,3
 Folate,Femmes adultes* 19 ans +,1994,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,24.6,1.5,21.6,27.7,mcg (ÉFA),7,0.4,,3
@@ -2109,10 +2109,10 @@ Folate,Femmes adultes* 19 ans +,2239,des,Produits céréaliers,des,Pains,des,Pai
 Folate,Femmes adultes* 19 ans +,914,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,3.1,0.2,2.6,3.5,mcg (ÉFA),0.9,0.1,,3
 Folate,Femmes adultes* 19 ans +,1756,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,9.4,0.6,8.2,10.6,mcg (ÉFA),2.7,0.2,,3
 Folate,Femmes adultes* 19 ans +,555,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),3,0.3,2.4,3.5,mcg (ÉFA),0.8,0.1,,3
-Folate,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.3,0,0.2,0.3,mcg (ÉFA),0.1,0,,3
-Folate,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.2,0,0.1,0.2,mcg (ÉFA),0,0,,3
-Folate,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,F,F,,,mcg (ÉFA),F,F,F,3
-Folate,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mcg (ÉFA),X,X,<10,3
+Folate,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.3,0,0.2,0.3,mcg (ÉFA),0.1,0,,3
+Folate,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.2,0,0.1,0.2,mcg (ÉFA),0,0,,3
+Folate,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,F,F,,,mcg (ÉFA),F,F,F,3
+Folate,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mcg (ÉFA),X,X,<10,3
 Folate,Femmes adultes* 19 ans +,3664,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,38.9,2.1,34.8,43.1,mcg (ÉFA),11.1,0.6,,3
 Folate,Femmes adultes* 19 ans +,1358,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,33.5,2.1,29.5,37.6,mcg (ÉFA),9.5,0.5,,3
 Folate,Femmes adultes* 19 ans +,1522,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,2.7,0.3,2.1,3.2,mcg (ÉFA),0.8,0.1,,3
@@ -2156,119 +2156,119 @@ Folate,Femmes adultes* 19 ans +,773,des,Confiseries - sucres et grignotines sal�
 Folate,Femmes adultes* 19 ans +,1529,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.1,0,0.1,0.1,mcg (ÉFA),0,0,,3
 Folate,Femmes adultes* 19 ans +,360,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mcg (ÉFA),0,0,,3
 Folate,Femmes adultes* 19 ans +,4229,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,mcg (ÉFA),0,0,,3
-Folate,Enfants 1 à 8 ans,122,des,Aliments pour bébés,,,,,F,F,,,mcg (ÉFA),F,F,F,1
-Folate,Enfants 1 à 8 ans,95,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,F,F,,,mcg (ÉFA),F,F,F,2
-Folate,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0,0,0,0,mcg (ÉFA),0,0,,2
-Folate,Enfants 1 à 8 ans,2443,des,Boissons (excluant laits),,,,,12.8,0.8,11.3,14.4,mcg (ÉFA),3.9,0.2,,1
-Folate,Enfants 1 à 8 ans,20,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0.1,mcg (ÉFA),0,0,,2
-Folate,Enfants 1 à 8 ans,141,des,Boissons (excluant laits),du,Café et thé,,,0.3,0.1,0.1,0.5,mcg (ÉFA),0.1,0,E,2
-Folate,Enfants 1 à 8 ans,,des,Boissons (excluant laits),des,Boissons Énergisantes,,,X,X,,,mcg (ÉFA),X,X,<10,2
-Folate,Enfants 1 à 8 ans,357,des,Boissons (excluant laits),des,Boissons aux fruits,,,0.4,0.1,0.2,0.6,mcg (ÉFA),0.1,0,E,2
-Folate,Enfants 1 à 8 ans,1159,des,Boissons (excluant laits),des,Jus de fruit,,,11.5,0.8,10,13,mcg (ÉFA),3.5,0.2,,2
-Folate,Enfants 1 à 8 ans,77,des,Boissons (excluant laits),des,Autres boissons,,,0.1,0,0,0.1,mcg (ÉFA),0,0,,2
-Folate,Enfants 1 à 8 ans,142,des,Boissons (excluant laits),des,Boissons gazeuses,,,0,0,0,0,mcg (ÉFA),0,0,,2
-Folate,Enfants 1 à 8 ans,21,des,Boissons (excluant laits),des,Boissons pour sportifs,,,0,0,0,0,mcg (ÉFA),0,0,,2
-Folate,Enfants 1 à 8 ans,52,des,Boissons (excluant laits),des,Jus de tomates et de légumes,,,0.6,0.2,0.3,0.9,mcg (ÉFA),0.2,0,E,2
-Folate,Enfants 1 à 8 ans,,des,Boissons (excluant laits),de l',Eau vitaminée,,,X,X,,,mcg (ÉFA),X,X,<10,2
-Folate,Enfants 1 à 8 ans,2344,des,Boissons (excluant laits),de l',Eau,,,0,0,0,0,mcg (ÉFA),0,0,,2
-Folate,Enfants 1 à 8 ans,133,des,Boissons (excluant laits),du,Café et thé,du,Thé,0.3,0.1,0.1,0.5,mcg (ÉFA),0.1,0,E,3
-Folate,Enfants 1 à 8 ans,,des,Boissons (excluant laits),du,Café et thé,du,Café,X,X,,,mcg (ÉFA),X,X,<10,3
-Folate,Enfants 1 à 8 ans,2436,des,Produits laitiers et Boissons à base de plantes,,,,,23.7,0.6,22.5,24.8,mcg (ÉFA),7.2,0.2,,1
-Folate,Enfants 1 à 8 ans,1632,des,Produits laitiers et Boissons à base de plantes,des,Fromages,,,4,0.2,3.6,4.5,mcg (ÉFA),1.2,0.1,,2
-Folate,Enfants 1 à 8 ans,2341,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,17.7,0.5,16.7,18.7,mcg (ÉFA),5.4,0.2,,2
-Folate,Enfants 1 à 8 ans,1032,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,,,1.9,0.1,1.7,2.2,mcg (ÉFA),0.6,0,,2
-Folate,Enfants 1 à 8 ans,1810,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,7.8,0.4,7.1,8.5,mcg (ÉFA),2.4,0.1,,3
-Folate,Enfants 1 à 8 ans,1078,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,5.3,0.3,4.7,6,mcg (ÉFA),1.6,0.1,,3
-Folate,Enfants 1 à 8 ans,854,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,2.9,0.3,2.2,3.5,mcg (ÉFA),0.9,0.1,,3
-Folate,Enfants 1 à 8 ans,128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,1,0.2,0.7,1.4,mcg (ÉFA),0.3,0.1,E,3
-Folate,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0.3,0.1,0.1,0.5,mcg (ÉFA),0.1,0,E,3
-Folate,Enfants 1 à 8 ans,739,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0.4,0.1,0.3,0.6,mcg (ÉFA),0.1,0,E,3
-Folate,Enfants 1 à 8 ans,2270,des,Graisses et huiles,,,,,0.2,0,0.2,0.2,mcg (ÉFA),0.1,0,,1
-Folate,Enfants 1 à 8 ans,83,des,Graisses et huiles,des,Graisses animales,,,0,0,0,0,mcg (ÉFA),0,0,,2
-Folate,Enfants 1 à 8 ans,657,des,Graisses et huiles,du,Beurre,,,0.1,0,0,0.1,mcg (ÉFA),0,0,,2
-Folate,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Margarines,,,0,0,0,0,mcg (ÉFA),0,0,,2
-Folate,Enfants 1 à 8 ans,463,des,Graisses et huiles,des,Sauces pour salade,,,0.1,0,0.1,0.1,mcg (ÉFA),0,0,,2
-Folate,Enfants 1 à 8 ans,1035,des,Graisses et huiles,du,Shortening,,,0,0,0,0,mcg (ÉFA),0,0,,2
-Folate,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Huiles végétales,,,0,0,0,0,mcg (ÉFA),0,0,,2
-Folate,Enfants 1 à 8 ans,298,des,Poissons et fruits de mer,,,,,1,0.3,0.5,1.5,mcg (ÉFA),0.3,0.1,E,1
-Folate,Enfants 1 à 8 ans,257,des,Poissons et fruits de mer,des,Poissons,,,0.9,0.2,0.4,1.4,mcg (ÉFA),0.3,0.1,E,2
-Folate,Enfants 1 à 8 ans,50,des,Poissons et fruits de mer,des,Mollusques et crustacés,,,0.1,0,0.1,0.2,mcg (ÉFA),0,0,,2
-Folate,Enfants 1 à 8 ans,2428,des,Fruits et légumes,,,,,52,1.7,48.6,55.3,mcg (ÉFA),15.8,0.5,,1
-Folate,Enfants 1 à 8 ans,2117,des,Fruits et légumes,des,Fruits,,,22.2,0.9,20.5,23.9,mcg (ÉFA),6.8,0.3,,2
-Folate,Enfants 1 à 8 ans,2235,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,29.8,1.4,27.1,32.4,mcg (ÉFA),9,0.4,,2
-Folate,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Bananes,5.8,0.3,5.1,6.5,mcg (ÉFA),1.8,0.1,,3
-Folate,Enfants 1 à 8 ans,421,des,Fruits et légumes,des,Fruits,des,Agrumes,4.6,0.4,3.8,5.4,mcg (ÉFA),1.4,0.1,,3
-Folate,Enfants 1 à 8 ans,830,des,Fruits et légumes,des,Fruits,des,Baies,3.9,0.4,3.2,4.6,mcg (ÉFA),1.2,0.1,,3
-Folate,Enfants 1 à 8 ans,260,des,Fruits et légumes,des,Fruits,des,Autres fruits,3,0.5,2,3.9,mcg (ÉFA),0.9,0.1,E,3
-Folate,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pommes,1.6,0.1,1.5,1.8,mcg (ÉFA),0.5,0,,3
-Folate,Enfants 1 à 8 ans,219,des,Fruits et légumes,des,Fruits,des,Melons,1.7,0.3,1.1,2.3,mcg (ÉFA),0.5,0.1,E,3
-Folate,Enfants 1 à 8 ans,572,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,0.3,0,0.2,0.4,mcg (ÉFA),0.1,0,,3
-Folate,Enfants 1 à 8 ans,118,des,Fruits et légumes,des,Fruits,des,Pêches et nectarines,0.3,0,0.2,0.3,mcg (ÉFA),0.1,0,,3
-Folate,Enfants 1 à 8 ans,133,des,Fruits et légumes,des,Fruits,des,Poires,0.5,0.1,0.3,0.6,mcg (ÉFA),0.1,0,E,3
-Folate,Enfants 1 à 8 ans,94,des,Fruits et légumes,des,Fruits,des,Ananas,0.4,0.1,0.2,0.5,mcg (ÉFA),0.1,0,E,3
-Folate,Enfants 1 à 8 ans,47,des,Fruits et légumes,des,Fruits,des,Cerises,0.1,0,0,0.1,mcg (ÉFA),0,0,,3
-Folate,Enfants 1 à 8 ans,37,des,Fruits et légumes,des,Fruits,des,Prunes et pruneaux,0.1,0,0,0.1,mcg (ÉFA),0,0,,3
-Folate,Enfants 1 à 8 ans,1068,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes vert foncé,12.5,1.1,10.4,14.6,mcg (ÉFA),3.8,0.3,,3
-Folate,Enfants 1 à 8 ans,1773,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Autres légumes,9.5,0.5,8.5,10.5,mcg (ÉFA),2.9,0.2,,3
-Folate,Enfants 1 à 8 ans,1032,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes féculents,5.7,0.4,4.9,6.4,mcg (ÉFA),1.7,0.1,,3
-Folate,Enfants 1 à 8 ans,875,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes jaune foncé ou orange,2.1,0.2,1.7,2.5,mcg (ÉFA),0.6,0.1,,3
-Folate,Enfants 1 à 8 ans,2475,des,Produits céréaliers,,,,,200,5.6,189.1,211,mcg (ÉFA),60.8,0.9,,1
-Folate,Enfants 1 à 8 ans,2114,des,Produits céréaliers,des,Pains,,,82.2,3.3,75.7,88.8,mcg (ÉFA),25,0.9,,2
-Folate,Enfants 1 à 8 ans,1282,des,Produits céréaliers,des,Céréales pour déjeuner,,,20.3,0.9,18.5,22.1,mcg (ÉFA),6.2,0.3,,2
-Folate,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,9.9,0.7,8.7,11.2,mcg (ÉFA),3,0.2,,2
-Folate,Enfants 1 à 8 ans,2037,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,87.6,4.4,79,96.2,mcg (ÉFA),26.6,1.1,,2
-Folate,Enfants 1 à 8 ans,951,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,41.2,2.9,35.5,47,mcg (ÉFA),12.5,0.8,,3
-Folate,Enfants 1 à 8 ans,805,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,20.5,1.7,17.1,24,mcg (ÉFA),6.2,0.5,,3
-Folate,Enfants 1 à 8 ans,745,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,12.2,1.2,10,14.5,mcg (ÉFA),3.7,0.3,,3
-Folate,Enfants 1 à 8 ans,813,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,8.2,0.7,6.9,9.6,mcg (ÉFA),2.5,0.2,,3
-Folate,Enfants 1 à 8 ans,670,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),11.4,0.7,10,12.9,mcg (ÉFA),3.5,0.2,,3
-Folate,Enfants 1 à 8 ans,728,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,8.9,0.7,7.5,10.3,mcg (ÉFA),2.7,0.2,,3
-Folate,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.4,0.1,0.1,0.6,mcg (ÉFA),0.1,0,E,3
-Folate,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.3,0.1,0,0.5,mcg (ÉFA),0.1,0,E,3
-Folate,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.4,0,0.3,0.5,mcg (ÉFA),0.1,0,,3
-Folate,Enfants 1 à 8 ans,1461,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,38.4,2.7,33.2,43.6,mcg (ÉFA),11.7,0.7,,3
-Folate,Enfants 1 à 8 ans,834,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,46.1,3.7,39,53.3,mcg (ÉFA),14,1,,3
-Folate,Enfants 1 à 8 ans,654,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,3,0.5,2,4.1,mcg (ÉFA),0.9,0.2,E,3
-Folate,Enfants 1 à 8 ans,2072,de la,Viandes et volailles,,,,,4,0.4,3.3,4.7,mcg (ÉFA),1.2,0.1,,1
-Folate,Enfants 1 à 8 ans,1003,de la,Viandes et volailles,de la,Volaille,,,1.7,0.3,1.1,2.3,mcg (ÉFA),0.5,0.1,E,2
-Folate,Enfants 1 à 8 ans,942,de la,Viandes et volailles,des,Viandes transformées,,,1.1,0.2,0.7,1.5,mcg (ÉFA),0.3,0.1,E,2
-Folate,Enfants 1 à 8 ans,999,de la,Viandes et volailles,de la,Viande rouge,,,1.2,0.1,1,1.4,mcg (ÉFA),0.4,0,,2
-Folate,Enfants 1 à 8 ans,933,de la,Viandes et volailles,de la,Volaille,du,Poulet,1.6,0.3,1,2.2,mcg (ÉFA),0.5,0.1,E,3
-Folate,Enfants 1 à 8 ans,86,de la,Viandes et volailles,de la,Volaille,de la,Dinde et autres volailles,0.1,0,0,0.1,mcg (ÉFA),0,0,,3
-Folate,Enfants 1 à 8 ans,375,de la,Viandes et volailles,des,Viandes transformées,des,Saucisses,0.9,0.2,0.5,1.3,mcg (ÉFA),0.3,0.1,E,3
-Folate,Enfants 1 à 8 ans,135,de la,Viandes et volailles,des,Viandes transformées,du,Bacon,0,0,0,0,mcg (ÉFA),0,0,,3
-Folate,Enfants 1 à 8 ans,106,de la,Viandes et volailles,des,Viandes transformées,du,Porc salé,0,0,0,0.1,mcg (ÉFA),0,0,,3
-Folate,Enfants 1 à 8 ans,513,de la,Viandes et volailles,des,Viandes transformées,des,Viandes froides,0.2,0,0.1,0.2,mcg (ÉFA),0,0,,3
-Folate,Enfants 1 à 8 ans,779,de la,Viandes et volailles,de la,Viande rouge,du,Bœuf,0.9,0.1,0.8,1,mcg (ÉFA),0.3,0,,3
-Folate,Enfants 1 à 8 ans,284,de la,Viandes et volailles,de la,Viande rouge,du,Porc frais,0.2,0,0.1,0.3,mcg (ÉFA),0.1,0,,3
-Folate,Enfants 1 à 8 ans,43,de la,Viandes et volailles,de la,Viande rouge,de l',Agneau - veau et gibiers,F,F,,,mcg (ÉFA),F,F,F,3
-Folate,Enfants 1 à 8 ans,,de la,Viandes et volailles,de la,Viande rouge,des,Abats - foies et pâtés,X,X,,,mcg (ÉFA),X,X,<10,3
-Folate,Enfants 1 à 8 ans,1789,des,Substituts de viande,,,,,20.4,1.9,16.7,24.1,mcg (ÉFA),6.2,0.5,,1
-Folate,Enfants 1 à 8 ans,1450,des,Substituts de viande,des,Œufs,,,7.8,0.4,7,8.6,mcg (ÉFA),2.4,0.1,,2
-Folate,Enfants 1 à 8 ans,210,des,Substituts de viande,des,Légumineuses,,,7.7,1.7,4.5,11,mcg (ÉFA),2.3,0.5,E,2
-Folate,Enfants 1 à 8 ans,749,des,Substituts de viande,des,Noix - graines et beurre d'arachides,,,4.3,0.5,3.4,5.2,mcg (ÉFA),1.3,0.1,,2
-Folate,Enfants 1 à 8 ans,58,des,Substituts de viande,du,Tofu et produits sans viande,,,0.6,0.2,0.2,1,mcg (ÉFA),0.2,0.1,E,2
-Folate,Enfants 1 à 8 ans,45,des,Boissons et barres nutritionnelles,,,,,2,0.6,0.9,3.1,mcg (ÉFA),0.6,0.2,E,1
-Folate,Enfants 1 à 8 ans,40,des,Boissons et barres nutritionnelles,des,Substituts de repas et boissons nutritionnelles,,,2,0.6,0.9,3.1,mcg (ÉFA),0.6,0.2,E,2
-Folate,Enfants 1 à 8 ans,,des,Boissons et barres nutritionnelles,des,Barres nutritionnelles,,,X,X,,,mcg (ÉFA),X,X,<10,2
-Folate,Enfants 1 à 8 ans,2295,des,Soupes - sauces - Épices et autres ingrédients,,,,,5.6,0.4,4.9,6.3,mcg (ÉFA),1.7,0.1,,1
-Folate,Enfants 1 à 8 ans,761,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.7,0.1,0.5,0.8,mcg (ÉFA),0.2,0,,2
-Folate,Enfants 1 à 8 ans,532,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,1.7,0.2,1.2,2.1,mcg (ÉFA),0.5,0.1,,2
-Folate,Enfants 1 à 8 ans,2205,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,3.3,0.3,2.7,3.9,mcg (ÉFA),1,0.1,,2
-Folate,Enfants 1 à 8 ans,2106,des,Confiseries - sucres et grignotines salées,,,,,6.8,1.5,3.8,9.8,mcg (ÉFA),2.1,0.5,E,1
-Folate,Enfants 1 à 8 ans,1048,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,0.8,0.1,0.7,0.9,mcg (ÉFA),0.2,0,,2
-Folate,Enfants 1 à 8 ans,497,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,1.1,0.1,0.8,1.3,mcg (ÉFA),0.3,0,,2
-Folate,Enfants 1 à 8 ans,615,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,2.4,0.4,1.7,3.2,mcg (ÉFA),0.7,0.1,E,2
-Folate,Enfants 1 à 8 ans,1642,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,F,F,,,mcg (ÉFA),F,F,F,2
-Folate,Enfants 1 à 8 ans,557,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0.2,0,0.1,0.3,mcg (ÉFA),0.1,0,,3
-Folate,Enfants 1 à 8 ans,548,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0.5,0,0.4,0.6,mcg (ÉFA),0.1,0,,3
-Folate,Enfants 1 à 8 ans,131,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0.1,0,0.1,0.1,mcg (ÉFA),0,0,,3
-Folate,Enfants 1 à 8 ans,346,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,1,0.1,0.8,1.3,mcg (ÉFA),0.3,0,,3
-Folate,Enfants 1 à 8 ans,184,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0.1,mcg (ÉFA),0,0,,3
-Folate,Enfants 1 à 8 ans,257,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.1,0,0.1,0.2,mcg (ÉFA),0,0,,3
-Folate,Enfants 1 à 8 ans,1341,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,mcg (ÉFA),0,0,,3
-Folate,Enfants 1 à 8 ans,720,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,F,F,,,mcg (ÉFA),F,F,F,3
-Folate,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,mcg (ÉFA),X,X,<10,3
+Folate,Enfants 1 à 8 ans,122,des,Aliments pour bébés,,,,,F,F,,,mcg (ÉFA),F,F,F,1
+Folate,Enfants 1 à 8 ans,95,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,F,F,,,mcg (ÉFA),F,F,F,2
+Folate,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0,0,0,0,mcg (ÉFA),0,0,,2
+Folate,Enfants 1 à 8 ans,2443,des,Boissons (excluant laits),,,,,12.8,0.8,11.3,14.4,mcg (ÉFA),3.9,0.2,,1
+Folate,Enfants 1 à 8 ans,20,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0.1,mcg (ÉFA),0,0,,2
+Folate,Enfants 1 à 8 ans,141,des,Boissons (excluant laits),du,Café et thé,,,0.3,0.1,0.1,0.5,mcg (ÉFA),0.1,0,E,2
+Folate,Enfants 1 à 8 ans,,des,Boissons (excluant laits),des,Boissons Énergisantes,,,X,X,,,mcg (ÉFA),X,X,<10,2
+Folate,Enfants 1 à 8 ans,357,des,Boissons (excluant laits),des,Boissons aux fruits,,,0.4,0.1,0.2,0.6,mcg (ÉFA),0.1,0,E,2
+Folate,Enfants 1 à 8 ans,1159,des,Boissons (excluant laits),des,Jus de fruit,,,11.5,0.8,10,13,mcg (ÉFA),3.5,0.2,,2
+Folate,Enfants 1 à 8 ans,77,des,Boissons (excluant laits),des,Autres boissons,,,0.1,0,0,0.1,mcg (ÉFA),0,0,,2
+Folate,Enfants 1 à 8 ans,142,des,Boissons (excluant laits),des,Boissons gazeuses,,,0,0,0,0,mcg (ÉFA),0,0,,2
+Folate,Enfants 1 à 8 ans,21,des,Boissons (excluant laits),des,Boissons pour sportifs,,,0,0,0,0,mcg (ÉFA),0,0,,2
+Folate,Enfants 1 à 8 ans,52,des,Boissons (excluant laits),des,Jus de tomates et de légumes,,,0.6,0.2,0.3,0.9,mcg (ÉFA),0.2,0,E,2
+Folate,Enfants 1 à 8 ans,,des,Boissons (excluant laits),de l',Eau vitaminée,,,X,X,,,mcg (ÉFA),X,X,<10,2
+Folate,Enfants 1 à 8 ans,2344,des,Boissons (excluant laits),de l',Eau,,,0,0,0,0,mcg (ÉFA),0,0,,2
+Folate,Enfants 1 à 8 ans,133,des,Boissons (excluant laits),du,Café et thé,du,Thé,0.3,0.1,0.1,0.5,mcg (ÉFA),0.1,0,E,3
+Folate,Enfants 1 à 8 ans,,des,Boissons (excluant laits),du,Café et thé,du,Café,X,X,,,mcg (ÉFA),X,X,<10,3
+Folate,Enfants 1 à 8 ans,2436,des,Produits laitiers et Boissons à base de plantes,,,,,23.7,0.6,22.5,24.8,mcg (ÉFA),7.2,0.2,,1
+Folate,Enfants 1 à 8 ans,1632,des,Produits laitiers et Boissons à base de plantes,des,Fromages,,,4,0.2,3.6,4.5,mcg (ÉFA),1.2,0.1,,2
+Folate,Enfants 1 à 8 ans,2341,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,17.7,0.5,16.7,18.7,mcg (ÉFA),5.4,0.2,,2
+Folate,Enfants 1 à 8 ans,1032,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,,,1.9,0.1,1.7,2.2,mcg (ÉFA),0.6,0,,2
+Folate,Enfants 1 à 8 ans,1810,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,7.8,0.4,7.1,8.5,mcg (ÉFA),2.4,0.1,,3
+Folate,Enfants 1 à 8 ans,1078,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,5.3,0.3,4.7,6,mcg (ÉFA),1.6,0.1,,3
+Folate,Enfants 1 à 8 ans,854,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,2.9,0.3,2.2,3.5,mcg (ÉFA),0.9,0.1,,3
+Folate,Enfants 1 à 8 ans,128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,1,0.2,0.7,1.4,mcg (ÉFA),0.3,0.1,E,3
+Folate,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0.3,0.1,0.1,0.5,mcg (ÉFA),0.1,0,E,3
+Folate,Enfants 1 à 8 ans,739,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0.4,0.1,0.3,0.6,mcg (ÉFA),0.1,0,E,3
+Folate,Enfants 1 à 8 ans,2270,des,Graisses et huiles,,,,,0.2,0,0.2,0.2,mcg (ÉFA),0.1,0,,1
+Folate,Enfants 1 à 8 ans,83,des,Graisses et huiles,des,Graisses animales,,,0,0,0,0,mcg (ÉFA),0,0,,2
+Folate,Enfants 1 à 8 ans,657,des,Graisses et huiles,du,Beurre,,,0.1,0,0,0.1,mcg (ÉFA),0,0,,2
+Folate,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Margarines,,,0,0,0,0,mcg (ÉFA),0,0,,2
+Folate,Enfants 1 à 8 ans,463,des,Graisses et huiles,des,Sauces pour salade,,,0.1,0,0.1,0.1,mcg (ÉFA),0,0,,2
+Folate,Enfants 1 à 8 ans,1035,des,Graisses et huiles,du,Shortening,,,0,0,0,0,mcg (ÉFA),0,0,,2
+Folate,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Huiles végétales,,,0,0,0,0,mcg (ÉFA),0,0,,2
+Folate,Enfants 1 à 8 ans,298,des,Poissons et fruits de mer,,,,,1,0.3,0.5,1.5,mcg (ÉFA),0.3,0.1,E,1
+Folate,Enfants 1 à 8 ans,257,des,Poissons et fruits de mer,des,Poissons,,,0.9,0.2,0.4,1.4,mcg (ÉFA),0.3,0.1,E,2
+Folate,Enfants 1 à 8 ans,50,des,Poissons et fruits de mer,des,Mollusques et crustacés,,,0.1,0,0.1,0.2,mcg (ÉFA),0,0,,2
+Folate,Enfants 1 à 8 ans,2428,des,Fruits et légumes,,,,,52,1.7,48.6,55.3,mcg (ÉFA),15.8,0.5,,1
+Folate,Enfants 1 à 8 ans,2117,des,Fruits et légumes,des,Fruits,,,22.2,0.9,20.5,23.9,mcg (ÉFA),6.8,0.3,,2
+Folate,Enfants 1 à 8 ans,2235,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,29.8,1.4,27.1,32.4,mcg (ÉFA),9,0.4,,2
+Folate,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Bananes,5.8,0.3,5.1,6.5,mcg (ÉFA),1.8,0.1,,3
+Folate,Enfants 1 à 8 ans,421,des,Fruits et légumes,des,Fruits,des,Agrumes,4.6,0.4,3.8,5.4,mcg (ÉFA),1.4,0.1,,3
+Folate,Enfants 1 à 8 ans,830,des,Fruits et légumes,des,Fruits,des,Baies,3.9,0.4,3.2,4.6,mcg (ÉFA),1.2,0.1,,3
+Folate,Enfants 1 à 8 ans,260,des,Fruits et légumes,des,Fruits,des,Autres fruits,3,0.5,2,3.9,mcg (ÉFA),0.9,0.1,E,3
+Folate,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pommes,1.6,0.1,1.5,1.8,mcg (ÉFA),0.5,0,,3
+Folate,Enfants 1 à 8 ans,219,des,Fruits et légumes,des,Fruits,des,Melons,1.7,0.3,1.1,2.3,mcg (ÉFA),0.5,0.1,E,3
+Folate,Enfants 1 à 8 ans,572,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,0.3,0,0.2,0.4,mcg (ÉFA),0.1,0,,3
+Folate,Enfants 1 à 8 ans,118,des,Fruits et légumes,des,Fruits,des,Pêches et nectarines,0.3,0,0.2,0.3,mcg (ÉFA),0.1,0,,3
+Folate,Enfants 1 à 8 ans,133,des,Fruits et légumes,des,Fruits,des,Poires,0.5,0.1,0.3,0.6,mcg (ÉFA),0.1,0,E,3
+Folate,Enfants 1 à 8 ans,94,des,Fruits et légumes,des,Fruits,des,Ananas,0.4,0.1,0.2,0.5,mcg (ÉFA),0.1,0,E,3
+Folate,Enfants 1 à 8 ans,47,des,Fruits et légumes,des,Fruits,des,Cerises,0.1,0,0,0.1,mcg (ÉFA),0,0,,3
+Folate,Enfants 1 à 8 ans,37,des,Fruits et légumes,des,Fruits,des,Prunes et pruneaux,0.1,0,0,0.1,mcg (ÉFA),0,0,,3
+Folate,Enfants 1 à 8 ans,1068,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes vert foncé,12.5,1.1,10.4,14.6,mcg (ÉFA),3.8,0.3,,3
+Folate,Enfants 1 à 8 ans,1773,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Autres légumes,9.5,0.5,8.5,10.5,mcg (ÉFA),2.9,0.2,,3
+Folate,Enfants 1 à 8 ans,1032,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes féculents,5.7,0.4,4.9,6.4,mcg (ÉFA),1.7,0.1,,3
+Folate,Enfants 1 à 8 ans,875,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes jaune foncé ou orange,2.1,0.2,1.7,2.5,mcg (ÉFA),0.6,0.1,,3
+Folate,Enfants 1 à 8 ans,2475,des,Produits céréaliers,,,,,200,5.6,189.1,211,mcg (ÉFA),60.8,0.9,,1
+Folate,Enfants 1 à 8 ans,2114,des,Produits céréaliers,des,Pains,,,82.2,3.3,75.7,88.8,mcg (ÉFA),25,0.9,,2
+Folate,Enfants 1 à 8 ans,1282,des,Produits céréaliers,des,Céréales pour déjeuner,,,20.3,0.9,18.5,22.1,mcg (ÉFA),6.2,0.3,,2
+Folate,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,9.9,0.7,8.7,11.2,mcg (ÉFA),3,0.2,,2
+Folate,Enfants 1 à 8 ans,2037,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,87.6,4.4,79,96.2,mcg (ÉFA),26.6,1.1,,2
+Folate,Enfants 1 à 8 ans,951,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,41.2,2.9,35.5,47,mcg (ÉFA),12.5,0.8,,3
+Folate,Enfants 1 à 8 ans,805,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,20.5,1.7,17.1,24,mcg (ÉFA),6.2,0.5,,3
+Folate,Enfants 1 à 8 ans,745,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,12.2,1.2,10,14.5,mcg (ÉFA),3.7,0.3,,3
+Folate,Enfants 1 à 8 ans,813,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,8.2,0.7,6.9,9.6,mcg (ÉFA),2.5,0.2,,3
+Folate,Enfants 1 à 8 ans,670,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),11.4,0.7,10,12.9,mcg (ÉFA),3.5,0.2,,3
+Folate,Enfants 1 à 8 ans,728,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,8.9,0.7,7.5,10.3,mcg (ÉFA),2.7,0.2,,3
+Folate,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.4,0.1,0.1,0.6,mcg (ÉFA),0.1,0,E,3
+Folate,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.3,0.1,0,0.5,mcg (ÉFA),0.1,0,E,3
+Folate,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.4,0,0.3,0.5,mcg (ÉFA),0.1,0,,3
+Folate,Enfants 1 à 8 ans,1461,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,38.4,2.7,33.2,43.6,mcg (ÉFA),11.7,0.7,,3
+Folate,Enfants 1 à 8 ans,834,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,46.1,3.7,39,53.3,mcg (ÉFA),14,1,,3
+Folate,Enfants 1 à 8 ans,654,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,3,0.5,2,4.1,mcg (ÉFA),0.9,0.2,E,3
+Folate,Enfants 1 à 8 ans,2072,de la,Viandes et volailles,,,,,4,0.4,3.3,4.7,mcg (ÉFA),1.2,0.1,,1
+Folate,Enfants 1 à 8 ans,1003,de la,Viandes et volailles,de la,Volaille,,,1.7,0.3,1.1,2.3,mcg (ÉFA),0.5,0.1,E,2
+Folate,Enfants 1 à 8 ans,942,de la,Viandes et volailles,des,Viandes transformées,,,1.1,0.2,0.7,1.5,mcg (ÉFA),0.3,0.1,E,2
+Folate,Enfants 1 à 8 ans,999,de la,Viandes et volailles,de la,Viande rouge,,,1.2,0.1,1,1.4,mcg (ÉFA),0.4,0,,2
+Folate,Enfants 1 à 8 ans,933,de la,Viandes et volailles,de la,Volaille,du,Poulet,1.6,0.3,1,2.2,mcg (ÉFA),0.5,0.1,E,3
+Folate,Enfants 1 à 8 ans,86,de la,Viandes et volailles,de la,Volaille,de la,Dinde et autres volailles,0.1,0,0,0.1,mcg (ÉFA),0,0,,3
+Folate,Enfants 1 à 8 ans,375,de la,Viandes et volailles,des,Viandes transformées,des,Saucisses,0.9,0.2,0.5,1.3,mcg (ÉFA),0.3,0.1,E,3
+Folate,Enfants 1 à 8 ans,135,de la,Viandes et volailles,des,Viandes transformées,du,Bacon,0,0,0,0,mcg (ÉFA),0,0,,3
+Folate,Enfants 1 à 8 ans,106,de la,Viandes et volailles,des,Viandes transformées,du,Porc salé,0,0,0,0.1,mcg (ÉFA),0,0,,3
+Folate,Enfants 1 à 8 ans,513,de la,Viandes et volailles,des,Viandes transformées,des,Viandes froides,0.2,0,0.1,0.2,mcg (ÉFA),0,0,,3
+Folate,Enfants 1 à 8 ans,779,de la,Viandes et volailles,de la,Viande rouge,du,Bœuf,0.9,0.1,0.8,1,mcg (ÉFA),0.3,0,,3
+Folate,Enfants 1 à 8 ans,284,de la,Viandes et volailles,de la,Viande rouge,du,Porc frais,0.2,0,0.1,0.3,mcg (ÉFA),0.1,0,,3
+Folate,Enfants 1 à 8 ans,43,de la,Viandes et volailles,de la,Viande rouge,de l',Agneau - veau et gibiers,F,F,,,mcg (ÉFA),F,F,F,3
+Folate,Enfants 1 à 8 ans,,de la,Viandes et volailles,de la,Viande rouge,des,Abats - foies et pâtés,X,X,,,mcg (ÉFA),X,X,<10,3
+Folate,Enfants 1 à 8 ans,1789,des,Substituts de viande,,,,,20.4,1.9,16.7,24.1,mcg (ÉFA),6.2,0.5,,1
+Folate,Enfants 1 à 8 ans,1450,des,Substituts de viande,des,Œufs,,,7.8,0.4,7,8.6,mcg (ÉFA),2.4,0.1,,2
+Folate,Enfants 1 à 8 ans,210,des,Substituts de viande,des,Légumineuses,,,7.7,1.7,4.5,11,mcg (ÉFA),2.3,0.5,E,2
+Folate,Enfants 1 à 8 ans,749,des,Substituts de viande,des,Noix - graines et beurre d'arachides,,,4.3,0.5,3.4,5.2,mcg (ÉFA),1.3,0.1,,2
+Folate,Enfants 1 à 8 ans,58,des,Substituts de viande,du,Tofu et produits sans viande,,,0.6,0.2,0.2,1,mcg (ÉFA),0.2,0.1,E,2
+Folate,Enfants 1 à 8 ans,45,des,Boissons et barres nutritionnelles,,,,,2,0.6,0.9,3.1,mcg (ÉFA),0.6,0.2,E,1
+Folate,Enfants 1 à 8 ans,40,des,Boissons et barres nutritionnelles,des,Substituts de repas et boissons nutritionnelles,,,2,0.6,0.9,3.1,mcg (ÉFA),0.6,0.2,E,2
+Folate,Enfants 1 à 8 ans,,des,Boissons et barres nutritionnelles,des,Barres nutritionnelles,,,X,X,,,mcg (ÉFA),X,X,<10,2
+Folate,Enfants 1 à 8 ans,2295,des,Soupes - sauces - Épices et autres ingrédients,,,,,5.6,0.4,4.9,6.3,mcg (ÉFA),1.7,0.1,,1
+Folate,Enfants 1 à 8 ans,761,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.7,0.1,0.5,0.8,mcg (ÉFA),0.2,0,,2
+Folate,Enfants 1 à 8 ans,532,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,1.7,0.2,1.2,2.1,mcg (ÉFA),0.5,0.1,,2
+Folate,Enfants 1 à 8 ans,2205,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,3.3,0.3,2.7,3.9,mcg (ÉFA),1,0.1,,2
+Folate,Enfants 1 à 8 ans,2106,des,Confiseries - sucres et grignotines salées,,,,,6.8,1.5,3.8,9.8,mcg (ÉFA),2.1,0.5,E,1
+Folate,Enfants 1 à 8 ans,1048,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,0.8,0.1,0.7,0.9,mcg (ÉFA),0.2,0,,2
+Folate,Enfants 1 à 8 ans,497,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,1.1,0.1,0.8,1.3,mcg (ÉFA),0.3,0,,2
+Folate,Enfants 1 à 8 ans,615,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,2.4,0.4,1.7,3.2,mcg (ÉFA),0.7,0.1,E,2
+Folate,Enfants 1 à 8 ans,1642,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,F,F,,,mcg (ÉFA),F,F,F,2
+Folate,Enfants 1 à 8 ans,557,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0.2,0,0.1,0.3,mcg (ÉFA),0.1,0,,3
+Folate,Enfants 1 à 8 ans,548,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0.5,0,0.4,0.6,mcg (ÉFA),0.1,0,,3
+Folate,Enfants 1 à 8 ans,131,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0.1,0,0.1,0.1,mcg (ÉFA),0,0,,3
+Folate,Enfants 1 à 8 ans,346,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,1,0.1,0.8,1.3,mcg (ÉFA),0.3,0,,3
+Folate,Enfants 1 à 8 ans,184,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0.1,mcg (ÉFA),0,0,,3
+Folate,Enfants 1 à 8 ans,257,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.1,0,0.1,0.2,mcg (ÉFA),0,0,,3
+Folate,Enfants 1 à 8 ans,1341,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,mcg (ÉFA),0,0,,3
+Folate,Enfants 1 à 8 ans,720,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,F,F,,,mcg (ÉFA),F,F,F,3
+Folate,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,mcg (ÉFA),X,X,<10,3
 Fer,Population 1 an et +,186,des,Aliments pour bébés,,,,,0,0,0,0.1,mg,0.3,0.1,,1
 Fer,Population 1 an et +,154,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0,mg,0.2,0.1,,2
 Fer,Population 1 an et +,51,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0,0,0,0,mg,0.1,0,,2
@@ -2328,7 +2328,7 @@ Fer,Population 1 an et +,6318,des,Fruits et légumes,des,Légumes incluant pomme
 Fer,Population 1 an et +,19327,des,Produits céréaliers,,,,,6,0.1,5.9,6.1,mg,48.6,0.3,,1
 Fer,Population 1 an et +,16168,des,Produits céréaliers,des,Pains,,,2.7,0,2.6,2.7,mg,21.7,0.3,,2
 Fer,Population 1 an et +,6966,des,Produits céréaliers,des,Céréales pour déjeuner,,,1.4,0,1.3,1.4,mg,11.1,0.3,,2
-Fer,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.3,0,0.3,0.4,mg,2.7,0.1,,2
+Fer,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.3,0,0.3,0.4,mg,2.7,0.1,,2
 Fer,Population 1 an et +,14820,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,1.6,0,1.6,1.7,mg,13.2,0.2,,2
 Fer,Population 1 an et +,8159,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,1.2,0,1.2,1.3,mg,10,0.3,,3
 Fer,Population 1 an et +,6257,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,0.7,0,0.7,0.8,mg,5.9,0.2,,3
@@ -2336,10 +2336,10 @@ Fer,Population 1 an et +,5962,des,Produits céréaliers,des,Pains,des,Pains et p
 Fer,Population 1 an et +,2918,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.1,0,0.1,0.1,mg,1,0,,3
 Fer,Population 1 an et +,4760,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.9,0,0.8,1,mg,7.4,0.3,,3
 Fer,Population 1 an et +,2573,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.4,0,0.4,0.5,mg,3.6,0.2,,3
-Fer,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.1,mg,0.5,0,,3
-Fer,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mg,0.1,0,,3
-Fer,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mg,0.1,0,,3
-Fer,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
+Fer,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.1,mg,0.5,0,,3
+Fer,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mg,0.1,0,,3
+Fer,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mg,0.1,0,,3
+Fer,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
 Fer,Population 1 an et +,11102,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,1.1,0,1,1.1,mg,8.8,0.2,,3
 Fer,Population 1 an et +,4543,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.4,0,0.4,0.5,mg,3.6,0.1,,3
 Fer,Population 1 an et +,4598,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0.1,0,0.1,0.1,mg,0.8,0,,3
@@ -2442,7 +2442,7 @@ Fer,Hommes adultes 19 ans +,1991,des,Fruits et légumes,des,Légumes incluant po
 Fer,Hommes adultes 19 ans +,6068,des,Produits céréaliers,,,,,6.7,0.1,6.5,6.9,mg,47.5,0.6,,1
 Fer,Hommes adultes 19 ans +,5104,des,Produits céréaliers,des,Pains,,,3.1,0.1,3,3.3,mg,22.2,0.5,,2
 Fer,Hommes adultes 19 ans +,1921,des,Produits céréaliers,des,Céréales pour déjeuner,,,1.4,0.1,1.2,1.5,mg,9.9,0.5,,2
-Fer,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.3,0,0.3,0.4,mg,2.2,0.2,,2
+Fer,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.3,0,0.3,0.4,mg,2.2,0.2,,2
 Fer,Hommes adultes 19 ans +,4551,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,1.8,0.1,1.7,2,mg,13.2,0.4,,2
 Fer,Hommes adultes 19 ans +,2752,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,1.6,0.1,1.4,1.7,mg,11.1,0.4,,3
 Fer,Hommes adultes 19 ans +,1885,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,0.8,0,0.7,0.9,mg,5.8,0.3,,3
@@ -2450,9 +2450,9 @@ Fer,Hommes adultes 19 ans +,1980,des,Produits céréaliers,des,Pains,des,Pains e
 Fer,Hommes adultes 19 ans +,593,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.1,0,0.1,0.1,mg,0.8,0.1,,3
 Fer,Hommes adultes 19 ans +,1481,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,1.1,0.1,0.9,1.2,mg,7.7,0.5,,3
 Fer,Hommes adultes 19 ans +,523,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.3,0,0.3,0.4,mg,2.2,0.2,,3
-Fer,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.1,mg,0.5,0.1,,3
-Fer,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mg,0.1,0,,3
-Fer,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mg,0,0,,3
+Fer,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.1,mg,0.5,0.1,,3
+Fer,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mg,0.1,0,,3
+Fer,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mg,0,0,,3
 Fer,Hommes adultes 19 ans +,3442,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,1.3,0.1,1.2,1.4,mg,9,0.4,,3
 Fer,Hommes adultes 19 ans +,1250,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.5,0,0.4,0.5,mg,3.3,0.2,,3
 Fer,Hommes adultes 19 ans +,1449,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0.1,0,0.1,0.1,mg,0.8,0.1,,3
@@ -2555,7 +2555,7 @@ Fer,Femmes adultes* 19 ans +,2348,des,Fruits et légumes,des,Légumes incluant p
 Fer,Femmes adultes* 19 ans +,6669,des,Produits céréaliers,,,,,4.8,0.1,4.7,5,mg,45.5,0.6,,1
 Fer,Femmes adultes* 19 ans +,5520,des,Produits céréaliers,des,Pains,,,2.2,0,2.1,2.3,mg,21,0.4,,2
 Fer,Femmes adultes* 19 ans +,2230,des,Produits céréaliers,des,Céréales pour déjeuner,,,1.1,0,1,1.2,mg,9.9,0.4,,2
-Fer,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.2,0,0.2,0.3,mg,2.3,0.1,,2
+Fer,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.2,0,0.2,0.3,mg,2.3,0.1,,2
 Fer,Femmes adultes* 19 ans +,4893,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,1.3,0,1.2,1.4,mg,12.4,0.4,,2
 Fer,Femmes adultes* 19 ans +,2551,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,1,0,0.9,1,mg,9,0.4,,3
 Fer,Femmes adultes* 19 ans +,1994,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,0.6,0,0.5,0.7,mg,5.7,0.3,,3
@@ -2563,10 +2563,10 @@ Fer,Femmes adultes* 19 ans +,2239,des,Produits céréaliers,des,Pains,des,Pains 
 Fer,Femmes adultes* 19 ans +,914,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.1,0,0.1,0.1,mg,0.9,0.1,,3
 Fer,Femmes adultes* 19 ans +,1756,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.8,0,0.7,0.9,mg,7.5,0.4,,3
 Fer,Femmes adultes* 19 ans +,555,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.3,0,0.2,0.3,mg,2.4,0.2,,3
-Fer,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0,0,0,0,mg,0.4,0,,3
-Fer,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mg,0.1,0,,3
-Fer,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mg,0,0,,3
-Fer,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
+Fer,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0,0,0,0,mg,0.4,0,,3
+Fer,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mg,0.1,0,,3
+Fer,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mg,0,0,,3
+Fer,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
 Fer,Femmes adultes* 19 ans +,3664,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.9,0,0.8,1,mg,8.1,0.4,,3
 Fer,Femmes adultes* 19 ans +,1358,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.4,0,0.3,0.4,mg,3.4,0.2,,3
 Fer,Femmes adultes* 19 ans +,1522,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0.1,0,0.1,0.1,mg,0.9,0.1,,3
@@ -2610,119 +2610,119 @@ Fer,Femmes adultes* 19 ans +,1529,des,Confiseries - sucres et grignotines salée
 Fer,Femmes adultes* 19 ans +,773,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,mg,0.1,0,,3
 Fer,Femmes adultes* 19 ans +,4229,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,mg,0.1,0,,3
 Fer,Femmes adultes* 19 ans +,360,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mg,0,0,,3
-Fer,Enfants 1 à 8 ans,122,des,Aliments pour bébés,,,,,F,F,,,mg,F,F,F,1
-Fer,Enfants 1 à 8 ans,95,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0.2,0,0.1,0.3,mg,1.6,0.4,,2
-Fer,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0.1,0,0,0.1,mg,0.8,0.2,,2
-Fer,Enfants 1 à 8 ans,2443,des,Boissons (excluant laits),,,,,0.3,0,0.3,0.4,mg,3.2,0.2,,1
-Fer,Enfants 1 à 8 ans,20,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0,mg,0,0,,2
-Fer,Enfants 1 à 8 ans,141,des,Boissons (excluant laits),du,Café et thé,,,0,0,0,0,mg,0,0,,2
-Fer,Enfants 1 à 8 ans,,des,Boissons (excluant laits),des,Boissons Énergisantes,,,X,X,,,mg,X,X,<10,2
-Fer,Enfants 1 à 8 ans,357,des,Boissons (excluant laits),des,Boissons aux fruits,,,0.1,0,0,0.1,mg,0.6,0.1,,2
-Fer,Enfants 1 à 8 ans,1159,des,Boissons (excluant laits),des,Jus de fruit,,,0.2,0,0.2,0.2,mg,2,0.2,,2
-Fer,Enfants 1 à 8 ans,77,des,Boissons (excluant laits),des,Autres boissons,,,0,0,0,0,mg,0.2,0,,2
-Fer,Enfants 1 à 8 ans,142,des,Boissons (excluant laits),des,Boissons gazeuses,,,0,0,0,0,mg,0.1,0,,2
-Fer,Enfants 1 à 8 ans,21,des,Boissons (excluant laits),des,Boissons pour sportifs,,,0,0,0,0,mg,0,0,,2
-Fer,Enfants 1 à 8 ans,52,des,Boissons (excluant laits),des,Jus de tomates et de légumes,,,0,0,0,0,mg,0.1,0,,2
-Fer,Enfants 1 à 8 ans,,des,Boissons (excluant laits),de l',Eau vitaminée,,,X,X,,,mg,X,X,<10,2
-Fer,Enfants 1 à 8 ans,2344,des,Boissons (excluant laits),de l',Eau,,,0,0,0,0,mg,0.1,0,,2
-Fer,Enfants 1 à 8 ans,133,des,Boissons (excluant laits),du,Café et thé,du,Thé,0,0,0,0,mg,0,0,,3
-Fer,Enfants 1 à 8 ans,,des,Boissons (excluant laits),du,Café et thé,du,Café,X,X,,,mg,X,X,<10,3
-Fer,Enfants 1 à 8 ans,2436,des,Produits laitiers et Boissons à base de plantes,,,,,0.3,0,0.3,0.3,mg,2.8,0.1,,1
-Fer,Enfants 1 à 8 ans,1632,des,Produits laitiers et Boissons à base de plantes,des,Fromages,,,0.1,0,0.1,0.1,mg,0.6,0,,2
-Fer,Enfants 1 à 8 ans,2341,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,0.2,0,0.1,0.2,mg,1.6,0.1,,2
-Fer,Enfants 1 à 8 ans,1032,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,,,0.1,0,0,0.1,mg,0.6,0.1,,2
-Fer,Enfants 1 à 8 ans,1810,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,0.1,0,0,0.1,mg,0.5,0,,3
-Fer,Enfants 1 à 8 ans,854,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,0,0,0,0,mg,0.4,0.1,,3
-Fer,Enfants 1 à 8 ans,128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0,0,0,0,mg,0.3,0,,3
-Fer,Enfants 1 à 8 ans,1078,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,0,0,0,0,mg,0.3,0,,3
-Fer,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0,0,0,0,mg,0,0,,3
-Fer,Enfants 1 à 8 ans,739,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0,0,0,0,mg,0,0,,3
-Fer,Enfants 1 à 8 ans,2270,des,Graisses et huiles,,,,,0,0,0,0,mg,0.1,0,,1
-Fer,Enfants 1 à 8 ans,83,des,Graisses et huiles,des,Graisses animales,,,0,0,0,0,mg,0,0,,2
-Fer,Enfants 1 à 8 ans,657,des,Graisses et huiles,du,Beurre,,,0,0,0,0,mg,0,0,,2
-Fer,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Margarines,,,0,0,0,0,mg,0,0,,2
-Fer,Enfants 1 à 8 ans,463,des,Graisses et huiles,des,Sauces pour salade,,,0,0,0,0,mg,0.1,0,,2
-Fer,Enfants 1 à 8 ans,1035,des,Graisses et huiles,du,Shortening,,,0,0,0,0,mg,0,0,,2
-Fer,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Huiles végétales,,,0,0,0,0,mg,0.1,0,,2
-Fer,Enfants 1 à 8 ans,298,des,Poissons et fruits de mer,,,,,0.1,0,0,0.1,mg,0.6,0.1,,1
-Fer,Enfants 1 à 8 ans,257,des,Poissons et fruits de mer,des,Poissons,,,0.1,0,0,0.1,mg,0.5,0.1,,2
-Fer,Enfants 1 à 8 ans,50,des,Poissons et fruits de mer,des,Mollusques et crustacés,,,0,0,0,0,mg,0.1,0,,2
-Fer,Enfants 1 à 8 ans,2428,des,Fruits et légumes,,,,,1.2,0,1.2,1.3,mg,12.1,0.4,,1
-Fer,Enfants 1 à 8 ans,2117,des,Fruits et légumes,des,Fruits,,,0.4,0,0.4,0.5,mg,4.3,0.2,,2
-Fer,Enfants 1 à 8 ans,2235,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,0.8,0,0.7,0.9,mg,7.8,0.3,,2
-Fer,Enfants 1 à 8 ans,830,des,Fruits et légumes,des,Fruits,des,Baies,0.1,0,0.1,0.1,mg,0.9,0.1,,3
-Fer,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pommes,0.1,0,0.1,0.1,mg,0.8,0,,3
-Fer,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Bananes,0.1,0,0.1,0.1,mg,0.7,0,,3
-Fer,Enfants 1 à 8 ans,572,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,0.1,0,0,0.1,mg,0.6,0.1,,3
-Fer,Enfants 1 à 8 ans,219,des,Fruits et légumes,des,Fruits,des,Melons,0,0,0,0,mg,0.3,0,,3
-Fer,Enfants 1 à 8 ans,260,des,Fruits et légumes,des,Fruits,des,Autres fruits,0,0,0,0,mg,0.3,0,,3
-Fer,Enfants 1 à 8 ans,421,des,Fruits et légumes,des,Fruits,des,Agrumes,0,0,0,0,mg,0.2,0,,3
-Fer,Enfants 1 à 8 ans,118,des,Fruits et légumes,des,Fruits,des,Pêches et nectarines,0,0,0,0,mg,0.2,0,,3
-Fer,Enfants 1 à 8 ans,47,des,Fruits et légumes,des,Fruits,des,Cerises,0,0,0,0,mg,0.1,0,,3
-Fer,Enfants 1 à 8 ans,133,des,Fruits et légumes,des,Fruits,des,Poires,0,0,0,0,mg,0.1,0,,3
-Fer,Enfants 1 à 8 ans,94,des,Fruits et légumes,des,Fruits,des,Ananas,0,0,0,0,mg,0.1,0,,3
-Fer,Enfants 1 à 8 ans,37,des,Fruits et légumes,des,Fruits,des,Prunes et pruneaux,0,0,0,0,mg,0,0,,3
-Fer,Enfants 1 à 8 ans,1773,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Autres légumes,0.4,0,0.3,0.4,mg,3.6,0.2,,3
-Fer,Enfants 1 à 8 ans,1068,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes vert foncé,0.2,0,0.2,0.2,mg,2,0.2,,3
-Fer,Enfants 1 à 8 ans,1032,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes féculents,0.2,0,0.1,0.2,mg,1.7,0.1,,3
-Fer,Enfants 1 à 8 ans,875,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes jaune foncé ou orange,0.1,0,0,0.1,mg,0.5,0.1,,3
-Fer,Enfants 1 à 8 ans,2475,des,Produits céréaliers,,,,,5.8,0.1,5.6,6,mg,56.7,0.8,,1
-Fer,Enfants 1 à 8 ans,2114,des,Produits céréaliers,des,Pains,,,2.2,0.1,2,2.3,mg,21.1,0.7,,2
-Fer,Enfants 1 à 8 ans,1282,des,Produits céréaliers,des,Céréales pour déjeuner,,,1.8,0.1,1.6,1.9,mg,17.2,0.7,,2
-Fer,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.5,0,0.4,0.5,mg,4.8,0.3,,2
-Fer,Enfants 1 à 8 ans,2037,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,1.4,0.1,1.3,1.5,mg,13.6,0.6,,2
-Fer,Enfants 1 à 8 ans,951,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,0.9,0.1,0.8,1,mg,8.6,0.6,,3
-Fer,Enfants 1 à 8 ans,805,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,0.6,0,0.5,0.7,mg,5.5,0.5,,3
-Fer,Enfants 1 à 8 ans,813,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,0.4,0,0.4,0.5,mg,4.1,0.3,,3
-Fer,Enfants 1 à 8 ans,745,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.3,0,0.2,0.3,mg,2.8,0.3,,3
-Fer,Enfants 1 à 8 ans,670,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),1,0.1,0.8,1.1,mg,9.3,0.6,,3
-Fer,Enfants 1 à 8 ans,728,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.8,0.1,0.7,0.9,mg,7.9,0.6,,3
-Fer,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.1,mg,0.7,0.1,,3
-Fer,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mg,0.1,0,,3
-Fer,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mg,0.1,0,,3
-Fer,Enfants 1 à 8 ans,1461,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.8,0.1,0.7,0.9,mg,8.1,0.5,,3
-Fer,Enfants 1 à 8 ans,834,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.5,0,0.4,0.5,mg,4.7,0.3,,3
-Fer,Enfants 1 à 8 ans,654,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0.1,0,0.1,0.1,mg,0.8,0.1,,3
-Fer,Enfants 1 à 8 ans,2072,de la,Viandes et volailles,,,,,0.9,0,0.8,1,mg,9.1,0.5,,1
-Fer,Enfants 1 à 8 ans,1003,de la,Viandes et volailles,de la,Volaille,,,0.3,0,0.2,0.3,mg,2.6,0.2,,2
-Fer,Enfants 1 à 8 ans,942,de la,Viandes et volailles,des,Viandes transformées,,,0.2,0,0.2,0.3,mg,2.4,0.4,,2
-Fer,Enfants 1 à 8 ans,999,de la,Viandes et volailles,de la,Viande rouge,,,0.4,0,0.4,0.5,mg,4.1,0.3,,2
-Fer,Enfants 1 à 8 ans,933,de la,Viandes et volailles,de la,Volaille,du,Poulet,0.3,0,0.2,0.3,mg,2.6,0.2,,3
-Fer,Enfants 1 à 8 ans,86,de la,Viandes et volailles,de la,Volaille,de la,Dinde et autres volailles,0,0,0,0,mg,0.1,0,,3
-Fer,Enfants 1 à 8 ans,375,de la,Viandes et volailles,des,Viandes transformées,des,Saucisses,0.2,0,0.1,0.2,mg,1.6,0.4,,3
-Fer,Enfants 1 à 8 ans,513,de la,Viandes et volailles,des,Viandes transformées,des,Viandes froides,0.1,0,0,0.1,mg,0.6,0.1,,3
-Fer,Enfants 1 à 8 ans,106,de la,Viandes et volailles,des,Viandes transformées,du,Porc salé,0,0,0,0,mg,0.2,0.1,,3
-Fer,Enfants 1 à 8 ans,135,de la,Viandes et volailles,des,Viandes transformées,du,Bacon,0,0,0,0,mg,0.1,0,,3
-Fer,Enfants 1 à 8 ans,779,de la,Viandes et volailles,de la,Viande rouge,du,Bœuf,0.3,0,0.3,0.4,mg,3.2,0.3,,3
-Fer,Enfants 1 à 8 ans,284,de la,Viandes et volailles,de la,Viande rouge,du,Porc frais,0.1,0,0,0.1,mg,0.6,0.1,,3
-Fer,Enfants 1 à 8 ans,43,de la,Viandes et volailles,de la,Viande rouge,de l',Agneau - veau et gibiers,0,0,0,0,mg,0.2,0.1,,3
-Fer,Enfants 1 à 8 ans,,de la,Viandes et volailles,de la,Viande rouge,des,Abats - foies et pâtés,X,X,,,mg,X,X,<10,3
-Fer,Enfants 1 à 8 ans,1789,des,Substituts de viande,,,,,0.5,0,0.4,0.6,mg,5.2,0.4,,1
-Fer,Enfants 1 à 8 ans,1450,des,Substituts de viande,des,Œufs,,,0.2,0,0.2,0.2,mg,2,0.1,,2
-Fer,Enfants 1 à 8 ans,210,des,Substituts de viande,des,Légumineuses,,,0.2,0,0.1,0.2,mg,1.5,0.3,,2
-Fer,Enfants 1 à 8 ans,749,des,Substituts de viande,des,Noix - graines et beurre d'arachides,,,0.1,0,0.1,0.2,mg,1.4,0.2,,2
-Fer,Enfants 1 à 8 ans,58,des,Substituts de viande,du,Tofu et produits sans viande,,,0,0,0,0.1,mg,0.4,0.1,,2
-Fer,Enfants 1 à 8 ans,45,des,Boissons et barres nutritionnelles,,,,,0.1,0,0,0.1,mg,0.7,0.2,,1
-Fer,Enfants 1 à 8 ans,40,des,Boissons et barres nutritionnelles,des,Substituts de repas et boissons nutritionnelles,,,0.1,0,0,0.1,mg,0.7,0.2,,2
-Fer,Enfants 1 à 8 ans,,des,Boissons et barres nutritionnelles,des,Barres nutritionnelles,,,X,X,,,mg,X,X,<10,2
-Fer,Enfants 1 à 8 ans,2295,des,Soupes - sauces - Épices et autres ingrédients,,,,,0.2,0,0.2,0.3,mg,2.1,0.2,,1
-Fer,Enfants 1 à 8 ans,761,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.1,0,0,0.1,mg,0.6,0.1,,2
-Fer,Enfants 1 à 8 ans,532,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0.1,0,0,0.1,mg,0.7,0.1,,2
-Fer,Enfants 1 à 8 ans,2205,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.1,0,0.1,0.1,mg,0.8,0.1,,2
-Fer,Enfants 1 à 8 ans,2106,des,Confiseries - sucres et grignotines salées,,,,,0.5,0,0.4,0.6,mg,4.9,0.4,,1
-Fer,Enfants 1 à 8 ans,1048,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,0.2,0,0.1,0.2,mg,1.5,0.1,,2
-Fer,Enfants 1 à 8 ans,497,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,0.1,0,0.1,0.1,mg,0.7,0.1,,2
-Fer,Enfants 1 à 8 ans,615,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0.1,0,0.1,0.1,mg,1.2,0.1,,2
-Fer,Enfants 1 à 8 ans,1642,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.2,0,0.1,0.2,mg,1.6,0.4,,2
-Fer,Enfants 1 à 8 ans,548,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0.1,0,0.1,0.1,mg,1,0.1,,3
-Fer,Enfants 1 à 8 ans,131,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0,0,0,0,mg,0.3,0.1,,3
-Fer,Enfants 1 à 8 ans,557,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0,0,0,0,mg,0.2,0,,3
-Fer,Enfants 1 à 8 ans,346,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0,0,0,0.1,mg,0.4,0.1,,3
-Fer,Enfants 1 à 8 ans,184,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,mg,0.3,0,,3
-Fer,Enfants 1 à 8 ans,720,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.2,0,0.1,0.2,mg,1.5,0.4,,3
-Fer,Enfants 1 à 8 ans,257,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,mg,0.1,0,,3
-Fer,Enfants 1 à 8 ans,1341,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,mg,0,0,,3
-Fer,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,mg,X,X,<10,3
+Fer,Enfants 1 à 8 ans,122,des,Aliments pour bébés,,,,,F,F,,,mg,F,F,F,1
+Fer,Enfants 1 à 8 ans,95,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0.2,0,0.1,0.3,mg,1.6,0.4,,2
+Fer,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0.1,0,0,0.1,mg,0.8,0.2,,2
+Fer,Enfants 1 à 8 ans,2443,des,Boissons (excluant laits),,,,,0.3,0,0.3,0.4,mg,3.2,0.2,,1
+Fer,Enfants 1 à 8 ans,20,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0,mg,0,0,,2
+Fer,Enfants 1 à 8 ans,141,des,Boissons (excluant laits),du,Café et thé,,,0,0,0,0,mg,0,0,,2
+Fer,Enfants 1 à 8 ans,,des,Boissons (excluant laits),des,Boissons Énergisantes,,,X,X,,,mg,X,X,<10,2
+Fer,Enfants 1 à 8 ans,357,des,Boissons (excluant laits),des,Boissons aux fruits,,,0.1,0,0,0.1,mg,0.6,0.1,,2
+Fer,Enfants 1 à 8 ans,1159,des,Boissons (excluant laits),des,Jus de fruit,,,0.2,0,0.2,0.2,mg,2,0.2,,2
+Fer,Enfants 1 à 8 ans,77,des,Boissons (excluant laits),des,Autres boissons,,,0,0,0,0,mg,0.2,0,,2
+Fer,Enfants 1 à 8 ans,142,des,Boissons (excluant laits),des,Boissons gazeuses,,,0,0,0,0,mg,0.1,0,,2
+Fer,Enfants 1 à 8 ans,21,des,Boissons (excluant laits),des,Boissons pour sportifs,,,0,0,0,0,mg,0,0,,2
+Fer,Enfants 1 à 8 ans,52,des,Boissons (excluant laits),des,Jus de tomates et de légumes,,,0,0,0,0,mg,0.1,0,,2
+Fer,Enfants 1 à 8 ans,,des,Boissons (excluant laits),de l',Eau vitaminée,,,X,X,,,mg,X,X,<10,2
+Fer,Enfants 1 à 8 ans,2344,des,Boissons (excluant laits),de l',Eau,,,0,0,0,0,mg,0.1,0,,2
+Fer,Enfants 1 à 8 ans,133,des,Boissons (excluant laits),du,Café et thé,du,Thé,0,0,0,0,mg,0,0,,3
+Fer,Enfants 1 à 8 ans,,des,Boissons (excluant laits),du,Café et thé,du,Café,X,X,,,mg,X,X,<10,3
+Fer,Enfants 1 à 8 ans,2436,des,Produits laitiers et Boissons à base de plantes,,,,,0.3,0,0.3,0.3,mg,2.8,0.1,,1
+Fer,Enfants 1 à 8 ans,1632,des,Produits laitiers et Boissons à base de plantes,des,Fromages,,,0.1,0,0.1,0.1,mg,0.6,0,,2
+Fer,Enfants 1 à 8 ans,2341,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,0.2,0,0.1,0.2,mg,1.6,0.1,,2
+Fer,Enfants 1 à 8 ans,1032,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,,,0.1,0,0,0.1,mg,0.6,0.1,,2
+Fer,Enfants 1 à 8 ans,1810,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,0.1,0,0,0.1,mg,0.5,0,,3
+Fer,Enfants 1 à 8 ans,854,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,0,0,0,0,mg,0.4,0.1,,3
+Fer,Enfants 1 à 8 ans,128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0,0,0,0,mg,0.3,0,,3
+Fer,Enfants 1 à 8 ans,1078,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,0,0,0,0,mg,0.3,0,,3
+Fer,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0,0,0,0,mg,0,0,,3
+Fer,Enfants 1 à 8 ans,739,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0,0,0,0,mg,0,0,,3
+Fer,Enfants 1 à 8 ans,2270,des,Graisses et huiles,,,,,0,0,0,0,mg,0.1,0,,1
+Fer,Enfants 1 à 8 ans,83,des,Graisses et huiles,des,Graisses animales,,,0,0,0,0,mg,0,0,,2
+Fer,Enfants 1 à 8 ans,657,des,Graisses et huiles,du,Beurre,,,0,0,0,0,mg,0,0,,2
+Fer,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Margarines,,,0,0,0,0,mg,0,0,,2
+Fer,Enfants 1 à 8 ans,463,des,Graisses et huiles,des,Sauces pour salade,,,0,0,0,0,mg,0.1,0,,2
+Fer,Enfants 1 à 8 ans,1035,des,Graisses et huiles,du,Shortening,,,0,0,0,0,mg,0,0,,2
+Fer,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Huiles végétales,,,0,0,0,0,mg,0.1,0,,2
+Fer,Enfants 1 à 8 ans,298,des,Poissons et fruits de mer,,,,,0.1,0,0,0.1,mg,0.6,0.1,,1
+Fer,Enfants 1 à 8 ans,257,des,Poissons et fruits de mer,des,Poissons,,,0.1,0,0,0.1,mg,0.5,0.1,,2
+Fer,Enfants 1 à 8 ans,50,des,Poissons et fruits de mer,des,Mollusques et crustacés,,,0,0,0,0,mg,0.1,0,,2
+Fer,Enfants 1 à 8 ans,2428,des,Fruits et légumes,,,,,1.2,0,1.2,1.3,mg,12.1,0.4,,1
+Fer,Enfants 1 à 8 ans,2117,des,Fruits et légumes,des,Fruits,,,0.4,0,0.4,0.5,mg,4.3,0.2,,2
+Fer,Enfants 1 à 8 ans,2235,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,0.8,0,0.7,0.9,mg,7.8,0.3,,2
+Fer,Enfants 1 à 8 ans,830,des,Fruits et légumes,des,Fruits,des,Baies,0.1,0,0.1,0.1,mg,0.9,0.1,,3
+Fer,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pommes,0.1,0,0.1,0.1,mg,0.8,0,,3
+Fer,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Bananes,0.1,0,0.1,0.1,mg,0.7,0,,3
+Fer,Enfants 1 à 8 ans,572,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,0.1,0,0,0.1,mg,0.6,0.1,,3
+Fer,Enfants 1 à 8 ans,219,des,Fruits et légumes,des,Fruits,des,Melons,0,0,0,0,mg,0.3,0,,3
+Fer,Enfants 1 à 8 ans,260,des,Fruits et légumes,des,Fruits,des,Autres fruits,0,0,0,0,mg,0.3,0,,3
+Fer,Enfants 1 à 8 ans,421,des,Fruits et légumes,des,Fruits,des,Agrumes,0,0,0,0,mg,0.2,0,,3
+Fer,Enfants 1 à 8 ans,118,des,Fruits et légumes,des,Fruits,des,Pêches et nectarines,0,0,0,0,mg,0.2,0,,3
+Fer,Enfants 1 à 8 ans,47,des,Fruits et légumes,des,Fruits,des,Cerises,0,0,0,0,mg,0.1,0,,3
+Fer,Enfants 1 à 8 ans,133,des,Fruits et légumes,des,Fruits,des,Poires,0,0,0,0,mg,0.1,0,,3
+Fer,Enfants 1 à 8 ans,94,des,Fruits et légumes,des,Fruits,des,Ananas,0,0,0,0,mg,0.1,0,,3
+Fer,Enfants 1 à 8 ans,37,des,Fruits et légumes,des,Fruits,des,Prunes et pruneaux,0,0,0,0,mg,0,0,,3
+Fer,Enfants 1 à 8 ans,1773,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Autres légumes,0.4,0,0.3,0.4,mg,3.6,0.2,,3
+Fer,Enfants 1 à 8 ans,1068,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes vert foncé,0.2,0,0.2,0.2,mg,2,0.2,,3
+Fer,Enfants 1 à 8 ans,1032,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes féculents,0.2,0,0.1,0.2,mg,1.7,0.1,,3
+Fer,Enfants 1 à 8 ans,875,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes jaune foncé ou orange,0.1,0,0,0.1,mg,0.5,0.1,,3
+Fer,Enfants 1 à 8 ans,2475,des,Produits céréaliers,,,,,5.8,0.1,5.6,6,mg,56.7,0.8,,1
+Fer,Enfants 1 à 8 ans,2114,des,Produits céréaliers,des,Pains,,,2.2,0.1,2,2.3,mg,21.1,0.7,,2
+Fer,Enfants 1 à 8 ans,1282,des,Produits céréaliers,des,Céréales pour déjeuner,,,1.8,0.1,1.6,1.9,mg,17.2,0.7,,2
+Fer,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.5,0,0.4,0.5,mg,4.8,0.3,,2
+Fer,Enfants 1 à 8 ans,2037,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,1.4,0.1,1.3,1.5,mg,13.6,0.6,,2
+Fer,Enfants 1 à 8 ans,951,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,0.9,0.1,0.8,1,mg,8.6,0.6,,3
+Fer,Enfants 1 à 8 ans,805,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,0.6,0,0.5,0.7,mg,5.5,0.5,,3
+Fer,Enfants 1 à 8 ans,813,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,0.4,0,0.4,0.5,mg,4.1,0.3,,3
+Fer,Enfants 1 à 8 ans,745,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.3,0,0.2,0.3,mg,2.8,0.3,,3
+Fer,Enfants 1 à 8 ans,670,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),1,0.1,0.8,1.1,mg,9.3,0.6,,3
+Fer,Enfants 1 à 8 ans,728,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.8,0.1,0.7,0.9,mg,7.9,0.6,,3
+Fer,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.1,mg,0.7,0.1,,3
+Fer,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mg,0.1,0,,3
+Fer,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mg,0.1,0,,3
+Fer,Enfants 1 à 8 ans,1461,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.8,0.1,0.7,0.9,mg,8.1,0.5,,3
+Fer,Enfants 1 à 8 ans,834,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.5,0,0.4,0.5,mg,4.7,0.3,,3
+Fer,Enfants 1 à 8 ans,654,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0.1,0,0.1,0.1,mg,0.8,0.1,,3
+Fer,Enfants 1 à 8 ans,2072,de la,Viandes et volailles,,,,,0.9,0,0.8,1,mg,9.1,0.5,,1
+Fer,Enfants 1 à 8 ans,1003,de la,Viandes et volailles,de la,Volaille,,,0.3,0,0.2,0.3,mg,2.6,0.2,,2
+Fer,Enfants 1 à 8 ans,942,de la,Viandes et volailles,des,Viandes transformées,,,0.2,0,0.2,0.3,mg,2.4,0.4,,2
+Fer,Enfants 1 à 8 ans,999,de la,Viandes et volailles,de la,Viande rouge,,,0.4,0,0.4,0.5,mg,4.1,0.3,,2
+Fer,Enfants 1 à 8 ans,933,de la,Viandes et volailles,de la,Volaille,du,Poulet,0.3,0,0.2,0.3,mg,2.6,0.2,,3
+Fer,Enfants 1 à 8 ans,86,de la,Viandes et volailles,de la,Volaille,de la,Dinde et autres volailles,0,0,0,0,mg,0.1,0,,3
+Fer,Enfants 1 à 8 ans,375,de la,Viandes et volailles,des,Viandes transformées,des,Saucisses,0.2,0,0.1,0.2,mg,1.6,0.4,,3
+Fer,Enfants 1 à 8 ans,513,de la,Viandes et volailles,des,Viandes transformées,des,Viandes froides,0.1,0,0,0.1,mg,0.6,0.1,,3
+Fer,Enfants 1 à 8 ans,106,de la,Viandes et volailles,des,Viandes transformées,du,Porc salé,0,0,0,0,mg,0.2,0.1,,3
+Fer,Enfants 1 à 8 ans,135,de la,Viandes et volailles,des,Viandes transformées,du,Bacon,0,0,0,0,mg,0.1,0,,3
+Fer,Enfants 1 à 8 ans,779,de la,Viandes et volailles,de la,Viande rouge,du,Bœuf,0.3,0,0.3,0.4,mg,3.2,0.3,,3
+Fer,Enfants 1 à 8 ans,284,de la,Viandes et volailles,de la,Viande rouge,du,Porc frais,0.1,0,0,0.1,mg,0.6,0.1,,3
+Fer,Enfants 1 à 8 ans,43,de la,Viandes et volailles,de la,Viande rouge,de l',Agneau - veau et gibiers,0,0,0,0,mg,0.2,0.1,,3
+Fer,Enfants 1 à 8 ans,,de la,Viandes et volailles,de la,Viande rouge,des,Abats - foies et pâtés,X,X,,,mg,X,X,<10,3
+Fer,Enfants 1 à 8 ans,1789,des,Substituts de viande,,,,,0.5,0,0.4,0.6,mg,5.2,0.4,,1
+Fer,Enfants 1 à 8 ans,1450,des,Substituts de viande,des,Œufs,,,0.2,0,0.2,0.2,mg,2,0.1,,2
+Fer,Enfants 1 à 8 ans,210,des,Substituts de viande,des,Légumineuses,,,0.2,0,0.1,0.2,mg,1.5,0.3,,2
+Fer,Enfants 1 à 8 ans,749,des,Substituts de viande,des,Noix - graines et beurre d'arachides,,,0.1,0,0.1,0.2,mg,1.4,0.2,,2
+Fer,Enfants 1 à 8 ans,58,des,Substituts de viande,du,Tofu et produits sans viande,,,0,0,0,0.1,mg,0.4,0.1,,2
+Fer,Enfants 1 à 8 ans,45,des,Boissons et barres nutritionnelles,,,,,0.1,0,0,0.1,mg,0.7,0.2,,1
+Fer,Enfants 1 à 8 ans,40,des,Boissons et barres nutritionnelles,des,Substituts de repas et boissons nutritionnelles,,,0.1,0,0,0.1,mg,0.7,0.2,,2
+Fer,Enfants 1 à 8 ans,,des,Boissons et barres nutritionnelles,des,Barres nutritionnelles,,,X,X,,,mg,X,X,<10,2
+Fer,Enfants 1 à 8 ans,2295,des,Soupes - sauces - Épices et autres ingrédients,,,,,0.2,0,0.2,0.3,mg,2.1,0.2,,1
+Fer,Enfants 1 à 8 ans,761,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.1,0,0,0.1,mg,0.6,0.1,,2
+Fer,Enfants 1 à 8 ans,532,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0.1,0,0,0.1,mg,0.7,0.1,,2
+Fer,Enfants 1 à 8 ans,2205,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.1,0,0.1,0.1,mg,0.8,0.1,,2
+Fer,Enfants 1 à 8 ans,2106,des,Confiseries - sucres et grignotines salées,,,,,0.5,0,0.4,0.6,mg,4.9,0.4,,1
+Fer,Enfants 1 à 8 ans,1048,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,0.2,0,0.1,0.2,mg,1.5,0.1,,2
+Fer,Enfants 1 à 8 ans,497,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,0.1,0,0.1,0.1,mg,0.7,0.1,,2
+Fer,Enfants 1 à 8 ans,615,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0.1,0,0.1,0.1,mg,1.2,0.1,,2
+Fer,Enfants 1 à 8 ans,1642,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.2,0,0.1,0.2,mg,1.6,0.4,,2
+Fer,Enfants 1 à 8 ans,548,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0.1,0,0.1,0.1,mg,1,0.1,,3
+Fer,Enfants 1 à 8 ans,131,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0,0,0,0,mg,0.3,0.1,,3
+Fer,Enfants 1 à 8 ans,557,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0,0,0,0,mg,0.2,0,,3
+Fer,Enfants 1 à 8 ans,346,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0,0,0,0.1,mg,0.4,0.1,,3
+Fer,Enfants 1 à 8 ans,184,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,mg,0.3,0,,3
+Fer,Enfants 1 à 8 ans,720,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.2,0,0.1,0.2,mg,1.5,0.4,,3
+Fer,Enfants 1 à 8 ans,257,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,mg,0.1,0,,3
+Fer,Enfants 1 à 8 ans,1341,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,mg,0,0,,3
+Fer,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,mg,X,X,<10,3
 Potassium,Population 1 an et +,186,des,Aliments pour bébés,,,,,1.8,0.4,1.1,2.5,mg,0.1,0,E,1
 Potassium,Population 1 an et +,154,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,1.3,0.3,0.7,2,mg,0.1,0,E,2
 Potassium,Population 1 an et +,51,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0.5,0.1,0.2,0.7,mg,0,0,E,2
@@ -2782,7 +2782,7 @@ Potassium,Population 1 an et +,6318,des,Fruits et légumes,des,Légumes incluant
 Potassium,Population 1 an et +,19327,des,Produits céréaliers,,,,,251.1,2.5,246.1,256.1,mg,9.6,0.1,,1
 Potassium,Population 1 an et +,16168,des,Produits céréaliers,des,Pains,,,125.5,1.9,121.8,129.3,mg,4.8,0.1,,2
 Potassium,Population 1 an et +,6966,des,Produits céréaliers,des,Céréales pour déjeuner,,,45.6,1.5,42.7,48.5,mg,1.7,0.1,,2
-Potassium,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,18.3,0.7,17,19.7,mg,0.7,0,,2
+Potassium,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,18.3,0.7,17,19.7,mg,0.7,0,,2
 Potassium,Population 1 an et +,14820,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,61.6,1.1,59.4,63.8,mg,2.4,0,,2
 Potassium,Population 1 an et +,8159,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,40.9,1.1,38.8,43,mg,1.6,0,,3
 Potassium,Population 1 an et +,5962,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,43,1.2,40.6,45.5,mg,1.6,0,,3
@@ -2790,10 +2790,10 @@ Potassium,Population 1 an et +,6257,des,Produits céréaliers,des,Pains,des,Autr
 Potassium,Population 1 an et +,2918,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,5.6,0.3,5,6.2,mg,0.2,0,,3
 Potassium,Population 1 an et +,4760,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,40.4,1.5,37.5,43.3,mg,1.5,0.1,,3
 Potassium,Population 1 an et +,2573,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),5.2,0.3,4.7,5.7,mg,0.2,0,,3
-Potassium,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,7.9,0.5,6.9,8.9,mg,0.3,0,,3
-Potassium,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.6,0.1,0.4,0.8,mg,0,0,E,3
-Potassium,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.2,0,0.1,0.3,mg,0,0,,3
-Potassium,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
+Potassium,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,7.9,0.5,6.9,8.9,mg,0.3,0,,3
+Potassium,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.6,0.1,0.4,0.8,mg,0,0,E,3
+Potassium,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.2,0,0.1,0.3,mg,0,0,,3
+Potassium,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
 Potassium,Population 1 an et +,11102,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,30,0.9,28.3,31.8,mg,1.1,0,,3
 Potassium,Population 1 an et +,4543,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,16.3,0.6,15.2,17.5,mg,0.6,0,,3
 Potassium,Population 1 an et +,4598,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,15.3,0.6,14.1,16.4,mg,0.6,0,,3
@@ -2896,7 +2896,7 @@ Potassium,Hommes adultes 19 ans +,1991,des,Fruits et légumes,des,Légumes inclu
 Potassium,Hommes adultes 19 ans +,6068,des,Produits céréaliers,,,,,283.3,4.5,274.4,292.3,mg,9.6,0.2,,1
 Potassium,Hommes adultes 19 ans +,5104,des,Produits céréaliers,des,Pains,,,144.7,3.5,137.9,151.5,mg,4.9,0.1,,2
 Potassium,Hommes adultes 19 ans +,1921,des,Produits céréaliers,des,Céréales pour déjeuner,,,50.6,2.7,45.3,56,mg,1.7,0.1,,2
-Potassium,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,18.8,1.4,16.1,21.5,mg,0.6,0,,2
+Potassium,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,18.8,1.4,16.1,21.5,mg,0.6,0,,2
 Potassium,Hommes adultes 19 ans +,4551,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,69.2,2.2,65,73.4,mg,2.3,0.1,,2
 Potassium,Hommes adultes 19 ans +,2752,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,51.4,2.1,47.2,55.6,mg,1.7,0.1,,3
 Potassium,Hommes adultes 19 ans +,1980,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,48.9,2.3,44.4,53.3,mg,1.7,0.1,,3
@@ -2904,9 +2904,9 @@ Potassium,Hommes adultes 19 ans +,1885,des,Produits céréaliers,des,Pains,des,A
 Potassium,Hommes adultes 19 ans +,593,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,4.2,0.4,3.4,4.9,mg,0.1,0,,3
 Potassium,Hommes adultes 19 ans +,1481,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,47.2,2.7,41.9,52.5,mg,1.6,0.1,,3
 Potassium,Hommes adultes 19 ans +,523,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),3.5,0.4,2.8,4.1,mg,0.1,0,,3
-Potassium,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,8.9,1.1,6.7,11.1,mg,0.3,0,,3
-Potassium,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.6,0.2,0.1,1.1,mg,0,0,E,3
-Potassium,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,F,F,,,mg,F,F,F,3
+Potassium,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,8.9,1.1,6.7,11.1,mg,0.3,0,,3
+Potassium,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.6,0.2,0.1,1.1,mg,0,0,E,3
+Potassium,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,F,F,,,mg,F,F,F,3
 Potassium,Hommes adultes 19 ans +,3442,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,35.4,1.7,32,38.9,mg,1.2,0.1,,3
 Potassium,Hommes adultes 19 ans +,1250,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,16.9,1,14.9,18.9,mg,0.6,0,,3
 Potassium,Hommes adultes 19 ans +,1449,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,16.8,1,14.8,18.8,mg,0.6,0,,3
@@ -3009,7 +3009,7 @@ Potassium,Femmes adultes* 19 ans +,2348,des,Fruits et légumes,des,Légumes incl
 Potassium,Femmes adultes* 19 ans +,6669,des,Produits céréaliers,,,,,216.5,3.7,209.3,223.7,mg,9,0.2,,1
 Potassium,Femmes adultes* 19 ans +,5520,des,Produits céréaliers,des,Pains,,,109.6,2.4,104.9,114.2,mg,4.6,0.1,,2
 Potassium,Femmes adultes* 19 ans +,2230,des,Produits céréaliers,des,Céréales pour déjeuner,,,41.2,2.2,36.7,45.6,mg,1.7,0.1,,2
-Potassium,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,12.9,0.8,11.4,14.5,mg,0.5,0,,2
+Potassium,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,12.9,0.8,11.4,14.5,mg,0.5,0,,2
 Potassium,Femmes adultes* 19 ans +,4893,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,52.9,1.8,49.4,56.4,mg,2.2,0.1,,2
 Potassium,Femmes adultes* 19 ans +,2239,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,42.2,1.7,38.9,45.5,mg,1.8,0.1,,3
 Potassium,Femmes adultes* 19 ans +,1994,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,30.2,1.7,26.8,33.6,mg,1.3,0.1,,3
@@ -3017,10 +3017,10 @@ Potassium,Femmes adultes* 19 ans +,2551,des,Produits céréaliers,des,Pains,des,
 Potassium,Femmes adultes* 19 ans +,914,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,5,0.6,3.9,6.2,mg,0.2,0,,3
 Potassium,Femmes adultes* 19 ans +,1756,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,38.4,2.3,34,42.9,mg,1.6,0.1,,3
 Potassium,Femmes adultes* 19 ans +,555,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),2.8,0.3,2.2,3.3,mg,0.1,0,,3
-Potassium,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,4.4,0.5,3.4,5.4,mg,0.2,0,,3
-Potassium,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.3,0.1,0.2,0.5,mg,0,0,E,3
-Potassium,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,F,F,,,mg,F,F,F,3
-Potassium,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
+Potassium,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,4.4,0.5,3.4,5.4,mg,0.2,0,,3
+Potassium,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.3,0.1,0.2,0.5,mg,0,0,E,3
+Potassium,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,F,F,,,mg,F,F,F,3
+Potassium,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
 Potassium,Femmes adultes* 19 ans +,3664,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,25.5,1.3,22.9,28.1,mg,1.1,0.1,,3
 Potassium,Femmes adultes* 19 ans +,1358,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,13.2,0.9,11.5,14.9,mg,0.6,0,,3
 Potassium,Femmes adultes* 19 ans +,1522,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,14.2,0.9,12.3,16,mg,0.6,0,,3
@@ -3064,119 +3064,119 @@ Potassium,Femmes adultes* 19 ans +,1529,des,Confiseries - sucres et grignotines 
 Potassium,Femmes adultes* 19 ans +,773,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,1.2,0.1,1,1.4,mg,0.1,0,,3
 Potassium,Femmes adultes* 19 ans +,360,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mg,0,0,,3
 Potassium,Femmes adultes* 19 ans +,4229,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,1.1,0.1,1,1.3,mg,0,0,,3
-Potassium,Enfants 1 à 8 ans,122,des,Aliments pour bébés,,,,,11.9,2.4,7.1,16.6,mg,0.5,0.1,E,1
-Potassium,Enfants 1 à 8 ans,95,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,6.5,1.6,3.4,9.6,mg,0.3,0.1,E,2
-Potassium,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparations pour nourrissons,,,5.4,1.5,2.4,8.3,mg,0.2,0.1,E,2
-Potassium,Enfants 1 à 8 ans,2443,des,Boissons (excluant laits),,,,,214,9,196.3,231.8,mg,9.8,0.4,,1
-Potassium,Enfants 1 à 8 ans,20,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0.1,mg,0,0,,2
-Potassium,Enfants 1 à 8 ans,141,des,Boissons (excluant laits),du,Café et thé,,,F,F,,,mg,F,F,F,2
-Potassium,Enfants 1 à 8 ans,,des,Boissons (excluant laits),des,Boissons Énergisantes,,,X,X,,,mg,X,X,<10,2
-Potassium,Enfants 1 à 8 ans,357,des,Boissons (excluant laits),des,Boissons aux fruits,,,27.2,3.6,20.1,34.3,mg,1.2,0.2,,2
-Potassium,Enfants 1 à 8 ans,1159,des,Boissons (excluant laits),des,Jus de fruit,,,164.7,7.9,149.2,180.1,mg,7.6,0.3,,2
-Potassium,Enfants 1 à 8 ans,77,des,Boissons (excluant laits),des,Autres boissons,,,6.6,1.4,3.7,9.4,mg,0.3,0.1,E,2
-Potassium,Enfants 1 à 8 ans,142,des,Boissons (excluant laits),des,Boissons gazeuses,,,0.3,0,0.2,0.4,mg,0,0,,2
-Potassium,Enfants 1 à 8 ans,21,des,Boissons (excluant laits),des,Boissons pour sportifs,,,F,F,,,mg,F,F,F,2
-Potassium,Enfants 1 à 8 ans,52,des,Boissons (excluant laits),des,Jus de tomates et de légumes,,,6,1.6,2.9,9.1,mg,0.3,0.1,E,2
-Potassium,Enfants 1 à 8 ans,,des,Boissons (excluant laits),de l',Eau vitaminée,,,X,X,,,mg,X,X,<10,2
-Potassium,Enfants 1 à 8 ans,2344,des,Boissons (excluant laits),de l',Eau,,,3.9,0.1,3.6,4.2,mg,0.2,0,,2
-Potassium,Enfants 1 à 8 ans,,des,Boissons (excluant laits),du,Café et thé,du,Café,X,X,,,mg,X,X,<10,3
-Potassium,Enfants 1 à 8 ans,133,des,Boissons (excluant laits),du,Café et thé,du,Thé,F,F,,,mg,F,F,F,3
-Potassium,Enfants 1 à 8 ans,2436,des,Produits laitiers et Boissons à base de plantes,,,,,607.1,15,577.6,636.6,mg,27.9,0.6,,1
-Potassium,Enfants 1 à 8 ans,1632,des,Produits laitiers et Boissons à base de plantes,des,Fromages,,,35,2.1,30.9,39,mg,1.6,0.1,,2
-Potassium,Enfants 1 à 8 ans,2341,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,493.7,14,466.1,521.3,mg,22.7,0.5,,2
-Potassium,Enfants 1 à 8 ans,1032,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,,,78.4,3.9,70.8,86,mg,3.6,0.2,,2
-Potassium,Enfants 1 à 8 ans,1810,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,231.8,10.2,211.8,251.8,mg,10.6,0.4,,3
-Potassium,Enfants 1 à 8 ans,1078,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,141.2,8.8,123.8,158.5,mg,6.5,0.4,,3
-Potassium,Enfants 1 à 8 ans,854,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,88,9.9,68.6,107.4,mg,4,0.4,,3
-Potassium,Enfants 1 à 8 ans,739,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,14.5,2.4,9.7,19.3,mg,0.7,0.1,,3
-Potassium,Enfants 1 à 8 ans,128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,12.1,2.1,8.1,16.2,mg,0.6,0.1,E,3
-Potassium,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,6.1,1.5,3.2,9,mg,0.3,0.1,E,3
-Potassium,Enfants 1 à 8 ans,2270,des,Graisses et huiles,,,,,3.2,0.2,2.8,3.6,mg,0.1,0,,1
-Potassium,Enfants 1 à 8 ans,83,des,Graisses et huiles,des,Graisses animales,,,0.1,0,0,0.1,mg,0,0,,2
-Potassium,Enfants 1 à 8 ans,657,des,Graisses et huiles,du,Beurre,,,0.4,0,0.4,0.5,mg,0,0,,2
-Potassium,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Margarines,,,1.7,0.1,1.5,1.8,mg,0.1,0,,2
-Potassium,Enfants 1 à 8 ans,463,des,Graisses et huiles,des,Sauces pour salade,,,1.1,0.2,0.7,1.4,mg,0,0,E,2
-Potassium,Enfants 1 à 8 ans,1035,des,Graisses et huiles,du,Shortening,,,0,0,0,0,mg,0,0,,2
-Potassium,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Huiles végétales,,,0,0,0,0,mg,0,0,,2
-Potassium,Enfants 1 à 8 ans,298,des,Poissons et fruits de mer,,,,,29.3,4.4,20.6,38,mg,1.3,0.2,,1
-Potassium,Enfants 1 à 8 ans,257,des,Poissons et fruits de mer,des,Poissons,,,28,4.3,19.6,36.5,mg,1.3,0.2,,2
-Potassium,Enfants 1 à 8 ans,50,des,Poissons et fruits de mer,des,Mollusques et crustacés,,,1.3,0.3,0.7,1.9,mg,0.1,0,E,2
-Potassium,Enfants 1 à 8 ans,2428,des,Fruits et légumes,,,,,680.1,18.2,644.4,715.8,mg,31.2,0.6,,1
-Potassium,Enfants 1 à 8 ans,2117,des,Fruits et légumes,des,Fruits,,,331.3,11.1,309.5,353.1,mg,15.2,0.4,,2
-Potassium,Enfants 1 à 8 ans,2235,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,348.8,12.7,323.9,373.6,mg,16,0.5,,2
-Potassium,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Bananes,103.9,6,92.1,115.8,mg,4.8,0.3,,3
-Potassium,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pommes,57.8,3.6,50.7,65,mg,2.7,0.2,,3
-Potassium,Enfants 1 à 8 ans,421,des,Fruits et légumes,des,Fruits,des,Agrumes,31,2.7,25.8,36.3,mg,1.4,0.1,,3
-Potassium,Enfants 1 à 8 ans,572,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,31.5,4.5,22.7,40.3,mg,1.4,0.2,,3
-Potassium,Enfants 1 à 8 ans,830,des,Fruits et légumes,des,Fruits,des,Baies,27.4,2.3,22.8,32,mg,1.3,0.1,,3
-Potassium,Enfants 1 à 8 ans,219,des,Fruits et légumes,des,Fruits,des,Melons,28,4.2,19.7,36.2,mg,1.3,0.2,,3
-Potassium,Enfants 1 à 8 ans,260,des,Fruits et légumes,des,Fruits,des,Autres fruits,23.7,3.3,17.3,30.2,mg,1.1,0.2,,3
-Potassium,Enfants 1 à 8 ans,118,des,Fruits et légumes,des,Fruits,des,Pêches et nectarines,11.2,2.1,7.1,15.3,mg,0.5,0.1,E,3
-Potassium,Enfants 1 à 8 ans,133,des,Fruits et légumes,des,Fruits,des,Poires,7.7,1.4,5,10.5,mg,0.4,0.1,E,3
-Potassium,Enfants 1 à 8 ans,94,des,Fruits et légumes,des,Fruits,des,Ananas,2.9,0.6,1.6,4.1,mg,0.1,0,E,3
-Potassium,Enfants 1 à 8 ans,37,des,Fruits et légumes,des,Fruits,des,Prunes et pruneaux,2.7,0.9,0.9,4.4,mg,0.1,0,E,3
-Potassium,Enfants 1 à 8 ans,47,des,Fruits et légumes,des,Fruits,des,Cerises,F,F,,,mg,F,F,F,3
-Potassium,Enfants 1 à 8 ans,1773,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Autres légumes,153.7,7.3,139.4,168,mg,7.1,0.3,,3
-Potassium,Enfants 1 à 8 ans,1032,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes féculents,115.9,8.3,99.6,132.2,mg,5.3,0.4,,3
-Potassium,Enfants 1 à 8 ans,1068,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes vert foncé,44.8,3.6,37.7,51.8,mg,2.1,0.2,,3
-Potassium,Enfants 1 à 8 ans,875,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes jaune foncé ou orange,34.4,3.3,27.8,41,mg,1.6,0.1,,3
-Potassium,Enfants 1 à 8 ans,2475,des,Produits céréaliers,,,,,216.1,4.5,207.3,224.9,mg,9.9,0.2,,1
-Potassium,Enfants 1 à 8 ans,2114,des,Produits céréaliers,des,Pains,,,99.7,3.8,92.3,107.2,mg,4.6,0.2,,2
-Potassium,Enfants 1 à 8 ans,1282,des,Produits céréaliers,des,Céréales pour déjeuner,,,39,2,35.2,42.8,mg,1.8,0.1,,2
-Potassium,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,23.9,1.3,21.4,26.4,mg,1.1,0.1,,2
-Potassium,Enfants 1 à 8 ans,2037,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,53.5,2,49.5,57.4,mg,2.5,0.1,,2
-Potassium,Enfants 1 à 8 ans,813,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,32.1,1.9,28.3,35.9,mg,1.5,0.1,,3
-Potassium,Enfants 1 à 8 ans,951,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,31.2,2.9,25.5,37,mg,1.4,0.1,,3
-Potassium,Enfants 1 à 8 ans,805,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,25.1,2.1,21,29.3,mg,1.2,0.1,,3
-Potassium,Enfants 1 à 8 ans,745,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,11.3,1.1,9.1,13.4,mg,0.5,0,,3
-Potassium,Enfants 1 à 8 ans,728,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,27,2,23.1,30.9,mg,1.2,0.1,,3
-Potassium,Enfants 1 à 8 ans,670,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),12,0.8,10.4,13.6,mg,0.6,0,,3
-Potassium,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,8.4,0.8,6.9,9.9,mg,0.4,0,,3
-Potassium,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.3,0.1,0.1,0.6,mg,0,0,E,3
-Potassium,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,F,F,,,mg,F,F,F,3
-Potassium,Enfants 1 à 8 ans,1461,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,21.6,1.4,18.9,24.3,mg,1,0.1,,3
-Potassium,Enfants 1 à 8 ans,834,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,20.3,1.5,17.3,23.2,mg,0.9,0.1,,3
-Potassium,Enfants 1 à 8 ans,654,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,11.6,0.9,9.9,13.3,mg,0.5,0,,3
-Potassium,Enfants 1 à 8 ans,2072,de la,Viandes et volailles,,,,,196,8.2,179.9,212.2,mg,9,0.3,,1
-Potassium,Enfants 1 à 8 ans,1003,de la,Viandes et volailles,de la,Volaille,,,65.4,4.4,56.8,74,mg,3,0.2,,2
-Potassium,Enfants 1 à 8 ans,942,de la,Viandes et volailles,des,Viandes transformées,,,66.4,5.9,54.8,78.1,mg,3.1,0.3,,2
-Potassium,Enfants 1 à 8 ans,999,de la,Viandes et volailles,de la,Viande rouge,,,64.2,4.2,55.9,72.5,mg,2.9,0.2,,2
-Potassium,Enfants 1 à 8 ans,933,de la,Viandes et volailles,de la,Volaille,du,Poulet,61.3,4.1,53.3,69.3,mg,2.8,0.2,,3
-Potassium,Enfants 1 à 8 ans,86,de la,Viandes et volailles,de la,Volaille,de la,Dinde et autres volailles,F,F,,,mg,F,F,F,3
-Potassium,Enfants 1 à 8 ans,375,de la,Viandes et volailles,des,Viandes transformées,des,Saucisses,31.4,5.2,21.2,41.6,mg,1.4,0.2,,3
-Potassium,Enfants 1 à 8 ans,513,de la,Viandes et volailles,des,Viandes transformées,des,Viandes froides,26.9,2.5,22,31.8,mg,1.2,0.1,,3
-Potassium,Enfants 1 à 8 ans,106,de la,Viandes et volailles,des,Viandes transformées,du,Porc salé,5.3,1.3,2.8,7.9,mg,0.2,0.1,E,3
-Potassium,Enfants 1 à 8 ans,135,de la,Viandes et volailles,des,Viandes transformées,du,Bacon,2.8,0.6,1.7,3.9,mg,0.1,0,E,3
-Potassium,Enfants 1 à 8 ans,779,de la,Viandes et volailles,de la,Viande rouge,du,Bœuf,39.8,3,33.8,45.7,mg,1.8,0.1,,3
-Potassium,Enfants 1 à 8 ans,284,de la,Viandes et volailles,de la,Viande rouge,du,Porc frais,20.7,3.3,14.1,27.2,mg,0.9,0.2,,3
-Potassium,Enfants 1 à 8 ans,43,de la,Viandes et volailles,de la,Viande rouge,de l',Agneau - veau et gibiers,3.4,1.1,1.3,5.5,mg,0.2,0,E,3
-Potassium,Enfants 1 à 8 ans,,de la,Viandes et volailles,de la,Viande rouge,des,Abats - foies et pâtés,X,X,,,mg,X,X,<10,3
-Potassium,Enfants 1 à 8 ans,1789,des,Substituts de viande,,,,,70.7,5.5,59.8,81.5,mg,3.2,0.2,,1
-Potassium,Enfants 1 à 8 ans,1450,des,Substituts de viande,des,Œufs,,,16.9,0.9,15.1,18.8,mg,0.8,0,,2
-Potassium,Enfants 1 à 8 ans,210,des,Substituts de viande,des,Légumineuses,,,19.9,3.8,12.5,27.4,mg,0.9,0.2,E,2
-Potassium,Enfants 1 à 8 ans,749,des,Substituts de viande,des,Noix - graines et beurre d'arachides,,,31.3,3.2,24.9,37.7,mg,1.4,0.1,,2
-Potassium,Enfants 1 à 8 ans,58,des,Substituts de viande,du,Tofu et produits sans viande,,,2.5,0.7,1.1,4,mg,0.1,0,E,2
-Potassium,Enfants 1 à 8 ans,45,des,Boissons et barres nutritionnelles,,,,,5.6,1.4,2.9,8.2,mg,0.3,0.1,E,1
-Potassium,Enfants 1 à 8 ans,40,des,Boissons et barres nutritionnelles,des,Substituts de repas et boissons nutritionnelles,,,5.2,1.3,2.6,7.9,mg,0.2,0.1,E,2
-Potassium,Enfants 1 à 8 ans,,des,Boissons et barres nutritionnelles,des,Barres nutritionnelles,,,X,X,,,mg,X,X,<10,2
-Potassium,Enfants 1 à 8 ans,2295,des,Soupes - sauces - Épices et autres ingrédients,,,,,43.8,3.3,37.4,50.3,mg,2,0.1,,1
-Potassium,Enfants 1 à 8 ans,761,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,17.8,1.9,14,21.6,mg,0.8,0.1,,2
-Potassium,Enfants 1 à 8 ans,532,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,18.1,2.4,13.3,22.9,mg,0.8,0.1,,2
-Potassium,Enfants 1 à 8 ans,2205,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,8,0.7,6.6,9.4,mg,0.4,0,,2
-Potassium,Enfants 1 à 8 ans,2106,des,Confiseries - sucres et grignotines salées,,,,,99.2,5.5,88.4,109.9,mg,4.6,0.2,,1
-Potassium,Enfants 1 à 8 ans,1048,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,20.4,1.5,17.4,23.4,mg,0.9,0.1,,2
-Potassium,Enfants 1 à 8 ans,497,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,28,2.8,22.4,33.5,mg,1.3,0.1,,2
-Potassium,Enfants 1 à 8 ans,615,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,35.8,4,28,43.6,mg,1.6,0.2,,2
-Potassium,Enfants 1 à 8 ans,1642,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,15,1.6,11.9,18.2,mg,0.7,0.1,,2
-Potassium,Enfants 1 à 8 ans,548,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,12.1,1.1,10,14.2,mg,0.6,0,,3
-Potassium,Enfants 1 à 8 ans,557,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,3.4,0.5,2.5,4.4,mg,0.2,0,,3
-Potassium,Enfants 1 à 8 ans,131,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,4.9,1,3,6.8,mg,0.2,0,E,3
-Potassium,Enfants 1 à 8 ans,346,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,27,2.8,21.4,32.5,mg,1.2,0.1,,3
-Potassium,Enfants 1 à 8 ans,184,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,1,0.2,0.7,1.3,mg,0,0,E,3
-Potassium,Enfants 1 à 8 ans,720,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,13.3,1.6,10.2,16.4,mg,0.6,0.1,,3
-Potassium,Enfants 1 à 8 ans,257,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,1.1,0.2,0.8,1.5,mg,0.1,0,E,3
-Potassium,Enfants 1 à 8 ans,1341,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0.6,0.1,0.4,0.7,mg,0,0,E,3
-Potassium,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,mg,X,X,<10,3
+Potassium,Enfants 1 à 8 ans,122,des,Aliments pour bébés,,,,,11.9,2.4,7.1,16.6,mg,0.5,0.1,E,1
+Potassium,Enfants 1 à 8 ans,95,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,6.5,1.6,3.4,9.6,mg,0.3,0.1,E,2
+Potassium,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparations pour nourrissons,,,5.4,1.5,2.4,8.3,mg,0.2,0.1,E,2
+Potassium,Enfants 1 à 8 ans,2443,des,Boissons (excluant laits),,,,,214,9,196.3,231.8,mg,9.8,0.4,,1
+Potassium,Enfants 1 à 8 ans,20,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0.1,mg,0,0,,2
+Potassium,Enfants 1 à 8 ans,141,des,Boissons (excluant laits),du,Café et thé,,,F,F,,,mg,F,F,F,2
+Potassium,Enfants 1 à 8 ans,,des,Boissons (excluant laits),des,Boissons Énergisantes,,,X,X,,,mg,X,X,<10,2
+Potassium,Enfants 1 à 8 ans,357,des,Boissons (excluant laits),des,Boissons aux fruits,,,27.2,3.6,20.1,34.3,mg,1.2,0.2,,2
+Potassium,Enfants 1 à 8 ans,1159,des,Boissons (excluant laits),des,Jus de fruit,,,164.7,7.9,149.2,180.1,mg,7.6,0.3,,2
+Potassium,Enfants 1 à 8 ans,77,des,Boissons (excluant laits),des,Autres boissons,,,6.6,1.4,3.7,9.4,mg,0.3,0.1,E,2
+Potassium,Enfants 1 à 8 ans,142,des,Boissons (excluant laits),des,Boissons gazeuses,,,0.3,0,0.2,0.4,mg,0,0,,2
+Potassium,Enfants 1 à 8 ans,21,des,Boissons (excluant laits),des,Boissons pour sportifs,,,F,F,,,mg,F,F,F,2
+Potassium,Enfants 1 à 8 ans,52,des,Boissons (excluant laits),des,Jus de tomates et de légumes,,,6,1.6,2.9,9.1,mg,0.3,0.1,E,2
+Potassium,Enfants 1 à 8 ans,,des,Boissons (excluant laits),de l',Eau vitaminée,,,X,X,,,mg,X,X,<10,2
+Potassium,Enfants 1 à 8 ans,2344,des,Boissons (excluant laits),de l',Eau,,,3.9,0.1,3.6,4.2,mg,0.2,0,,2
+Potassium,Enfants 1 à 8 ans,,des,Boissons (excluant laits),du,Café et thé,du,Café,X,X,,,mg,X,X,<10,3
+Potassium,Enfants 1 à 8 ans,133,des,Boissons (excluant laits),du,Café et thé,du,Thé,F,F,,,mg,F,F,F,3
+Potassium,Enfants 1 à 8 ans,2436,des,Produits laitiers et Boissons à base de plantes,,,,,607.1,15,577.6,636.6,mg,27.9,0.6,,1
+Potassium,Enfants 1 à 8 ans,1632,des,Produits laitiers et Boissons à base de plantes,des,Fromages,,,35,2.1,30.9,39,mg,1.6,0.1,,2
+Potassium,Enfants 1 à 8 ans,2341,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,493.7,14,466.1,521.3,mg,22.7,0.5,,2
+Potassium,Enfants 1 à 8 ans,1032,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,,,78.4,3.9,70.8,86,mg,3.6,0.2,,2
+Potassium,Enfants 1 à 8 ans,1810,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,231.8,10.2,211.8,251.8,mg,10.6,0.4,,3
+Potassium,Enfants 1 à 8 ans,1078,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,141.2,8.8,123.8,158.5,mg,6.5,0.4,,3
+Potassium,Enfants 1 à 8 ans,854,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,88,9.9,68.6,107.4,mg,4,0.4,,3
+Potassium,Enfants 1 à 8 ans,739,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,14.5,2.4,9.7,19.3,mg,0.7,0.1,,3
+Potassium,Enfants 1 à 8 ans,128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,12.1,2.1,8.1,16.2,mg,0.6,0.1,E,3
+Potassium,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,6.1,1.5,3.2,9,mg,0.3,0.1,E,3
+Potassium,Enfants 1 à 8 ans,2270,des,Graisses et huiles,,,,,3.2,0.2,2.8,3.6,mg,0.1,0,,1
+Potassium,Enfants 1 à 8 ans,83,des,Graisses et huiles,des,Graisses animales,,,0.1,0,0,0.1,mg,0,0,,2
+Potassium,Enfants 1 à 8 ans,657,des,Graisses et huiles,du,Beurre,,,0.4,0,0.4,0.5,mg,0,0,,2
+Potassium,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Margarines,,,1.7,0.1,1.5,1.8,mg,0.1,0,,2
+Potassium,Enfants 1 à 8 ans,463,des,Graisses et huiles,des,Sauces pour salade,,,1.1,0.2,0.7,1.4,mg,0,0,E,2
+Potassium,Enfants 1 à 8 ans,1035,des,Graisses et huiles,du,Shortening,,,0,0,0,0,mg,0,0,,2
+Potassium,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Huiles végétales,,,0,0,0,0,mg,0,0,,2
+Potassium,Enfants 1 à 8 ans,298,des,Poissons et fruits de mer,,,,,29.3,4.4,20.6,38,mg,1.3,0.2,,1
+Potassium,Enfants 1 à 8 ans,257,des,Poissons et fruits de mer,des,Poissons,,,28,4.3,19.6,36.5,mg,1.3,0.2,,2
+Potassium,Enfants 1 à 8 ans,50,des,Poissons et fruits de mer,des,Mollusques et crustacés,,,1.3,0.3,0.7,1.9,mg,0.1,0,E,2
+Potassium,Enfants 1 à 8 ans,2428,des,Fruits et légumes,,,,,680.1,18.2,644.4,715.8,mg,31.2,0.6,,1
+Potassium,Enfants 1 à 8 ans,2117,des,Fruits et légumes,des,Fruits,,,331.3,11.1,309.5,353.1,mg,15.2,0.4,,2
+Potassium,Enfants 1 à 8 ans,2235,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,348.8,12.7,323.9,373.6,mg,16,0.5,,2
+Potassium,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Bananes,103.9,6,92.1,115.8,mg,4.8,0.3,,3
+Potassium,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pommes,57.8,3.6,50.7,65,mg,2.7,0.2,,3
+Potassium,Enfants 1 à 8 ans,421,des,Fruits et légumes,des,Fruits,des,Agrumes,31,2.7,25.8,36.3,mg,1.4,0.1,,3
+Potassium,Enfants 1 à 8 ans,572,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,31.5,4.5,22.7,40.3,mg,1.4,0.2,,3
+Potassium,Enfants 1 à 8 ans,830,des,Fruits et légumes,des,Fruits,des,Baies,27.4,2.3,22.8,32,mg,1.3,0.1,,3
+Potassium,Enfants 1 à 8 ans,219,des,Fruits et légumes,des,Fruits,des,Melons,28,4.2,19.7,36.2,mg,1.3,0.2,,3
+Potassium,Enfants 1 à 8 ans,260,des,Fruits et légumes,des,Fruits,des,Autres fruits,23.7,3.3,17.3,30.2,mg,1.1,0.2,,3
+Potassium,Enfants 1 à 8 ans,118,des,Fruits et légumes,des,Fruits,des,Pêches et nectarines,11.2,2.1,7.1,15.3,mg,0.5,0.1,E,3
+Potassium,Enfants 1 à 8 ans,133,des,Fruits et légumes,des,Fruits,des,Poires,7.7,1.4,5,10.5,mg,0.4,0.1,E,3
+Potassium,Enfants 1 à 8 ans,94,des,Fruits et légumes,des,Fruits,des,Ananas,2.9,0.6,1.6,4.1,mg,0.1,0,E,3
+Potassium,Enfants 1 à 8 ans,37,des,Fruits et légumes,des,Fruits,des,Prunes et pruneaux,2.7,0.9,0.9,4.4,mg,0.1,0,E,3
+Potassium,Enfants 1 à 8 ans,47,des,Fruits et légumes,des,Fruits,des,Cerises,F,F,,,mg,F,F,F,3
+Potassium,Enfants 1 à 8 ans,1773,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Autres légumes,153.7,7.3,139.4,168,mg,7.1,0.3,,3
+Potassium,Enfants 1 à 8 ans,1032,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes féculents,115.9,8.3,99.6,132.2,mg,5.3,0.4,,3
+Potassium,Enfants 1 à 8 ans,1068,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes vert foncé,44.8,3.6,37.7,51.8,mg,2.1,0.2,,3
+Potassium,Enfants 1 à 8 ans,875,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes jaune foncé ou orange,34.4,3.3,27.8,41,mg,1.6,0.1,,3
+Potassium,Enfants 1 à 8 ans,2475,des,Produits céréaliers,,,,,216.1,4.5,207.3,224.9,mg,9.9,0.2,,1
+Potassium,Enfants 1 à 8 ans,2114,des,Produits céréaliers,des,Pains,,,99.7,3.8,92.3,107.2,mg,4.6,0.2,,2
+Potassium,Enfants 1 à 8 ans,1282,des,Produits céréaliers,des,Céréales pour déjeuner,,,39,2,35.2,42.8,mg,1.8,0.1,,2
+Potassium,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,23.9,1.3,21.4,26.4,mg,1.1,0.1,,2
+Potassium,Enfants 1 à 8 ans,2037,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,53.5,2,49.5,57.4,mg,2.5,0.1,,2
+Potassium,Enfants 1 à 8 ans,813,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,32.1,1.9,28.3,35.9,mg,1.5,0.1,,3
+Potassium,Enfants 1 à 8 ans,951,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,31.2,2.9,25.5,37,mg,1.4,0.1,,3
+Potassium,Enfants 1 à 8 ans,805,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,25.1,2.1,21,29.3,mg,1.2,0.1,,3
+Potassium,Enfants 1 à 8 ans,745,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,11.3,1.1,9.1,13.4,mg,0.5,0,,3
+Potassium,Enfants 1 à 8 ans,728,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,27,2,23.1,30.9,mg,1.2,0.1,,3
+Potassium,Enfants 1 à 8 ans,670,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),12,0.8,10.4,13.6,mg,0.6,0,,3
+Potassium,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,8.4,0.8,6.9,9.9,mg,0.4,0,,3
+Potassium,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.3,0.1,0.1,0.6,mg,0,0,E,3
+Potassium,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,F,F,,,mg,F,F,F,3
+Potassium,Enfants 1 à 8 ans,1461,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,21.6,1.4,18.9,24.3,mg,1,0.1,,3
+Potassium,Enfants 1 à 8 ans,834,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,20.3,1.5,17.3,23.2,mg,0.9,0.1,,3
+Potassium,Enfants 1 à 8 ans,654,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,11.6,0.9,9.9,13.3,mg,0.5,0,,3
+Potassium,Enfants 1 à 8 ans,2072,de la,Viandes et volailles,,,,,196,8.2,179.9,212.2,mg,9,0.3,,1
+Potassium,Enfants 1 à 8 ans,1003,de la,Viandes et volailles,de la,Volaille,,,65.4,4.4,56.8,74,mg,3,0.2,,2
+Potassium,Enfants 1 à 8 ans,942,de la,Viandes et volailles,des,Viandes transformées,,,66.4,5.9,54.8,78.1,mg,3.1,0.3,,2
+Potassium,Enfants 1 à 8 ans,999,de la,Viandes et volailles,de la,Viande rouge,,,64.2,4.2,55.9,72.5,mg,2.9,0.2,,2
+Potassium,Enfants 1 à 8 ans,933,de la,Viandes et volailles,de la,Volaille,du,Poulet,61.3,4.1,53.3,69.3,mg,2.8,0.2,,3
+Potassium,Enfants 1 à 8 ans,86,de la,Viandes et volailles,de la,Volaille,de la,Dinde et autres volailles,F,F,,,mg,F,F,F,3
+Potassium,Enfants 1 à 8 ans,375,de la,Viandes et volailles,des,Viandes transformées,des,Saucisses,31.4,5.2,21.2,41.6,mg,1.4,0.2,,3
+Potassium,Enfants 1 à 8 ans,513,de la,Viandes et volailles,des,Viandes transformées,des,Viandes froides,26.9,2.5,22,31.8,mg,1.2,0.1,,3
+Potassium,Enfants 1 à 8 ans,106,de la,Viandes et volailles,des,Viandes transformées,du,Porc salé,5.3,1.3,2.8,7.9,mg,0.2,0.1,E,3
+Potassium,Enfants 1 à 8 ans,135,de la,Viandes et volailles,des,Viandes transformées,du,Bacon,2.8,0.6,1.7,3.9,mg,0.1,0,E,3
+Potassium,Enfants 1 à 8 ans,779,de la,Viandes et volailles,de la,Viande rouge,du,Bœuf,39.8,3,33.8,45.7,mg,1.8,0.1,,3
+Potassium,Enfants 1 à 8 ans,284,de la,Viandes et volailles,de la,Viande rouge,du,Porc frais,20.7,3.3,14.1,27.2,mg,0.9,0.2,,3
+Potassium,Enfants 1 à 8 ans,43,de la,Viandes et volailles,de la,Viande rouge,de l',Agneau - veau et gibiers,3.4,1.1,1.3,5.5,mg,0.2,0,E,3
+Potassium,Enfants 1 à 8 ans,,de la,Viandes et volailles,de la,Viande rouge,des,Abats - foies et pâtés,X,X,,,mg,X,X,<10,3
+Potassium,Enfants 1 à 8 ans,1789,des,Substituts de viande,,,,,70.7,5.5,59.8,81.5,mg,3.2,0.2,,1
+Potassium,Enfants 1 à 8 ans,1450,des,Substituts de viande,des,Œufs,,,16.9,0.9,15.1,18.8,mg,0.8,0,,2
+Potassium,Enfants 1 à 8 ans,210,des,Substituts de viande,des,Légumineuses,,,19.9,3.8,12.5,27.4,mg,0.9,0.2,E,2
+Potassium,Enfants 1 à 8 ans,749,des,Substituts de viande,des,Noix - graines et beurre d'arachides,,,31.3,3.2,24.9,37.7,mg,1.4,0.1,,2
+Potassium,Enfants 1 à 8 ans,58,des,Substituts de viande,du,Tofu et produits sans viande,,,2.5,0.7,1.1,4,mg,0.1,0,E,2
+Potassium,Enfants 1 à 8 ans,45,des,Boissons et barres nutritionnelles,,,,,5.6,1.4,2.9,8.2,mg,0.3,0.1,E,1
+Potassium,Enfants 1 à 8 ans,40,des,Boissons et barres nutritionnelles,des,Substituts de repas et boissons nutritionnelles,,,5.2,1.3,2.6,7.9,mg,0.2,0.1,E,2
+Potassium,Enfants 1 à 8 ans,,des,Boissons et barres nutritionnelles,des,Barres nutritionnelles,,,X,X,,,mg,X,X,<10,2
+Potassium,Enfants 1 à 8 ans,2295,des,Soupes - sauces - Épices et autres ingrédients,,,,,43.8,3.3,37.4,50.3,mg,2,0.1,,1
+Potassium,Enfants 1 à 8 ans,761,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,17.8,1.9,14,21.6,mg,0.8,0.1,,2
+Potassium,Enfants 1 à 8 ans,532,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,18.1,2.4,13.3,22.9,mg,0.8,0.1,,2
+Potassium,Enfants 1 à 8 ans,2205,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,8,0.7,6.6,9.4,mg,0.4,0,,2
+Potassium,Enfants 1 à 8 ans,2106,des,Confiseries - sucres et grignotines salées,,,,,99.2,5.5,88.4,109.9,mg,4.6,0.2,,1
+Potassium,Enfants 1 à 8 ans,1048,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,20.4,1.5,17.4,23.4,mg,0.9,0.1,,2
+Potassium,Enfants 1 à 8 ans,497,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,28,2.8,22.4,33.5,mg,1.3,0.1,,2
+Potassium,Enfants 1 à 8 ans,615,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,35.8,4,28,43.6,mg,1.6,0.2,,2
+Potassium,Enfants 1 à 8 ans,1642,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,15,1.6,11.9,18.2,mg,0.7,0.1,,2
+Potassium,Enfants 1 à 8 ans,548,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,12.1,1.1,10,14.2,mg,0.6,0,,3
+Potassium,Enfants 1 à 8 ans,557,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,3.4,0.5,2.5,4.4,mg,0.2,0,,3
+Potassium,Enfants 1 à 8 ans,131,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,4.9,1,3,6.8,mg,0.2,0,E,3
+Potassium,Enfants 1 à 8 ans,346,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,27,2.8,21.4,32.5,mg,1.2,0.1,,3
+Potassium,Enfants 1 à 8 ans,184,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,1,0.2,0.7,1.3,mg,0,0,E,3
+Potassium,Enfants 1 à 8 ans,720,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,13.3,1.6,10.2,16.4,mg,0.6,0.1,,3
+Potassium,Enfants 1 à 8 ans,257,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,1.1,0.2,0.8,1.5,mg,0.1,0,E,3
+Potassium,Enfants 1 à 8 ans,1341,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0.6,0.1,0.4,0.7,mg,0,0,E,3
+Potassium,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,mg,X,X,<10,3
 Protéine,Population 1 an et +,186,des,Aliments pour bébés,,,,,0,0,0,0,g,0,0,,1
 Protéine,Population 1 an et +,154,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0,g,0,0,,2
 Protéine,Population 1 an et +,51,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0,0,0,0,g,0,0,,2
@@ -3236,7 +3236,7 @@ Protéine,Population 1 an et +,6318,des,Fruits et légumes,des,Légumes incluant
 Protéine,Population 1 an et +,19327,des,Produits céréaliers,,,,,15.7,0.1,15.4,15.9,g,20.2,0.2,,1
 Protéine,Population 1 an et +,16168,des,Produits céréaliers,des,Pains,,,8,0.1,7.8,8.2,g,10.3,0.1,,2
 Protéine,Population 1 an et +,6966,des,Produits céréaliers,des,Céréales pour déjeuner,,,1.4,0,1.3,1.4,g,1.8,0.1,,2
-Protéine,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.6,0,0.5,0.6,g,0.7,0,,2
+Protéine,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.6,0,0.5,0.6,g,0.7,0,,2
 Protéine,Population 1 an et +,14820,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,5.7,0.1,5.5,5.9,g,7.4,0.1,,2
 Protéine,Population 1 an et +,8159,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,3.3,0.1,3.1,3.4,g,4.2,0.1,,3
 Protéine,Population 1 an et +,5962,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,2.3,0.1,2.1,2.4,g,2.9,0.1,,3
@@ -3244,10 +3244,10 @@ Protéine,Population 1 an et +,6257,des,Produits céréaliers,des,Pains,des,Autr
 Protéine,Population 1 an et +,2918,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.3,0,0.2,0.3,g,0.3,0,,3
 Protéine,Population 1 an et +,4760,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,1.1,0,1.1,1.2,g,1.5,0.1,,3
 Protéine,Population 1 an et +,2573,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.2,0,0.2,0.3,g,0.3,0,,3
-Protéine,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.2,0,0.2,0.2,g,0.2,0,,3
-Protéine,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0,0,,3
-Protéine,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
-Protéine,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
+Protéine,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.2,0,0.2,0.2,g,0.2,0,,3
+Protéine,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0,0,,3
+Protéine,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
+Protéine,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
 Protéine,Population 1 an et +,11102,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,2.8,0.1,2.6,2.9,g,3.6,0.1,,3
 Protéine,Population 1 an et +,4543,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,1.9,0.1,1.7,2,g,2.4,0.1,,3
 Protéine,Population 1 an et +,4598,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,1.1,0,1,1.2,g,1.4,0.1,,3
@@ -3350,7 +3350,7 @@ Protéine,Hommes adultes 19 ans +,1991,des,Fruits et légumes,des,Légumes inclu
 Protéine,Hommes adultes 19 ans +,6068,des,Produits céréaliers,,,,,17.9,0.3,17.4,18.4,g,19.4,0.3,,1
 Protéine,Hommes adultes 19 ans +,5104,des,Produits céréaliers,des,Pains,,,9.4,0.2,9,9.8,g,10.2,0.2,,2
 Protéine,Hommes adultes 19 ans +,1921,des,Produits céréaliers,des,Céréales pour déjeuner,,,1.5,0.1,1.3,1.7,g,1.6,0.1,,2
-Protéine,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.6,0,0.5,0.7,g,0.6,0,,2
+Protéine,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.6,0,0.5,0.7,g,0.6,0,,2
 Protéine,Hommes adultes 19 ans +,4551,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,6.4,0.2,6.1,6.8,g,7,0.2,,2
 Protéine,Hommes adultes 19 ans +,2752,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,4.2,0.2,3.8,4.5,g,4.5,0.2,,3
 Protéine,Hommes adultes 19 ans +,1980,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,2.6,0.1,2.3,2.8,g,2.8,0.1,,3
@@ -3358,9 +3358,9 @@ Protéine,Hommes adultes 19 ans +,1885,des,Produits céréaliers,des,Pains,des,A
 Protéine,Hommes adultes 19 ans +,593,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.2,0,0.2,0.2,g,0.2,0,,3
 Protéine,Hommes adultes 19 ans +,1481,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,1.3,0.1,1.2,1.5,g,1.5,0.1,,3
 Protéine,Hommes adultes 19 ans +,523,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.2,0,0.1,0.2,g,0.2,0,,3
-Protéine,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.2,0,0.2,0.3,g,0.2,0,,3
-Protéine,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0,0,,3
-Protéine,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
+Protéine,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.2,0,0.2,0.3,g,0.2,0,,3
+Protéine,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0,0,,3
+Protéine,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
 Protéine,Hommes adultes 19 ans +,3442,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,3.2,0.1,3,3.5,g,3.5,0.1,,3
 Protéine,Hommes adultes 19 ans +,1250,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,2,0.1,1.7,2.2,g,2.2,0.1,,3
 Protéine,Hommes adultes 19 ans +,1449,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,1.2,0.1,1.1,1.3,g,1.3,0.1,,3
@@ -3463,7 +3463,7 @@ Protéine,Femmes adultes* 19 ans +,2348,des,Fruits et légumes,des,Légumes incl
 Protéine,Femmes adultes* 19 ans +,6669,des,Produits céréaliers,,,,,13.2,0.2,12.7,13.6,g,19.9,0.3,,1
 Protéine,Femmes adultes* 19 ans +,5520,des,Produits céréaliers,des,Pains,,,6.8,0.1,6.5,7.1,g,10.3,0.2,,2
 Protéine,Femmes adultes* 19 ans +,2230,des,Produits céréaliers,des,Céréales pour déjeuner,,,1.2,0.1,1.1,1.3,g,1.8,0.1,,2
-Protéine,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.4,0,0.4,0.5,g,0.7,0,,2
+Protéine,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.4,0,0.4,0.5,g,0.7,0,,2
 Protéine,Femmes adultes* 19 ans +,4893,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,4.7,0.2,4.4,5,g,7.1,0.2,,2
 Protéine,Femmes adultes* 19 ans +,2551,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,2.6,0.1,2.4,2.8,g,3.9,0.2,,3
 Protéine,Femmes adultes* 19 ans +,2239,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,2.2,0.1,2.1,2.4,g,3.4,0.1,,3
@@ -3471,10 +3471,10 @@ Protéine,Femmes adultes* 19 ans +,1994,des,Produits céréaliers,des,Pains,des,
 Protéine,Femmes adultes* 19 ans +,914,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.2,0,0.2,0.2,g,0.3,0,,3
 Protéine,Femmes adultes* 19 ans +,1756,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,1,0.1,0.9,1.1,g,1.6,0.1,,3
 Protéine,Femmes adultes* 19 ans +,555,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.1,0,0.1,0.2,g,0.2,0,,3
-Protéine,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.1,g,0.2,0,,3
-Protéine,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0,0,,3
-Protéine,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
-Protéine,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
+Protéine,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.1,g,0.2,0,,3
+Protéine,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0,0,,3
+Protéine,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
+Protéine,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
 Protéine,Femmes adultes* 19 ans +,3664,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,2.2,0.1,2,2.4,g,3.4,0.2,,3
 Protéine,Femmes adultes* 19 ans +,1358,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,1.5,0.1,1.4,1.7,g,2.3,0.1,,3
 Protéine,Femmes adultes* 19 ans +,1522,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,1,0.1,0.9,1.1,g,1.4,0.1,,3
@@ -3518,119 +3518,119 @@ Protéine,Femmes adultes* 19 ans +,1529,des,Confiseries - sucres et grignotines 
 Protéine,Femmes adultes* 19 ans +,773,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0,0,,3
 Protéine,Femmes adultes* 19 ans +,360,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
 Protéine,Femmes adultes* 19 ans +,4229,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
-Protéine,Enfants 1 à 8 ans,122,des,Aliments pour bébés,,,,,0.2,0,0.1,0.3,g,0.4,0.1,,1
-Protéine,Enfants 1 à 8 ans,95,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0.1,0,0.1,0.2,g,0.2,0,,2
-Protéine,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0.1,0,0,0.2,g,0.2,0,,2
-Protéine,Enfants 1 à 8 ans,2443,des,Boissons (excluant laits),,,,,0.6,0,0.5,0.7,g,1,0.1,,1
-Protéine,Enfants 1 à 8 ans,20,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0,g,0,0,,2
-Protéine,Enfants 1 à 8 ans,141,des,Boissons (excluant laits),du,Café et thé,,,0,0,0,0,g,0,0,,2
-Protéine,Enfants 1 à 8 ans,,des,Boissons (excluant laits),des,Boissons Énergisantes,,,X,X,,,g,X,X,<10,2
-Protéine,Enfants 1 à 8 ans,357,des,Boissons (excluant laits),des,Boissons aux fruits,,,0,0,0,0,g,0.1,0,,2
-Protéine,Enfants 1 à 8 ans,1159,des,Boissons (excluant laits),des,Jus de fruit,,,0.5,0,0.4,0.5,g,0.8,0,,2
-Protéine,Enfants 1 à 8 ans,77,des,Boissons (excluant laits),des,Autres boissons,,,0.1,0,0,0.1,g,0.1,0,,2
-Protéine,Enfants 1 à 8 ans,142,des,Boissons (excluant laits),des,Boissons gazeuses,,,0,0,0,0,g,0,0,,2
-Protéine,Enfants 1 à 8 ans,21,des,Boissons (excluant laits),des,Boissons pour sportifs,,,0,0,0,0,g,0,0,,2
-Protéine,Enfants 1 à 8 ans,52,des,Boissons (excluant laits),des,Jus de tomates et de légumes,,,0,0,0,0,g,0,0,,2
-Protéine,Enfants 1 à 8 ans,,des,Boissons (excluant laits),de l',Eau vitaminée,,,X,X,,,g,X,X,<10,2
-Protéine,Enfants 1 à 8 ans,2344,des,Boissons (excluant laits),de l',Eau,,,0,0,0,0,g,0,0,,2
-Protéine,Enfants 1 à 8 ans,133,des,Boissons (excluant laits),du,Café et thé,du,Thé,0,0,0,0,g,0,0,,3
-Protéine,Enfants 1 à 8 ans,,des,Boissons (excluant laits),du,Café et thé,du,Café,X,X,,,g,X,X,<10,3
-Protéine,Enfants 1 à 8 ans,2436,des,Produits laitiers et Boissons à base de plantes,,,,,18.9,0.4,18,19.7,g,31.6,0.6,,1
-Protéine,Enfants 1 à 8 ans,1632,des,Produits laitiers et Boissons à base de plantes,des,Fromages,,,5.6,0.3,5.1,6.1,g,9.4,0.4,,2
-Protéine,Enfants 1 à 8 ans,2341,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,11.2,0.3,10.6,11.8,g,18.8,0.5,,2
-Protéine,Enfants 1 à 8 ans,1032,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,,,2.1,0.1,1.8,2.3,g,3.5,0.2,,2
-Protéine,Enfants 1 à 8 ans,1810,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,5.4,0.2,4.9,5.8,g,9,0.4,,3
-Protéine,Enfants 1 à 8 ans,1078,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,3.4,0.2,2.9,3.8,g,5.6,0.3,,3
-Protéine,Enfants 1 à 8 ans,854,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,1.9,0.2,1.5,2.4,g,3.2,0.4,,3
-Protéine,Enfants 1 à 8 ans,739,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0.3,0.1,0.2,0.4,g,0.5,0.1,E,3
-Protéine,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0.1,0,0.1,0.2,g,0.2,0.1,,3
-Protéine,Enfants 1 à 8 ans,128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0.1,0,0.1,0.2,g,0.2,0,,3
-Protéine,Enfants 1 à 8 ans,2270,des,Graisses et huiles,,,,,0,0,0,0.1,g,0.1,0,,1
-Protéine,Enfants 1 à 8 ans,83,des,Graisses et huiles,des,Graisses animales,,,0,0,0,0,g,0,0,,2
-Protéine,Enfants 1 à 8 ans,657,des,Graisses et huiles,du,Beurre,,,0,0,0,0,g,0,0,,2
-Protéine,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Margarines,,,0,0,0,0,g,0,0,,2
-Protéine,Enfants 1 à 8 ans,463,des,Graisses et huiles,des,Sauces pour salade,,,0,0,0,0,g,0,0,,2
-Protéine,Enfants 1 à 8 ans,1035,des,Graisses et huiles,du,Shortening,,,0,0,0,0,g,0,0,,2
-Protéine,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Huiles végétales,,,0,0,0,0,g,0,0,,2
-Protéine,Enfants 1 à 8 ans,298,des,Poissons et fruits de mer,,,,,1.9,0.3,1.4,2.5,g,3.2,0.5,,1
-Protéine,Enfants 1 à 8 ans,257,des,Poissons et fruits de mer,des,Poissons,,,1.8,0.3,1.2,2.3,g,2.9,0.4,E,2
-Protéine,Enfants 1 à 8 ans,50,des,Poissons et fruits de mer,des,Mollusques et crustacés,,,0.2,0,0.1,0.2,g,0.3,0.1,,2
-Protéine,Enfants 1 à 8 ans,2428,des,Fruits et légumes,,,,,3.2,0.1,3,3.4,g,5.4,0.2,,1
-Protéine,Enfants 1 à 8 ans,2117,des,Fruits et légumes,des,Fruits,,,1.2,0,1.1,1.3,g,2,0.1,,2
-Protéine,Enfants 1 à 8 ans,2235,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,2,0.1,1.9,2.2,g,3.4,0.1,,2
-Protéine,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Bananes,0.3,0,0.3,0.4,g,0.5,0,,3
-Protéine,Enfants 1 à 8 ans,830,des,Fruits et légumes,des,Fruits,des,Baies,0.2,0,0.1,0.2,g,0.3,0,,3
-Protéine,Enfants 1 à 8 ans,421,des,Fruits et légumes,des,Fruits,des,Agrumes,0.2,0,0.1,0.2,g,0.3,0,,3
-Protéine,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pommes,0.1,0,0.1,0.2,g,0.2,0,,3
-Protéine,Enfants 1 à 8 ans,572,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,0.1,0,0.1,0.2,g,0.2,0,,3
-Protéine,Enfants 1 à 8 ans,219,des,Fruits et légumes,des,Fruits,des,Melons,0.1,0,0.1,0.1,g,0.2,0,,3
-Protéine,Enfants 1 à 8 ans,260,des,Fruits et légumes,des,Fruits,des,Autres fruits,0.1,0,0.1,0.1,g,0.2,0,,3
-Protéine,Enfants 1 à 8 ans,118,des,Fruits et légumes,des,Fruits,des,Pêches et nectarines,0.1,0,0,0.1,g,0.1,0,,3
-Protéine,Enfants 1 à 8 ans,47,des,Fruits et légumes,des,Fruits,des,Cerises,0,0,0,0,g,0,0,,3
-Protéine,Enfants 1 à 8 ans,133,des,Fruits et légumes,des,Fruits,des,Poires,0,0,0,0,g,0,0,,3
-Protéine,Enfants 1 à 8 ans,94,des,Fruits et légumes,des,Fruits,des,Ananas,0,0,0,0,g,0,0,,3
-Protéine,Enfants 1 à 8 ans,37,des,Fruits et légumes,des,Fruits,des,Prunes et pruneaux,0,0,0,0,g,0,0,,3
-Protéine,Enfants 1 à 8 ans,1773,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Autres légumes,0.7,0,0.7,0.8,g,1.2,0.1,,3
-Protéine,Enfants 1 à 8 ans,1032,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes féculents,0.7,0,0.6,0.8,g,1.1,0.1,,3
-Protéine,Enfants 1 à 8 ans,1068,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes vert foncé,0.5,0,0.4,0.6,g,0.8,0.1,,3
-Protéine,Enfants 1 à 8 ans,875,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes jaune foncé ou orange,0.1,0,0.1,0.2,g,0.2,0,,3
-Protéine,Enfants 1 à 8 ans,2475,des,Produits céréaliers,,,,,13.4,0.3,12.8,13.9,g,22.4,0.5,,1
-Protéine,Enfants 1 à 8 ans,2114,des,Produits céréaliers,des,Pains,,,6.1,0.2,5.8,6.5,g,10.3,0.3,,2
-Protéine,Enfants 1 à 8 ans,1282,des,Produits céréaliers,des,Céréales pour déjeuner,,,1.3,0.1,1.2,1.5,g,2.3,0.1,,2
-Protéine,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.7,0,0.6,0.8,g,1.2,0.1,,2
-Protéine,Enfants 1 à 8 ans,2037,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,5.2,0.2,4.8,5.6,g,8.7,0.3,,2
-Protéine,Enfants 1 à 8 ans,951,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,2.3,0.2,2,2.7,g,3.9,0.3,,3
-Protéine,Enfants 1 à 8 ans,813,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,1.7,0.1,1.5,1.9,g,2.8,0.2,,3
-Protéine,Enfants 1 à 8 ans,805,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,1.5,0.1,1.3,1.7,g,2.5,0.2,,3
-Protéine,Enfants 1 à 8 ans,745,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.6,0.1,0.5,0.7,g,1,0.1,E,3
-Protéine,Enfants 1 à 8 ans,728,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.9,0.1,0.7,1,g,1.4,0.1,,3
-Protéine,Enfants 1 à 8 ans,670,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.5,0,0.4,0.6,g,0.8,0.1,,3
-Protéine,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.2,0,0.2,0.2,g,0.3,0,,3
-Protéine,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0,0,,3
-Protéine,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
-Protéine,Enfants 1 à 8 ans,834,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,2.2,0.2,1.9,2.5,g,3.7,0.3,,3
-Protéine,Enfants 1 à 8 ans,1461,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,2.1,0.1,1.9,2.4,g,3.6,0.2,,3
-Protéine,Enfants 1 à 8 ans,654,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0.9,0.1,0.7,1,g,1.4,0.1,,3
-Protéine,Enfants 1 à 8 ans,2072,de la,Viandes et volailles,,,,,15.6,0.6,14.4,16.8,g,26.1,0.8,,1
-Protéine,Enfants 1 à 8 ans,1003,de la,Viandes et volailles,de la,Volaille,,,7.1,0.5,6.2,8,g,11.9,0.7,,2
-Protéine,Enfants 1 à 8 ans,942,de la,Viandes et volailles,des,Viandes transformées,,,3.2,0.3,2.7,3.7,g,5.4,0.4,,2
-Protéine,Enfants 1 à 8 ans,999,de la,Viandes et volailles,de la,Viande rouge,,,5.3,0.3,4.6,5.9,g,8.8,0.5,,2
-Protéine,Enfants 1 à 8 ans,933,de la,Viandes et volailles,de la,Volaille,du,Poulet,6.7,0.5,5.9,7.6,g,11.3,0.7,,3
-Protéine,Enfants 1 à 8 ans,86,de la,Viandes et volailles,de la,Volaille,de la,Dinde et autres volailles,F,F,,,g,F,F,F,3
-Protéine,Enfants 1 à 8 ans,375,de la,Viandes et volailles,des,Viandes transformées,des,Saucisses,1.3,0.2,1,1.7,g,2.3,0.3,,3
-Protéine,Enfants 1 à 8 ans,513,de la,Viandes et volailles,des,Viandes transformées,des,Viandes froides,1.3,0.1,1.1,1.6,g,2.2,0.2,,3
-Protéine,Enfants 1 à 8 ans,106,de la,Viandes et volailles,des,Viandes transformées,du,Porc salé,0.4,0.1,0.2,0.5,g,0.6,0.1,E,3
-Protéine,Enfants 1 à 8 ans,135,de la,Viandes et volailles,des,Viandes transformées,du,Bacon,0.2,0,0.1,0.3,g,0.3,0.1,,3
-Protéine,Enfants 1 à 8 ans,779,de la,Viandes et volailles,de la,Viande rouge,du,Bœuf,3.4,0.3,2.9,3.9,g,5.7,0.4,,3
-Protéine,Enfants 1 à 8 ans,284,de la,Viandes et volailles,de la,Viande rouge,du,Porc frais,1.5,0.2,1.1,2,g,2.6,0.4,,3
-Protéine,Enfants 1 à 8 ans,43,de la,Viandes et volailles,de la,Viande rouge,de l',Agneau - veau et gibiers,0.3,0.1,0.1,0.5,g,0.5,0.2,E,3
-Protéine,Enfants 1 à 8 ans,,de la,Viandes et volailles,de la,Viande rouge,des,Abats - foies et pâtés,X,X,,,g,X,X,<10,3
-Protéine,Enfants 1 à 8 ans,1789,des,Substituts de viande,,,,,3.6,0.2,3.2,4,g,6,0.3,,1
-Protéine,Enfants 1 à 8 ans,1450,des,Substituts de viande,des,Œufs,,,1.7,0.1,1.6,1.9,g,2.9,0.1,,2
-Protéine,Enfants 1 à 8 ans,210,des,Substituts de viande,des,Légumineuses,,,0.5,0.1,0.3,0.7,g,0.8,0.1,E,2
-Protéine,Enfants 1 à 8 ans,749,des,Substituts de viande,des,Noix - graines et beurre d'arachides,,,1.1,0.1,0.9,1.3,g,1.9,0.2,,2
-Protéine,Enfants 1 à 8 ans,58,des,Substituts de viande,du,Tofu et produits sans viande,,,F,F,,,g,F,F,F,2
-Protéine,Enfants 1 à 8 ans,45,des,Boissons et barres nutritionnelles,,,,,0.2,0,0.1,0.3,g,0.3,0.1,,1
-Protéine,Enfants 1 à 8 ans,40,des,Boissons et barres nutritionnelles,des,Substituts de repas et boissons nutritionnelles,,,0.2,0,0.1,0.2,g,0.3,0.1,,2
-Protéine,Enfants 1 à 8 ans,,des,Boissons et barres nutritionnelles,des,Barres nutritionnelles,,,X,X,,,g,X,X,<10,2
-Protéine,Enfants 1 à 8 ans,2295,des,Soupes - sauces - Épices et autres ingrédients,,,,,0.6,0,0.5,0.7,g,1,0.1,,1
-Protéine,Enfants 1 à 8 ans,761,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.2,0,0.1,0.2,g,0.3,0,,2
-Protéine,Enfants 1 à 8 ans,532,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0.3,0,0.2,0.4,g,0.5,0.1,,2
-Protéine,Enfants 1 à 8 ans,2205,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.1,0,0.1,0.1,g,0.2,0,,2
-Protéine,Enfants 1 à 8 ans,2106,des,Confiseries - sucres et grignotines salées,,,,,1.4,0.1,1.3,1.6,g,2.4,0.1,,1
-Protéine,Enfants 1 à 8 ans,1048,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,0.3,0,0.3,0.4,g,0.6,0,,2
-Protéine,Enfants 1 à 8 ans,497,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,0.5,0.1,0.4,0.6,g,0.9,0.1,E,2
-Protéine,Enfants 1 à 8 ans,615,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0.5,0,0.4,0.5,g,0.8,0.1,,2
-Protéine,Enfants 1 à 8 ans,1642,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.1,0,0.1,0.1,g,0.2,0,,2
-Protéine,Enfants 1 à 8 ans,548,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0.2,0,0.2,0.3,g,0.4,0,,3
-Protéine,Enfants 1 à 8 ans,557,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0,0,0,0,g,0.1,0,,3
-Protéine,Enfants 1 à 8 ans,131,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0.1,0,0.1,0.1,g,0.1,0,,3
-Protéine,Enfants 1 à 8 ans,346,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.5,0.1,0.4,0.6,g,0.8,0.1,E,3
-Protéine,Enfants 1 à 8 ans,184,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0.1,g,0.1,0,,3
-Protéine,Enfants 1 à 8 ans,720,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.1,0,0.1,0.1,g,0.2,0,,3
-Protéine,Enfants 1 à 8 ans,257,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0,0,,3
-Protéine,Enfants 1 à 8 ans,1341,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
-Protéine,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,g,X,X,<10,3
+Protéine,Enfants 1 à 8 ans,122,des,Aliments pour bébés,,,,,0.2,0,0.1,0.3,g,0.4,0.1,,1
+Protéine,Enfants 1 à 8 ans,95,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0.1,0,0.1,0.2,g,0.2,0,,2
+Protéine,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0.1,0,0,0.2,g,0.2,0,,2
+Protéine,Enfants 1 à 8 ans,2443,des,Boissons (excluant laits),,,,,0.6,0,0.5,0.7,g,1,0.1,,1
+Protéine,Enfants 1 à 8 ans,20,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0,g,0,0,,2
+Protéine,Enfants 1 à 8 ans,141,des,Boissons (excluant laits),du,Café et thé,,,0,0,0,0,g,0,0,,2
+Protéine,Enfants 1 à 8 ans,,des,Boissons (excluant laits),des,Boissons Énergisantes,,,X,X,,,g,X,X,<10,2
+Protéine,Enfants 1 à 8 ans,357,des,Boissons (excluant laits),des,Boissons aux fruits,,,0,0,0,0,g,0.1,0,,2
+Protéine,Enfants 1 à 8 ans,1159,des,Boissons (excluant laits),des,Jus de fruit,,,0.5,0,0.4,0.5,g,0.8,0,,2
+Protéine,Enfants 1 à 8 ans,77,des,Boissons (excluant laits),des,Autres boissons,,,0.1,0,0,0.1,g,0.1,0,,2
+Protéine,Enfants 1 à 8 ans,142,des,Boissons (excluant laits),des,Boissons gazeuses,,,0,0,0,0,g,0,0,,2
+Protéine,Enfants 1 à 8 ans,21,des,Boissons (excluant laits),des,Boissons pour sportifs,,,0,0,0,0,g,0,0,,2
+Protéine,Enfants 1 à 8 ans,52,des,Boissons (excluant laits),des,Jus de tomates et de légumes,,,0,0,0,0,g,0,0,,2
+Protéine,Enfants 1 à 8 ans,,des,Boissons (excluant laits),de l',Eau vitaminée,,,X,X,,,g,X,X,<10,2
+Protéine,Enfants 1 à 8 ans,2344,des,Boissons (excluant laits),de l',Eau,,,0,0,0,0,g,0,0,,2
+Protéine,Enfants 1 à 8 ans,133,des,Boissons (excluant laits),du,Café et thé,du,Thé,0,0,0,0,g,0,0,,3
+Protéine,Enfants 1 à 8 ans,,des,Boissons (excluant laits),du,Café et thé,du,Café,X,X,,,g,X,X,<10,3
+Protéine,Enfants 1 à 8 ans,2436,des,Produits laitiers et Boissons à base de plantes,,,,,18.9,0.4,18,19.7,g,31.6,0.6,,1
+Protéine,Enfants 1 à 8 ans,1632,des,Produits laitiers et Boissons à base de plantes,des,Fromages,,,5.6,0.3,5.1,6.1,g,9.4,0.4,,2
+Protéine,Enfants 1 à 8 ans,2341,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,11.2,0.3,10.6,11.8,g,18.8,0.5,,2
+Protéine,Enfants 1 à 8 ans,1032,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,,,2.1,0.1,1.8,2.3,g,3.5,0.2,,2
+Protéine,Enfants 1 à 8 ans,1810,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,5.4,0.2,4.9,5.8,g,9,0.4,,3
+Protéine,Enfants 1 à 8 ans,1078,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,3.4,0.2,2.9,3.8,g,5.6,0.3,,3
+Protéine,Enfants 1 à 8 ans,854,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,1.9,0.2,1.5,2.4,g,3.2,0.4,,3
+Protéine,Enfants 1 à 8 ans,739,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0.3,0.1,0.2,0.4,g,0.5,0.1,E,3
+Protéine,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0.1,0,0.1,0.2,g,0.2,0.1,,3
+Protéine,Enfants 1 à 8 ans,128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0.1,0,0.1,0.2,g,0.2,0,,3
+Protéine,Enfants 1 à 8 ans,2270,des,Graisses et huiles,,,,,0,0,0,0.1,g,0.1,0,,1
+Protéine,Enfants 1 à 8 ans,83,des,Graisses et huiles,des,Graisses animales,,,0,0,0,0,g,0,0,,2
+Protéine,Enfants 1 à 8 ans,657,des,Graisses et huiles,du,Beurre,,,0,0,0,0,g,0,0,,2
+Protéine,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Margarines,,,0,0,0,0,g,0,0,,2
+Protéine,Enfants 1 à 8 ans,463,des,Graisses et huiles,des,Sauces pour salade,,,0,0,0,0,g,0,0,,2
+Protéine,Enfants 1 à 8 ans,1035,des,Graisses et huiles,du,Shortening,,,0,0,0,0,g,0,0,,2
+Protéine,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Huiles végétales,,,0,0,0,0,g,0,0,,2
+Protéine,Enfants 1 à 8 ans,298,des,Poissons et fruits de mer,,,,,1.9,0.3,1.4,2.5,g,3.2,0.5,,1
+Protéine,Enfants 1 à 8 ans,257,des,Poissons et fruits de mer,des,Poissons,,,1.8,0.3,1.2,2.3,g,2.9,0.4,E,2
+Protéine,Enfants 1 à 8 ans,50,des,Poissons et fruits de mer,des,Mollusques et crustacés,,,0.2,0,0.1,0.2,g,0.3,0.1,,2
+Protéine,Enfants 1 à 8 ans,2428,des,Fruits et légumes,,,,,3.2,0.1,3,3.4,g,5.4,0.2,,1
+Protéine,Enfants 1 à 8 ans,2117,des,Fruits et légumes,des,Fruits,,,1.2,0,1.1,1.3,g,2,0.1,,2
+Protéine,Enfants 1 à 8 ans,2235,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,2,0.1,1.9,2.2,g,3.4,0.1,,2
+Protéine,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Bananes,0.3,0,0.3,0.4,g,0.5,0,,3
+Protéine,Enfants 1 à 8 ans,830,des,Fruits et légumes,des,Fruits,des,Baies,0.2,0,0.1,0.2,g,0.3,0,,3
+Protéine,Enfants 1 à 8 ans,421,des,Fruits et légumes,des,Fruits,des,Agrumes,0.2,0,0.1,0.2,g,0.3,0,,3
+Protéine,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pommes,0.1,0,0.1,0.2,g,0.2,0,,3
+Protéine,Enfants 1 à 8 ans,572,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,0.1,0,0.1,0.2,g,0.2,0,,3
+Protéine,Enfants 1 à 8 ans,219,des,Fruits et légumes,des,Fruits,des,Melons,0.1,0,0.1,0.1,g,0.2,0,,3
+Protéine,Enfants 1 à 8 ans,260,des,Fruits et légumes,des,Fruits,des,Autres fruits,0.1,0,0.1,0.1,g,0.2,0,,3
+Protéine,Enfants 1 à 8 ans,118,des,Fruits et légumes,des,Fruits,des,Pêches et nectarines,0.1,0,0,0.1,g,0.1,0,,3
+Protéine,Enfants 1 à 8 ans,47,des,Fruits et légumes,des,Fruits,des,Cerises,0,0,0,0,g,0,0,,3
+Protéine,Enfants 1 à 8 ans,133,des,Fruits et légumes,des,Fruits,des,Poires,0,0,0,0,g,0,0,,3
+Protéine,Enfants 1 à 8 ans,94,des,Fruits et légumes,des,Fruits,des,Ananas,0,0,0,0,g,0,0,,3
+Protéine,Enfants 1 à 8 ans,37,des,Fruits et légumes,des,Fruits,des,Prunes et pruneaux,0,0,0,0,g,0,0,,3
+Protéine,Enfants 1 à 8 ans,1773,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Autres légumes,0.7,0,0.7,0.8,g,1.2,0.1,,3
+Protéine,Enfants 1 à 8 ans,1032,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes féculents,0.7,0,0.6,0.8,g,1.1,0.1,,3
+Protéine,Enfants 1 à 8 ans,1068,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes vert foncé,0.5,0,0.4,0.6,g,0.8,0.1,,3
+Protéine,Enfants 1 à 8 ans,875,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes jaune foncé ou orange,0.1,0,0.1,0.2,g,0.2,0,,3
+Protéine,Enfants 1 à 8 ans,2475,des,Produits céréaliers,,,,,13.4,0.3,12.8,13.9,g,22.4,0.5,,1
+Protéine,Enfants 1 à 8 ans,2114,des,Produits céréaliers,des,Pains,,,6.1,0.2,5.8,6.5,g,10.3,0.3,,2
+Protéine,Enfants 1 à 8 ans,1282,des,Produits céréaliers,des,Céréales pour déjeuner,,,1.3,0.1,1.2,1.5,g,2.3,0.1,,2
+Protéine,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.7,0,0.6,0.8,g,1.2,0.1,,2
+Protéine,Enfants 1 à 8 ans,2037,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,5.2,0.2,4.8,5.6,g,8.7,0.3,,2
+Protéine,Enfants 1 à 8 ans,951,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,2.3,0.2,2,2.7,g,3.9,0.3,,3
+Protéine,Enfants 1 à 8 ans,813,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,1.7,0.1,1.5,1.9,g,2.8,0.2,,3
+Protéine,Enfants 1 à 8 ans,805,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,1.5,0.1,1.3,1.7,g,2.5,0.2,,3
+Protéine,Enfants 1 à 8 ans,745,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.6,0.1,0.5,0.7,g,1,0.1,E,3
+Protéine,Enfants 1 à 8 ans,728,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.9,0.1,0.7,1,g,1.4,0.1,,3
+Protéine,Enfants 1 à 8 ans,670,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.5,0,0.4,0.6,g,0.8,0.1,,3
+Protéine,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.2,0,0.2,0.2,g,0.3,0,,3
+Protéine,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0,0,,3
+Protéine,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
+Protéine,Enfants 1 à 8 ans,834,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,2.2,0.2,1.9,2.5,g,3.7,0.3,,3
+Protéine,Enfants 1 à 8 ans,1461,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,2.1,0.1,1.9,2.4,g,3.6,0.2,,3
+Protéine,Enfants 1 à 8 ans,654,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0.9,0.1,0.7,1,g,1.4,0.1,,3
+Protéine,Enfants 1 à 8 ans,2072,de la,Viandes et volailles,,,,,15.6,0.6,14.4,16.8,g,26.1,0.8,,1
+Protéine,Enfants 1 à 8 ans,1003,de la,Viandes et volailles,de la,Volaille,,,7.1,0.5,6.2,8,g,11.9,0.7,,2
+Protéine,Enfants 1 à 8 ans,942,de la,Viandes et volailles,des,Viandes transformées,,,3.2,0.3,2.7,3.7,g,5.4,0.4,,2
+Protéine,Enfants 1 à 8 ans,999,de la,Viandes et volailles,de la,Viande rouge,,,5.3,0.3,4.6,5.9,g,8.8,0.5,,2
+Protéine,Enfants 1 à 8 ans,933,de la,Viandes et volailles,de la,Volaille,du,Poulet,6.7,0.5,5.9,7.6,g,11.3,0.7,,3
+Protéine,Enfants 1 à 8 ans,86,de la,Viandes et volailles,de la,Volaille,de la,Dinde et autres volailles,F,F,,,g,F,F,F,3
+Protéine,Enfants 1 à 8 ans,375,de la,Viandes et volailles,des,Viandes transformées,des,Saucisses,1.3,0.2,1,1.7,g,2.3,0.3,,3
+Protéine,Enfants 1 à 8 ans,513,de la,Viandes et volailles,des,Viandes transformées,des,Viandes froides,1.3,0.1,1.1,1.6,g,2.2,0.2,,3
+Protéine,Enfants 1 à 8 ans,106,de la,Viandes et volailles,des,Viandes transformées,du,Porc salé,0.4,0.1,0.2,0.5,g,0.6,0.1,E,3
+Protéine,Enfants 1 à 8 ans,135,de la,Viandes et volailles,des,Viandes transformées,du,Bacon,0.2,0,0.1,0.3,g,0.3,0.1,,3
+Protéine,Enfants 1 à 8 ans,779,de la,Viandes et volailles,de la,Viande rouge,du,Bœuf,3.4,0.3,2.9,3.9,g,5.7,0.4,,3
+Protéine,Enfants 1 à 8 ans,284,de la,Viandes et volailles,de la,Viande rouge,du,Porc frais,1.5,0.2,1.1,2,g,2.6,0.4,,3
+Protéine,Enfants 1 à 8 ans,43,de la,Viandes et volailles,de la,Viande rouge,de l',Agneau - veau et gibiers,0.3,0.1,0.1,0.5,g,0.5,0.2,E,3
+Protéine,Enfants 1 à 8 ans,,de la,Viandes et volailles,de la,Viande rouge,des,Abats - foies et pâtés,X,X,,,g,X,X,<10,3
+Protéine,Enfants 1 à 8 ans,1789,des,Substituts de viande,,,,,3.6,0.2,3.2,4,g,6,0.3,,1
+Protéine,Enfants 1 à 8 ans,1450,des,Substituts de viande,des,Œufs,,,1.7,0.1,1.6,1.9,g,2.9,0.1,,2
+Protéine,Enfants 1 à 8 ans,210,des,Substituts de viande,des,Légumineuses,,,0.5,0.1,0.3,0.7,g,0.8,0.1,E,2
+Protéine,Enfants 1 à 8 ans,749,des,Substituts de viande,des,Noix - graines et beurre d'arachides,,,1.1,0.1,0.9,1.3,g,1.9,0.2,,2
+Protéine,Enfants 1 à 8 ans,58,des,Substituts de viande,du,Tofu et produits sans viande,,,F,F,,,g,F,F,F,2
+Protéine,Enfants 1 à 8 ans,45,des,Boissons et barres nutritionnelles,,,,,0.2,0,0.1,0.3,g,0.3,0.1,,1
+Protéine,Enfants 1 à 8 ans,40,des,Boissons et barres nutritionnelles,des,Substituts de repas et boissons nutritionnelles,,,0.2,0,0.1,0.2,g,0.3,0.1,,2
+Protéine,Enfants 1 à 8 ans,,des,Boissons et barres nutritionnelles,des,Barres nutritionnelles,,,X,X,,,g,X,X,<10,2
+Protéine,Enfants 1 à 8 ans,2295,des,Soupes - sauces - Épices et autres ingrédients,,,,,0.6,0,0.5,0.7,g,1,0.1,,1
+Protéine,Enfants 1 à 8 ans,761,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.2,0,0.1,0.2,g,0.3,0,,2
+Protéine,Enfants 1 à 8 ans,532,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0.3,0,0.2,0.4,g,0.5,0.1,,2
+Protéine,Enfants 1 à 8 ans,2205,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.1,0,0.1,0.1,g,0.2,0,,2
+Protéine,Enfants 1 à 8 ans,2106,des,Confiseries - sucres et grignotines salées,,,,,1.4,0.1,1.3,1.6,g,2.4,0.1,,1
+Protéine,Enfants 1 à 8 ans,1048,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,0.3,0,0.3,0.4,g,0.6,0,,2
+Protéine,Enfants 1 à 8 ans,497,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,0.5,0.1,0.4,0.6,g,0.9,0.1,E,2
+Protéine,Enfants 1 à 8 ans,615,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0.5,0,0.4,0.5,g,0.8,0.1,,2
+Protéine,Enfants 1 à 8 ans,1642,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.1,0,0.1,0.1,g,0.2,0,,2
+Protéine,Enfants 1 à 8 ans,548,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0.2,0,0.2,0.3,g,0.4,0,,3
+Protéine,Enfants 1 à 8 ans,557,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0,0,0,0,g,0.1,0,,3
+Protéine,Enfants 1 à 8 ans,131,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0.1,0,0.1,0.1,g,0.1,0,,3
+Protéine,Enfants 1 à 8 ans,346,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.5,0.1,0.4,0.6,g,0.8,0.1,E,3
+Protéine,Enfants 1 à 8 ans,184,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0.1,g,0.1,0,,3
+Protéine,Enfants 1 à 8 ans,720,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.1,0,0.1,0.1,g,0.2,0,,3
+Protéine,Enfants 1 à 8 ans,257,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0,0,,3
+Protéine,Enfants 1 à 8 ans,1341,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
+Protéine,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,g,X,X,<10,3
 Acides gras saturés,Population 1 an et +,186,des,Aliments pour bébés,,,,,0,0,0,0,g,0.1,0,,1
 Acides gras saturés,Population 1 an et +,154,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0,g,0,0,,2
 Acides gras saturés,Population 1 an et +,51,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0,0,0,0,g,0,0,,2
@@ -3690,7 +3690,7 @@ Acides gras saturés,Population 1 an et +,6318,des,Fruits et légumes,des,Légum
 Acides gras saturés,Population 1 an et +,19327,des,Produits céréaliers,,,,,2,0,1.9,2.1,g,8.7,0.2,,1
 Acides gras saturés,Population 1 an et +,16168,des,Produits céréaliers,des,Pains,,,1,0,1,1.1,g,4.5,0.1,,2
 Acides gras saturés,Population 1 an et +,6966,des,Produits céréaliers,des,Céréales pour déjeuner,,,0.2,0,0.2,0.2,g,0.9,0,,2
-Acides gras saturés,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.5,0,0.5,0.6,g,2.3,0.1,,2
+Acides gras saturés,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.5,0,0.5,0.6,g,2.3,0.1,,2
 Acides gras saturés,Population 1 an et +,14820,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,0.2,0,0.2,0.2,g,1,0,,2
 Acides gras saturés,Population 1 an et +,6257,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,0.5,0,0.4,0.5,g,2.1,0.1,,3
 Acides gras saturés,Population 1 an et +,8159,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,0.3,0,0.3,0.3,g,1.3,0.1,,3
@@ -3698,10 +3698,10 @@ Acides gras saturés,Population 1 an et +,5962,des,Produits céréaliers,des,Pai
 Acides gras saturés,Population 1 an et +,2918,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.1,0,0.1,0.1,g,0.4,0,,3
 Acides gras saturés,Population 1 an et +,4760,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.2,0,0.2,0.2,g,0.8,0,,3
 Acides gras saturés,Population 1 an et +,2573,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0,0,0,0,g,0.1,0,,3
-Acides gras saturés,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.1,g,0.5,0,,3
-Acides gras saturés,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0.1,0,,3
-Acides gras saturés,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
-Acides gras saturés,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
+Acides gras saturés,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.1,g,0.5,0,,3
+Acides gras saturés,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0.1,0,,3
+Acides gras saturés,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
+Acides gras saturés,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
 Acides gras saturés,Population 1 an et +,11102,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.1,0,0.1,0.1,g,0.4,0,,3
 Acides gras saturés,Population 1 an et +,4543,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.1,0,0.1,0.1,g,0.4,0,,3
 Acides gras saturés,Population 1 an et +,4598,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0,0,0,0,g,0.2,0,,3
@@ -3804,7 +3804,7 @@ Acides gras saturés,Hommes adultes 19 ans +,1991,des,Fruits et légumes,des,Lé
 Acides gras saturés,Hommes adultes 19 ans +,6068,des,Produits céréaliers,,,,,2.1,0.1,2,2.3,g,8.1,0.3,,1
 Acides gras saturés,Hommes adultes 19 ans +,5104,des,Produits céréaliers,des,Pains,,,1.1,0.1,1,1.3,g,4.4,0.2,,2
 Acides gras saturés,Hommes adultes 19 ans +,1921,des,Produits céréaliers,des,Céréales pour déjeuner,,,0.2,0,0.2,0.3,g,0.8,0.1,,2
-Acides gras saturés,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.5,0,0.4,0.6,g,2,0.2,,2
+Acides gras saturés,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.5,0,0.4,0.6,g,2,0.2,,2
 Acides gras saturés,Hommes adultes 19 ans +,4551,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,0.2,0,0.2,0.3,g,0.9,0,,2
 Acides gras saturés,Hommes adultes 19 ans +,1885,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,0.5,0.1,0.4,0.6,g,2,0.2,E,3
 Acides gras saturés,Hommes adultes 19 ans +,2752,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,0.4,0,0.3,0.5,g,1.5,0.1,,3
@@ -3812,9 +3812,9 @@ Acides gras saturés,Hommes adultes 19 ans +,1980,des,Produits céréaliers,des,
 Acides gras saturés,Hommes adultes 19 ans +,593,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.1,0,0,0.1,g,0.2,0,,3
 Acides gras saturés,Hommes adultes 19 ans +,1481,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.2,0,0.2,0.2,g,0.8,0.1,,3
 Acides gras saturés,Hommes adultes 19 ans +,523,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0,0,0,0,g,0.1,0,,3
-Acides gras saturés,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.1,g,0.4,0,,3
-Acides gras saturés,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0.1,0,,3
-Acides gras saturés,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
+Acides gras saturés,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.1,g,0.4,0,,3
+Acides gras saturés,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0.1,0,,3
+Acides gras saturés,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
 Acides gras saturés,Hommes adultes 19 ans +,3442,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.1,0,0.1,0.1,g,0.4,0,,3
 Acides gras saturés,Hommes adultes 19 ans +,1250,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.1,0,0.1,0.1,g,0.4,0,,3
 Acides gras saturés,Hommes adultes 19 ans +,1449,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0,0,0,0,g,0.1,0,,3
@@ -3917,7 +3917,7 @@ Acides gras saturés,Femmes adultes* 19 ans +,2348,des,Fruits et légumes,des,L�
 Acides gras saturés,Femmes adultes* 19 ans +,6669,des,Produits céréaliers,,,,,1.6,0.1,1.5,1.8,g,8.5,0.3,,1
 Acides gras saturés,Femmes adultes* 19 ans +,5520,des,Produits céréaliers,des,Pains,,,0.8,0,0.8,0.9,g,4.4,0.2,,2
 Acides gras saturés,Femmes adultes* 19 ans +,2230,des,Produits céréaliers,des,Céréales pour déjeuner,,,0.2,0,0.1,0.2,g,0.9,0.1,,2
-Acides gras saturés,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.4,0,0.4,0.5,g,2.3,0.2,,2
+Acides gras saturés,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.4,0,0.4,0.5,g,2.3,0.2,,2
 Acides gras saturés,Femmes adultes* 19 ans +,4893,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,0.2,0,0.2,0.2,g,1,0.1,,2
 Acides gras saturés,Femmes adultes* 19 ans +,1994,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,0.4,0,0.3,0.5,g,2,0.2,,3
 Acides gras saturés,Femmes adultes* 19 ans +,2551,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,0.2,0,0.2,0.3,g,1.2,0.1,,3
@@ -3925,10 +3925,10 @@ Acides gras saturés,Femmes adultes* 19 ans +,2239,des,Produits céréaliers,des
 Acides gras saturés,Femmes adultes* 19 ans +,914,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.1,0,0,0.1,g,0.3,0,,3
 Acides gras saturés,Femmes adultes* 19 ans +,1756,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.2,0,0.1,0.2,g,0.9,0.1,,3
 Acides gras saturés,Femmes adultes* 19 ans +,555,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0,0,0,0,g,0.1,0,,3
-Acides gras saturés,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.1,g,0.3,0,,3
-Acides gras saturés,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0,0,,3
-Acides gras saturés,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
-Acides gras saturés,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
+Acides gras saturés,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.1,g,0.3,0,,3
+Acides gras saturés,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0,0,,3
+Acides gras saturés,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
+Acides gras saturés,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
 Acides gras saturés,Femmes adultes* 19 ans +,3664,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.1,0,0.1,0.1,g,0.4,0,,3
 Acides gras saturés,Femmes adultes* 19 ans +,1358,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.1,0,0.1,0.1,g,0.4,0.1,,3
 Acides gras saturés,Femmes adultes* 19 ans +,1522,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0,0,0,0,g,0.2,0,,3
@@ -3972,119 +3972,119 @@ Acides gras saturés,Femmes adultes* 19 ans +,1529,des,Confiseries - sucres et g
 Acides gras saturés,Femmes adultes* 19 ans +,773,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0,0,,3
 Acides gras saturés,Femmes adultes* 19 ans +,360,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
 Acides gras saturés,Femmes adultes* 19 ans +,4229,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
-Acides gras saturés,Enfants 1 à 8 ans,122,des,Aliments pour bébés,,,,,0.1,0,0.1,0.2,g,0.6,0.1,,1
-Acides gras saturés,Enfants 1 à 8 ans,95,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0,g,0.1,0,,2
-Acides gras saturés,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0.1,0,0,0.1,g,0.5,0.1,,2
-Acides gras saturés,Enfants 1 à 8 ans,2443,des,Boissons (excluant laits),,,,,0,0,0,0.1,g,0.2,0,,1
-Acides gras saturés,Enfants 1 à 8 ans,20,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0,g,0,0,,2
-Acides gras saturés,Enfants 1 à 8 ans,141,des,Boissons (excluant laits),du,Café et thé,,,0,0,0,0,g,0,0,,2
-Acides gras saturés,Enfants 1 à 8 ans,,des,Boissons (excluant laits),des,Boissons Énergisantes,,,X,X,,,g,X,X,<10,2
-Acides gras saturés,Enfants 1 à 8 ans,357,des,Boissons (excluant laits),des,Boissons aux fruits,,,0,0,0,0,g,0,0,,2
-Acides gras saturés,Enfants 1 à 8 ans,1159,des,Boissons (excluant laits),des,Jus de fruit,,,0,0,0,0,g,0.1,0,,2
-Acides gras saturés,Enfants 1 à 8 ans,77,des,Boissons (excluant laits),des,Autres boissons,,,0,0,0,0,g,0.1,0,,2
-Acides gras saturés,Enfants 1 à 8 ans,142,des,Boissons (excluant laits),des,Boissons gazeuses,,,0,0,0,0,g,0,0,,2
-Acides gras saturés,Enfants 1 à 8 ans,21,des,Boissons (excluant laits),des,Boissons pour sportifs,,,0,0,0,0,g,0,0,,2
-Acides gras saturés,Enfants 1 à 8 ans,52,des,Boissons (excluant laits),des,Jus de tomates et de légumes,,,0,0,0,0,g,0,0,,2
-Acides gras saturés,Enfants 1 à 8 ans,,des,Boissons (excluant laits),de l',Eau vitaminée,,,X,X,,,g,X,X,<10,2
-Acides gras saturés,Enfants 1 à 8 ans,2344,des,Boissons (excluant laits),de l',Eau,,,0,0,0,0,g,0,0,,2
-Acides gras saturés,Enfants 1 à 8 ans,133,des,Boissons (excluant laits),du,Café et thé,du,Thé,0,0,0,0,g,0,0,,3
-Acides gras saturés,Enfants 1 à 8 ans,,des,Boissons (excluant laits),du,Café et thé,du,Café,X,X,,,g,X,X,<10,3
-Acides gras saturés,Enfants 1 à 8 ans,2436,des,Produits laitiers et Boissons à base de plantes,,,,,8.8,0.2,8.3,9.3,g,44.4,0.9,,1
-Acides gras saturés,Enfants 1 à 8 ans,1632,des,Produits laitiers et Boissons à base de plantes,des,Fromages,,,3.5,0.2,3.2,3.9,g,17.8,0.8,,2
-Acides gras saturés,Enfants 1 à 8 ans,2341,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,4.7,0.1,4.4,4.9,g,23.5,0.6,,2
-Acides gras saturés,Enfants 1 à 8 ans,1032,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,,,0.6,0,0.5,0.7,g,3.1,0.2,,2
-Acides gras saturés,Enfants 1 à 8 ans,1810,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,2,0.1,1.9,2.2,g,10.3,0.5,,3
-Acides gras saturés,Enfants 1 à 8 ans,1078,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,2,0.1,1.7,2.2,g,10,0.6,,3
-Acides gras saturés,Enfants 1 à 8 ans,854,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,0.4,0,0.3,0.4,g,1.8,0.2,,3
-Acides gras saturés,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0.2,0,0.2,0.3,g,1.3,0.2,,3
-Acides gras saturés,Enfants 1 à 8 ans,128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0,0,0,0,g,0,0,,3
-Acides gras saturés,Enfants 1 à 8 ans,739,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0,0,0,0,g,0,0,,3
-Acides gras saturés,Enfants 1 à 8 ans,2270,des,Graisses et huiles,,,,,2.8,0.1,2.5,3,g,13.9,0.5,,1
-Acides gras saturés,Enfants 1 à 8 ans,83,des,Graisses et huiles,des,Graisses animales,,,0.1,0,0,0.1,g,0.3,0.1,,2
-Acides gras saturés,Enfants 1 à 8 ans,657,des,Graisses et huiles,du,Beurre,,,0.9,0.1,0.8,1.1,g,4.8,0.4,,2
-Acides gras saturés,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Margarines,,,0.5,0,0.5,0.6,g,2.6,0.1,,2
-Acides gras saturés,Enfants 1 à 8 ans,463,des,Graisses et huiles,des,Sauces pour salade,,,0.2,0,0.1,0.2,g,0.8,0.1,,2
-Acides gras saturés,Enfants 1 à 8 ans,1035,des,Graisses et huiles,du,Shortening,,,0.7,0,0.6,0.8,g,3.7,0.2,,2
-Acides gras saturés,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Huiles végétales,,,0.3,0,0.3,0.4,g,1.7,0.1,,2
-Acides gras saturés,Enfants 1 à 8 ans,298,des,Poissons et fruits de mer,,,,,0.1,0,0,0.1,g,0.4,0.1,,1
-Acides gras saturés,Enfants 1 à 8 ans,257,des,Poissons et fruits de mer,des,Poissons,,,0.1,0,0,0.1,g,0.4,0.1,,2
-Acides gras saturés,Enfants 1 à 8 ans,50,des,Poissons et fruits de mer,des,Mollusques et crustacés,,,0,0,0,0,g,0,0,,2
-Acides gras saturés,Enfants 1 à 8 ans,2428,des,Fruits et légumes,,,,,0.3,0,0.2,0.3,g,1.3,0.1,,1
-Acides gras saturés,Enfants 1 à 8 ans,2117,des,Fruits et légumes,des,Fruits,,,0.1,0,0.1,0.1,g,0.5,0.1,,2
-Acides gras saturés,Enfants 1 à 8 ans,2235,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,0.2,0,0.1,0.2,g,0.8,0.1,,2
-Acides gras saturés,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Bananes,0,0,0,0,g,0.2,0,,3
-Acides gras saturés,Enfants 1 à 8 ans,260,des,Fruits et légumes,des,Fruits,des,Autres fruits,0,0,0,0.1,g,0.2,0.1,,3
-Acides gras saturés,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pommes,0,0,0,0,g,0.1,0,,3
-Acides gras saturés,Enfants 1 à 8 ans,830,des,Fruits et légumes,des,Fruits,des,Baies,0,0,0,0,g,0,0,,3
-Acides gras saturés,Enfants 1 à 8 ans,47,des,Fruits et légumes,des,Fruits,des,Cerises,0,0,0,0,g,0,0,,3
-Acides gras saturés,Enfants 1 à 8 ans,421,des,Fruits et légumes,des,Fruits,des,Agrumes,0,0,0,0,g,0,0,,3
-Acides gras saturés,Enfants 1 à 8 ans,572,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,0,0,0,0,g,0,0,,3
-Acides gras saturés,Enfants 1 à 8 ans,219,des,Fruits et légumes,des,Fruits,des,Melons,0,0,0,0,g,0,0,,3
-Acides gras saturés,Enfants 1 à 8 ans,118,des,Fruits et légumes,des,Fruits,des,Pêches et nectarines,0,0,0,0,g,0,0,,3
-Acides gras saturés,Enfants 1 à 8 ans,133,des,Fruits et légumes,des,Fruits,des,Poires,0,0,0,0,g,0,0,,3
-Acides gras saturés,Enfants 1 à 8 ans,94,des,Fruits et légumes,des,Fruits,des,Ananas,0,0,0,0,g,0,0,,3
-Acides gras saturés,Enfants 1 à 8 ans,37,des,Fruits et légumes,des,Fruits,des,Prunes et pruneaux,0,0,0,0,g,0,0,,3
-Acides gras saturés,Enfants 1 à 8 ans,1032,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes féculents,0.1,0,0.1,0.1,g,0.5,0,,3
-Acides gras saturés,Enfants 1 à 8 ans,1773,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Autres légumes,0,0,0,0,g,0.2,0,,3
-Acides gras saturés,Enfants 1 à 8 ans,1068,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes vert foncé,0,0,0,0,g,0.1,0,,3
-Acides gras saturés,Enfants 1 à 8 ans,875,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes jaune foncé ou orange,0,0,0,0,g,0,0,,3
-Acides gras saturés,Enfants 1 à 8 ans,2475,des,Produits céréaliers,,,,,2,0.1,1.9,2.2,g,10.2,0.4,,1
-Acides gras saturés,Enfants 1 à 8 ans,2114,des,Produits céréaliers,des,Pains,,,1,0.1,0.9,1.1,g,4.9,0.3,,2
-Acides gras saturés,Enfants 1 à 8 ans,1282,des,Produits céréaliers,des,Céréales pour déjeuner,,,0.2,0,0.1,0.2,g,0.8,0.1,,2
-Acides gras saturés,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.7,0.1,0.6,0.8,g,3.3,0.3,,2
-Acides gras saturés,Enfants 1 à 8 ans,2037,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,0.2,0,0.2,0.2,g,1.1,0.1,,2
-Acides gras saturés,Enfants 1 à 8 ans,805,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,0.4,0,0.3,0.5,g,1.9,0.2,,3
-Acides gras saturés,Enfants 1 à 8 ans,745,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.3,0,0.2,0.3,g,1.4,0.1,,3
-Acides gras saturés,Enfants 1 à 8 ans,951,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,0.2,0,0.2,0.2,g,1.1,0.1,,3
-Acides gras saturés,Enfants 1 à 8 ans,813,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,0.1,0,0.1,0.1,g,0.6,0,,3
-Acides gras saturés,Enfants 1 à 8 ans,728,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.1,0,0.1,0.1,g,0.5,0.1,,3
-Acides gras saturés,Enfants 1 à 8 ans,670,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.1,0,0,0.1,g,0.3,0,,3
-Acides gras saturés,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.2,g,0.7,0.1,,3
-Acides gras saturés,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0.1,0,,3
-Acides gras saturés,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0.1,0,,3
-Acides gras saturés,Enfants 1 à 8 ans,834,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.1,0,0.1,0.1,g,0.6,0.1,,3
-Acides gras saturés,Enfants 1 à 8 ans,1461,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.1,0,0.1,0.1,g,0.3,0,,3
-Acides gras saturés,Enfants 1 à 8 ans,654,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0,0,0,0,g,0.1,0,,3
-Acides gras saturés,Enfants 1 à 8 ans,2072,de la,Viandes et volailles,,,,,2.4,0.1,2.2,2.6,g,12.2,0.5,,1
-Acides gras saturés,Enfants 1 à 8 ans,1003,de la,Viandes et volailles,de la,Volaille,,,0.5,0,0.4,0.6,g,2.7,0.2,,2
-Acides gras saturés,Enfants 1 à 8 ans,942,de la,Viandes et volailles,des,Viandes transformées,,,1.1,0.1,0.9,1.2,g,5.3,0.4,,2
-Acides gras saturés,Enfants 1 à 8 ans,999,de la,Viandes et volailles,de la,Viande rouge,,,0.8,0.1,0.7,1,g,4.3,0.3,,2
-Acides gras saturés,Enfants 1 à 8 ans,933,de la,Viandes et volailles,de la,Volaille,du,Poulet,0.5,0,0.4,0.6,g,2.6,0.2,,3
-Acides gras saturés,Enfants 1 à 8 ans,86,de la,Viandes et volailles,de la,Volaille,de la,Dinde et autres volailles,0,0,0,0,g,0.1,0,,3
-Acides gras saturés,Enfants 1 à 8 ans,375,de la,Viandes et volailles,des,Viandes transformées,des,Saucisses,0.6,0.1,0.5,0.8,g,3.2,0.4,E,3
-Acides gras saturés,Enfants 1 à 8 ans,513,de la,Viandes et volailles,des,Viandes transformées,des,Viandes froides,0.3,0,0.2,0.4,g,1.5,0.2,,3
-Acides gras saturés,Enfants 1 à 8 ans,135,de la,Viandes et volailles,des,Viandes transformées,du,Bacon,0.1,0,0,0.1,g,0.3,0.1,,3
-Acides gras saturés,Enfants 1 à 8 ans,106,de la,Viandes et volailles,des,Viandes transformées,du,Porc salé,0,0,0,0.1,g,0.2,0.1,,3
-Acides gras saturés,Enfants 1 à 8 ans,779,de la,Viandes et volailles,de la,Viande rouge,du,Bœuf,0.6,0,0.5,0.7,g,3.1,0.2,,3
-Acides gras saturés,Enfants 1 à 8 ans,284,de la,Viandes et volailles,de la,Viande rouge,du,Porc frais,0.2,0,0.1,0.2,g,0.9,0.1,,3
-Acides gras saturés,Enfants 1 à 8 ans,43,de la,Viandes et volailles,de la,Viande rouge,de l',Agneau - veau et gibiers,0,0,0,0.1,g,0.2,0.1,,3
-Acides gras saturés,Enfants 1 à 8 ans,,de la,Viandes et volailles,de la,Viande rouge,des,Abats - foies et pâtés,X,X,,,g,X,X,<10,3
-Acides gras saturés,Enfants 1 à 8 ans,1789,des,Substituts de viande,,,,,0.9,0.1,0.8,1,g,4.6,0.3,,1
-Acides gras saturés,Enfants 1 à 8 ans,1450,des,Substituts de viande,des,Œufs,,,0.4,0,0.4,0.5,g,2.2,0.1,,2
-Acides gras saturés,Enfants 1 à 8 ans,210,des,Substituts de viande,des,Légumineuses,,,0,0,0,0,g,0.1,0,,2
-Acides gras saturés,Enfants 1 à 8 ans,749,des,Substituts de viande,des,Noix - graines et beurre d'arachides,,,0.4,0.1,0.3,0.5,g,2.2,0.3,E,2
-Acides gras saturés,Enfants 1 à 8 ans,58,des,Substituts de viande,du,Tofu et produits sans viande,,,0,0,0,0,g,0.1,0,,2
-Acides gras saturés,Enfants 1 à 8 ans,45,des,Boissons et barres nutritionnelles,,,,,0,0,0,0.1,g,0.2,0.1,,1
-Acides gras saturés,Enfants 1 à 8 ans,40,des,Boissons et barres nutritionnelles,des,Substituts de repas et boissons nutritionnelles,,,0,0,0,0.1,g,0.2,0.1,,2
-Acides gras saturés,Enfants 1 à 8 ans,,des,Boissons et barres nutritionnelles,des,Barres nutritionnelles,,,X,X,,,g,X,X,<10,2
-Acides gras saturés,Enfants 1 à 8 ans,2295,des,Soupes - sauces - Épices et autres ingrédients,,,,,0.3,0.1,0.1,0.4,g,1.4,0.4,E,1
-Acides gras saturés,Enfants 1 à 8 ans,761,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,F,F,,,g,F,F,F,2
-Acides gras saturés,Enfants 1 à 8 ans,532,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0,0,0,0.1,g,0.2,0,,2
-Acides gras saturés,Enfants 1 à 8 ans,2205,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0,0,0,0,g,0.1,0,,2
-Acides gras saturés,Enfants 1 à 8 ans,2106,des,Confiseries - sucres et grignotines salées,,,,,2.1,0.1,1.8,2.4,g,10.5,0.6,,1
-Acides gras saturés,Enfants 1 à 8 ans,1048,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,0.7,0.1,0.6,0.8,g,3.4,0.3,,2
-Acides gras saturés,Enfants 1 à 8 ans,497,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,0.8,0.1,0.6,1,g,4.1,0.4,,2
-Acides gras saturés,Enfants 1 à 8 ans,615,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0.2,0,0.2,0.3,g,1.2,0.1,,2
-Acides gras saturés,Enfants 1 à 8 ans,1642,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.4,0.1,0.2,0.5,g,1.8,0.3,E,2
-Acides gras saturés,Enfants 1 à 8 ans,548,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0.6,0.1,0.5,0.7,g,3,0.3,E,3
-Acides gras saturés,Enfants 1 à 8 ans,557,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0.1,0,0,0.1,g,0.3,0,,3
-Acides gras saturés,Enfants 1 à 8 ans,131,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0,0,0,0,g,0.2,0,,3
-Acides gras saturés,Enfants 1 à 8 ans,346,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.8,0.1,0.6,1,g,4.1,0.4,,3
-Acides gras saturés,Enfants 1 à 8 ans,184,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0,0,,3
-Acides gras saturés,Enfants 1 à 8 ans,720,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.4,0.1,0.2,0.5,g,1.8,0.3,E,3
-Acides gras saturés,Enfants 1 à 8 ans,257,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0,0,,3
-Acides gras saturés,Enfants 1 à 8 ans,1341,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
-Acides gras saturés,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,g,X,X,<10,3
+Acides gras saturés,Enfants 1 à 8 ans,122,des,Aliments pour bébés,,,,,0.1,0,0.1,0.2,g,0.6,0.1,,1
+Acides gras saturés,Enfants 1 à 8 ans,95,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0,g,0.1,0,,2
+Acides gras saturés,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0.1,0,0,0.1,g,0.5,0.1,,2
+Acides gras saturés,Enfants 1 à 8 ans,2443,des,Boissons (excluant laits),,,,,0,0,0,0.1,g,0.2,0,,1
+Acides gras saturés,Enfants 1 à 8 ans,20,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0,g,0,0,,2
+Acides gras saturés,Enfants 1 à 8 ans,141,des,Boissons (excluant laits),du,Café et thé,,,0,0,0,0,g,0,0,,2
+Acides gras saturés,Enfants 1 à 8 ans,,des,Boissons (excluant laits),des,Boissons Énergisantes,,,X,X,,,g,X,X,<10,2
+Acides gras saturés,Enfants 1 à 8 ans,357,des,Boissons (excluant laits),des,Boissons aux fruits,,,0,0,0,0,g,0,0,,2
+Acides gras saturés,Enfants 1 à 8 ans,1159,des,Boissons (excluant laits),des,Jus de fruit,,,0,0,0,0,g,0.1,0,,2
+Acides gras saturés,Enfants 1 à 8 ans,77,des,Boissons (excluant laits),des,Autres boissons,,,0,0,0,0,g,0.1,0,,2
+Acides gras saturés,Enfants 1 à 8 ans,142,des,Boissons (excluant laits),des,Boissons gazeuses,,,0,0,0,0,g,0,0,,2
+Acides gras saturés,Enfants 1 à 8 ans,21,des,Boissons (excluant laits),des,Boissons pour sportifs,,,0,0,0,0,g,0,0,,2
+Acides gras saturés,Enfants 1 à 8 ans,52,des,Boissons (excluant laits),des,Jus de tomates et de légumes,,,0,0,0,0,g,0,0,,2
+Acides gras saturés,Enfants 1 à 8 ans,,des,Boissons (excluant laits),de l',Eau vitaminée,,,X,X,,,g,X,X,<10,2
+Acides gras saturés,Enfants 1 à 8 ans,2344,des,Boissons (excluant laits),de l',Eau,,,0,0,0,0,g,0,0,,2
+Acides gras saturés,Enfants 1 à 8 ans,133,des,Boissons (excluant laits),du,Café et thé,du,Thé,0,0,0,0,g,0,0,,3
+Acides gras saturés,Enfants 1 à 8 ans,,des,Boissons (excluant laits),du,Café et thé,du,Café,X,X,,,g,X,X,<10,3
+Acides gras saturés,Enfants 1 à 8 ans,2436,des,Produits laitiers et Boissons à base de plantes,,,,,8.8,0.2,8.3,9.3,g,44.4,0.9,,1
+Acides gras saturés,Enfants 1 à 8 ans,1632,des,Produits laitiers et Boissons à base de plantes,des,Fromages,,,3.5,0.2,3.2,3.9,g,17.8,0.8,,2
+Acides gras saturés,Enfants 1 à 8 ans,2341,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,4.7,0.1,4.4,4.9,g,23.5,0.6,,2
+Acides gras saturés,Enfants 1 à 8 ans,1032,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,,,0.6,0,0.5,0.7,g,3.1,0.2,,2
+Acides gras saturés,Enfants 1 à 8 ans,1810,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,2,0.1,1.9,2.2,g,10.3,0.5,,3
+Acides gras saturés,Enfants 1 à 8 ans,1078,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,2,0.1,1.7,2.2,g,10,0.6,,3
+Acides gras saturés,Enfants 1 à 8 ans,854,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,0.4,0,0.3,0.4,g,1.8,0.2,,3
+Acides gras saturés,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0.2,0,0.2,0.3,g,1.3,0.2,,3
+Acides gras saturés,Enfants 1 à 8 ans,128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0,0,0,0,g,0,0,,3
+Acides gras saturés,Enfants 1 à 8 ans,739,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0,0,0,0,g,0,0,,3
+Acides gras saturés,Enfants 1 à 8 ans,2270,des,Graisses et huiles,,,,,2.8,0.1,2.5,3,g,13.9,0.5,,1
+Acides gras saturés,Enfants 1 à 8 ans,83,des,Graisses et huiles,des,Graisses animales,,,0.1,0,0,0.1,g,0.3,0.1,,2
+Acides gras saturés,Enfants 1 à 8 ans,657,des,Graisses et huiles,du,Beurre,,,0.9,0.1,0.8,1.1,g,4.8,0.4,,2
+Acides gras saturés,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Margarines,,,0.5,0,0.5,0.6,g,2.6,0.1,,2
+Acides gras saturés,Enfants 1 à 8 ans,463,des,Graisses et huiles,des,Sauces pour salade,,,0.2,0,0.1,0.2,g,0.8,0.1,,2
+Acides gras saturés,Enfants 1 à 8 ans,1035,des,Graisses et huiles,du,Shortening,,,0.7,0,0.6,0.8,g,3.7,0.2,,2
+Acides gras saturés,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Huiles végétales,,,0.3,0,0.3,0.4,g,1.7,0.1,,2
+Acides gras saturés,Enfants 1 à 8 ans,298,des,Poissons et fruits de mer,,,,,0.1,0,0,0.1,g,0.4,0.1,,1
+Acides gras saturés,Enfants 1 à 8 ans,257,des,Poissons et fruits de mer,des,Poissons,,,0.1,0,0,0.1,g,0.4,0.1,,2
+Acides gras saturés,Enfants 1 à 8 ans,50,des,Poissons et fruits de mer,des,Mollusques et crustacés,,,0,0,0,0,g,0,0,,2
+Acides gras saturés,Enfants 1 à 8 ans,2428,des,Fruits et légumes,,,,,0.3,0,0.2,0.3,g,1.3,0.1,,1
+Acides gras saturés,Enfants 1 à 8 ans,2117,des,Fruits et légumes,des,Fruits,,,0.1,0,0.1,0.1,g,0.5,0.1,,2
+Acides gras saturés,Enfants 1 à 8 ans,2235,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,0.2,0,0.1,0.2,g,0.8,0.1,,2
+Acides gras saturés,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Bananes,0,0,0,0,g,0.2,0,,3
+Acides gras saturés,Enfants 1 à 8 ans,260,des,Fruits et légumes,des,Fruits,des,Autres fruits,0,0,0,0.1,g,0.2,0.1,,3
+Acides gras saturés,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pommes,0,0,0,0,g,0.1,0,,3
+Acides gras saturés,Enfants 1 à 8 ans,830,des,Fruits et légumes,des,Fruits,des,Baies,0,0,0,0,g,0,0,,3
+Acides gras saturés,Enfants 1 à 8 ans,47,des,Fruits et légumes,des,Fruits,des,Cerises,0,0,0,0,g,0,0,,3
+Acides gras saturés,Enfants 1 à 8 ans,421,des,Fruits et légumes,des,Fruits,des,Agrumes,0,0,0,0,g,0,0,,3
+Acides gras saturés,Enfants 1 à 8 ans,572,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,0,0,0,0,g,0,0,,3
+Acides gras saturés,Enfants 1 à 8 ans,219,des,Fruits et légumes,des,Fruits,des,Melons,0,0,0,0,g,0,0,,3
+Acides gras saturés,Enfants 1 à 8 ans,118,des,Fruits et légumes,des,Fruits,des,Pêches et nectarines,0,0,0,0,g,0,0,,3
+Acides gras saturés,Enfants 1 à 8 ans,133,des,Fruits et légumes,des,Fruits,des,Poires,0,0,0,0,g,0,0,,3
+Acides gras saturés,Enfants 1 à 8 ans,94,des,Fruits et légumes,des,Fruits,des,Ananas,0,0,0,0,g,0,0,,3
+Acides gras saturés,Enfants 1 à 8 ans,37,des,Fruits et légumes,des,Fruits,des,Prunes et pruneaux,0,0,0,0,g,0,0,,3
+Acides gras saturés,Enfants 1 à 8 ans,1032,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes féculents,0.1,0,0.1,0.1,g,0.5,0,,3
+Acides gras saturés,Enfants 1 à 8 ans,1773,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Autres légumes,0,0,0,0,g,0.2,0,,3
+Acides gras saturés,Enfants 1 à 8 ans,1068,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes vert foncé,0,0,0,0,g,0.1,0,,3
+Acides gras saturés,Enfants 1 à 8 ans,875,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes jaune foncé ou orange,0,0,0,0,g,0,0,,3
+Acides gras saturés,Enfants 1 à 8 ans,2475,des,Produits céréaliers,,,,,2,0.1,1.9,2.2,g,10.2,0.4,,1
+Acides gras saturés,Enfants 1 à 8 ans,2114,des,Produits céréaliers,des,Pains,,,1,0.1,0.9,1.1,g,4.9,0.3,,2
+Acides gras saturés,Enfants 1 à 8 ans,1282,des,Produits céréaliers,des,Céréales pour déjeuner,,,0.2,0,0.1,0.2,g,0.8,0.1,,2
+Acides gras saturés,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.7,0.1,0.6,0.8,g,3.3,0.3,,2
+Acides gras saturés,Enfants 1 à 8 ans,2037,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,0.2,0,0.2,0.2,g,1.1,0.1,,2
+Acides gras saturés,Enfants 1 à 8 ans,805,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,0.4,0,0.3,0.5,g,1.9,0.2,,3
+Acides gras saturés,Enfants 1 à 8 ans,745,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.3,0,0.2,0.3,g,1.4,0.1,,3
+Acides gras saturés,Enfants 1 à 8 ans,951,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,0.2,0,0.2,0.2,g,1.1,0.1,,3
+Acides gras saturés,Enfants 1 à 8 ans,813,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,0.1,0,0.1,0.1,g,0.6,0,,3
+Acides gras saturés,Enfants 1 à 8 ans,728,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.1,0,0.1,0.1,g,0.5,0.1,,3
+Acides gras saturés,Enfants 1 à 8 ans,670,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.1,0,0,0.1,g,0.3,0,,3
+Acides gras saturés,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.2,g,0.7,0.1,,3
+Acides gras saturés,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0.1,0,,3
+Acides gras saturés,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0.1,0,,3
+Acides gras saturés,Enfants 1 à 8 ans,834,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.1,0,0.1,0.1,g,0.6,0.1,,3
+Acides gras saturés,Enfants 1 à 8 ans,1461,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.1,0,0.1,0.1,g,0.3,0,,3
+Acides gras saturés,Enfants 1 à 8 ans,654,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0,0,0,0,g,0.1,0,,3
+Acides gras saturés,Enfants 1 à 8 ans,2072,de la,Viandes et volailles,,,,,2.4,0.1,2.2,2.6,g,12.2,0.5,,1
+Acides gras saturés,Enfants 1 à 8 ans,1003,de la,Viandes et volailles,de la,Volaille,,,0.5,0,0.4,0.6,g,2.7,0.2,,2
+Acides gras saturés,Enfants 1 à 8 ans,942,de la,Viandes et volailles,des,Viandes transformées,,,1.1,0.1,0.9,1.2,g,5.3,0.4,,2
+Acides gras saturés,Enfants 1 à 8 ans,999,de la,Viandes et volailles,de la,Viande rouge,,,0.8,0.1,0.7,1,g,4.3,0.3,,2
+Acides gras saturés,Enfants 1 à 8 ans,933,de la,Viandes et volailles,de la,Volaille,du,Poulet,0.5,0,0.4,0.6,g,2.6,0.2,,3
+Acides gras saturés,Enfants 1 à 8 ans,86,de la,Viandes et volailles,de la,Volaille,de la,Dinde et autres volailles,0,0,0,0,g,0.1,0,,3
+Acides gras saturés,Enfants 1 à 8 ans,375,de la,Viandes et volailles,des,Viandes transformées,des,Saucisses,0.6,0.1,0.5,0.8,g,3.2,0.4,E,3
+Acides gras saturés,Enfants 1 à 8 ans,513,de la,Viandes et volailles,des,Viandes transformées,des,Viandes froides,0.3,0,0.2,0.4,g,1.5,0.2,,3
+Acides gras saturés,Enfants 1 à 8 ans,135,de la,Viandes et volailles,des,Viandes transformées,du,Bacon,0.1,0,0,0.1,g,0.3,0.1,,3
+Acides gras saturés,Enfants 1 à 8 ans,106,de la,Viandes et volailles,des,Viandes transformées,du,Porc salé,0,0,0,0.1,g,0.2,0.1,,3
+Acides gras saturés,Enfants 1 à 8 ans,779,de la,Viandes et volailles,de la,Viande rouge,du,Bœuf,0.6,0,0.5,0.7,g,3.1,0.2,,3
+Acides gras saturés,Enfants 1 à 8 ans,284,de la,Viandes et volailles,de la,Viande rouge,du,Porc frais,0.2,0,0.1,0.2,g,0.9,0.1,,3
+Acides gras saturés,Enfants 1 à 8 ans,43,de la,Viandes et volailles,de la,Viande rouge,de l',Agneau - veau et gibiers,0,0,0,0.1,g,0.2,0.1,,3
+Acides gras saturés,Enfants 1 à 8 ans,,de la,Viandes et volailles,de la,Viande rouge,des,Abats - foies et pâtés,X,X,,,g,X,X,<10,3
+Acides gras saturés,Enfants 1 à 8 ans,1789,des,Substituts de viande,,,,,0.9,0.1,0.8,1,g,4.6,0.3,,1
+Acides gras saturés,Enfants 1 à 8 ans,1450,des,Substituts de viande,des,Œufs,,,0.4,0,0.4,0.5,g,2.2,0.1,,2
+Acides gras saturés,Enfants 1 à 8 ans,210,des,Substituts de viande,des,Légumineuses,,,0,0,0,0,g,0.1,0,,2
+Acides gras saturés,Enfants 1 à 8 ans,749,des,Substituts de viande,des,Noix - graines et beurre d'arachides,,,0.4,0.1,0.3,0.5,g,2.2,0.3,E,2
+Acides gras saturés,Enfants 1 à 8 ans,58,des,Substituts de viande,du,Tofu et produits sans viande,,,0,0,0,0,g,0.1,0,,2
+Acides gras saturés,Enfants 1 à 8 ans,45,des,Boissons et barres nutritionnelles,,,,,0,0,0,0.1,g,0.2,0.1,,1
+Acides gras saturés,Enfants 1 à 8 ans,40,des,Boissons et barres nutritionnelles,des,Substituts de repas et boissons nutritionnelles,,,0,0,0,0.1,g,0.2,0.1,,2
+Acides gras saturés,Enfants 1 à 8 ans,,des,Boissons et barres nutritionnelles,des,Barres nutritionnelles,,,X,X,,,g,X,X,<10,2
+Acides gras saturés,Enfants 1 à 8 ans,2295,des,Soupes - sauces - Épices et autres ingrédients,,,,,0.3,0.1,0.1,0.4,g,1.4,0.4,E,1
+Acides gras saturés,Enfants 1 à 8 ans,761,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,F,F,,,g,F,F,F,2
+Acides gras saturés,Enfants 1 à 8 ans,532,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0,0,0,0.1,g,0.2,0,,2
+Acides gras saturés,Enfants 1 à 8 ans,2205,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0,0,0,0,g,0.1,0,,2
+Acides gras saturés,Enfants 1 à 8 ans,2106,des,Confiseries - sucres et grignotines salées,,,,,2.1,0.1,1.8,2.4,g,10.5,0.6,,1
+Acides gras saturés,Enfants 1 à 8 ans,1048,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,0.7,0.1,0.6,0.8,g,3.4,0.3,,2
+Acides gras saturés,Enfants 1 à 8 ans,497,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,0.8,0.1,0.6,1,g,4.1,0.4,,2
+Acides gras saturés,Enfants 1 à 8 ans,615,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0.2,0,0.2,0.3,g,1.2,0.1,,2
+Acides gras saturés,Enfants 1 à 8 ans,1642,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.4,0.1,0.2,0.5,g,1.8,0.3,E,2
+Acides gras saturés,Enfants 1 à 8 ans,548,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0.6,0.1,0.5,0.7,g,3,0.3,E,3
+Acides gras saturés,Enfants 1 à 8 ans,557,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0.1,0,0,0.1,g,0.3,0,,3
+Acides gras saturés,Enfants 1 à 8 ans,131,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0,0,0,0,g,0.2,0,,3
+Acides gras saturés,Enfants 1 à 8 ans,346,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.8,0.1,0.6,1,g,4.1,0.4,,3
+Acides gras saturés,Enfants 1 à 8 ans,184,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0,0,,3
+Acides gras saturés,Enfants 1 à 8 ans,720,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.4,0.1,0.2,0.5,g,1.8,0.3,E,3
+Acides gras saturés,Enfants 1 à 8 ans,257,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0,0,,3
+Acides gras saturés,Enfants 1 à 8 ans,1341,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
+Acides gras saturés,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,g,X,X,<10,3
 Sodium,Population 1 an et +,186,des,Aliments pour bébés,,,,,0.3,0.1,0.1,0.5,mg,0,0,E,1
 Sodium,Population 1 an et +,154,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,F,F,,,mg,F,F,F,2
 Sodium,Population 1 an et +,51,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0.1,0,0.1,0.2,mg,0,0,,2
@@ -4144,7 +4144,7 @@ Sodium,Population 1 an et +,2923,des,Fruits et légumes,des,Légumes incluant po
 Sodium,Population 1 an et +,19327,des,Produits céréaliers,,,,,523.7,6.7,510.5,536.8,mg,19.5,0.2,,1
 Sodium,Population 1 an et +,16168,des,Produits céréaliers,des,Pains,,,428.7,6.1,416.7,440.8,mg,15.9,0.2,,2
 Sodium,Population 1 an et +,6966,des,Produits céréaliers,des,Céréales pour déjeuner,,,42.7,1.3,40.1,45.2,mg,1.6,0,,2
-Sodium,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,35.7,1.9,31.9,39.5,mg,1.3,0.1,,2
+Sodium,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,35.7,1.9,31.9,39.5,mg,1.3,0.1,,2
 Sodium,Population 1 an et +,14820,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,16.6,1.3,14.1,19.1,mg,0.6,0,,2
 Sodium,Population 1 an et +,8159,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,181.5,4.7,172.2,190.7,mg,6.7,0.2,,3
 Sodium,Population 1 an et +,6257,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,114,3.8,106.6,121.5,mg,4.2,0.1,,3
@@ -4152,10 +4152,10 @@ Sodium,Population 1 an et +,5962,des,Produits céréaliers,des,Pains,des,Pains e
 Sodium,Population 1 an et +,2918,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,22.7,1.2,20.4,25,mg,0.8,0,,3
 Sodium,Population 1 an et +,4760,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,25.9,1.2,23.7,28.2,mg,1,0,,3
 Sodium,Population 1 an et +,2573,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),16.8,0.8,15.1,18.4,mg,0.6,0,,3
-Sodium,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,7.5,0.4,6.6,8.4,mg,0.3,0,,3
-Sodium,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,1.1,0.2,0.7,1.5,mg,0,0,E,3
-Sodium,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.9,0.2,0.6,1.3,mg,0,0,E,3
-Sodium,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
+Sodium,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,7.5,0.4,6.6,8.4,mg,0.3,0,,3
+Sodium,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,1.1,0.2,0.7,1.5,mg,0,0,E,3
+Sodium,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.9,0.2,0.6,1.3,mg,0,0,E,3
+Sodium,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
 Sodium,Population 1 an et +,4543,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,14.4,1.2,12,16.8,mg,0.5,0,,3
 Sodium,Population 1 an et +,4598,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,1.9,0.4,1.2,2.6,mg,0.1,0,E,3
 Sodium,Population 1 an et +,11102,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.3,0,0.2,0.3,mg,0,0,,3
@@ -4258,7 +4258,7 @@ Sodium,Hommes adultes 19 ans +,5438,des,Fruits et légumes,des,Légumes incluant
 Sodium,Hommes adultes 19 ans +,6068,des,Produits céréaliers,,,,,587.9,12.3,563.7,612.1,mg,18.5,0.3,,1
 Sodium,Hommes adultes 19 ans +,5104,des,Produits céréaliers,des,Pains,,,499.9,11.8,476.7,523.1,mg,15.7,0.3,,2
 Sodium,Hommes adultes 19 ans +,1921,des,Produits céréaliers,des,Céréales pour déjeuner,,,40.3,2.4,35.6,45,mg,1.3,0.1,,2
-Sodium,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,34.3,3.3,27.9,40.7,mg,1.1,0.1,,2
+Sodium,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,34.3,3.3,27.9,40.7,mg,1.1,0.1,,2
 Sodium,Hommes adultes 19 ans +,4551,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,13.4,2.3,8.9,17.9,mg,0.4,0.1,E,2
 Sodium,Hommes adultes 19 ans +,2752,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,231,9.7,212.1,250,mg,7.3,0.3,,3
 Sodium,Hommes adultes 19 ans +,1980,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,126.1,5.9,114.5,137.7,mg,4,0.2,,3
@@ -4266,9 +4266,9 @@ Sodium,Hommes adultes 19 ans +,1885,des,Produits céréaliers,des,Pains,des,Autr
 Sodium,Hommes adultes 19 ans +,593,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,17.6,1.7,14.3,21,mg,0.6,0.1,,3
 Sodium,Hommes adultes 19 ans +,1481,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,28.5,2.2,24.2,32.9,mg,0.9,0.1,,3
 Sodium,Hommes adultes 19 ans +,523,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),11.8,1.2,9.3,14.2,mg,0.4,0,,3
-Sodium,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,8,0.9,6.1,9.8,mg,0.3,0,,3
-Sodium,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,F,F,,,mg,F,F,F,3
-Sodium,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,F,F,,,mg,F,F,F,3
+Sodium,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,8,0.9,6.1,9.8,mg,0.3,0,,3
+Sodium,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,F,F,,,mg,F,F,F,3
+Sodium,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,F,F,,,mg,F,F,F,3
 Sodium,Hommes adultes 19 ans +,1250,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,11.3,2.2,7,15.6,mg,0.4,0.1,E,3
 Sodium,Hommes adultes 19 ans +,1449,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,1.8,0.5,0.7,2.8,mg,0.1,0,E,3
 Sodium,Hommes adultes 19 ans +,3442,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.3,0,0.2,0.4,mg,0,0,,3
@@ -4371,7 +4371,7 @@ Sodium,Femmes adultes* 19 ans +,662,des,Fruits et légumes,des,Légumes incluant
 Sodium,Femmes adultes* 19 ans +,6669,des,Produits céréaliers,,,,,437.7,8.7,420.5,454.9,mg,19.1,0.4,,1
 Sodium,Femmes adultes* 19 ans +,5520,des,Produits céréaliers,des,Pains,,,360.8,7.5,346,375.6,mg,15.8,0.3,,2
 Sodium,Femmes adultes* 19 ans +,2230,des,Produits céréaliers,des,Céréales pour déjeuner,,,32.9,1.7,29.5,36.3,mg,1.4,0.1,,2
-Sodium,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,31.3,3.4,24.6,37.9,mg,1.4,0.1,,2
+Sodium,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,31.3,3.4,24.6,37.9,mg,1.4,0.1,,2
 Sodium,Femmes adultes* 19 ans +,4893,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,12.7,1.9,8.9,16.5,mg,0.6,0.1,,2
 Sodium,Femmes adultes* 19 ans +,2551,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,141.7,5.7,130.6,152.8,mg,6.2,0.3,,3
 Sodium,Femmes adultes* 19 ans +,2239,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,107.2,4.3,98.9,115.6,mg,4.7,0.2,,3
@@ -4379,10 +4379,10 @@ Sodium,Femmes adultes* 19 ans +,1994,des,Produits céréaliers,des,Pains,des,Aut
 Sodium,Femmes adultes* 19 ans +,914,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,16.9,1.7,13.6,20.2,mg,0.7,0.1,,3
 Sodium,Femmes adultes* 19 ans +,1756,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,23.5,1.6,20.4,26.5,mg,1,0.1,,3
 Sodium,Femmes adultes* 19 ans +,555,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),9.4,0.9,7.7,11.1,mg,0.4,0,,3
-Sodium,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,4.3,0.5,3.4,5.3,mg,0.2,0,,3
-Sodium,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.6,0.2,0.3,1,mg,0,0,E,3
-Sodium,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.8,0.2,0.3,1.2,mg,0,0,E,3
-Sodium,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
+Sodium,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,4.3,0.5,3.4,5.3,mg,0.2,0,,3
+Sodium,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.6,0.2,0.3,1,mg,0,0,E,3
+Sodium,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.8,0.2,0.3,1.2,mg,0,0,E,3
+Sodium,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
 Sodium,Femmes adultes* 19 ans +,1358,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,10.7,1.8,7.1,14.3,mg,0.5,0.1,E,3
 Sodium,Femmes adultes* 19 ans +,1522,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,1.8,0.6,0.6,3,mg,0.1,0,E,3
 Sodium,Femmes adultes* 19 ans +,3664,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.2,0,0.2,0.3,mg,0,0,,3
@@ -4426,119 +4426,119 @@ Sodium,Femmes adultes* 19 ans +,1529,des,Confiseries - sucres et grignotines sal
 Sodium,Femmes adultes* 19 ans +,773,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.5,0,0.4,0.6,mg,0,0,,3
 Sodium,Femmes adultes* 19 ans +,360,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0.1,mg,0,0,,3
 Sodium,Femmes adultes* 19 ans +,4229,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0.3,0,0.2,0.3,mg,0,0,,3
-Sodium,Enfants 1 à 8 ans,122,des,Aliments pour bébés,,,,,2.2,0.6,1,3.4,mg,0.1,0,E,1
-Sodium,Enfants 1 à 8 ans,95,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,F,F,,,mg,F,F,F,2
-Sodium,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparations pour nourrissons,,,1.4,0.4,0.6,2.2,mg,0.1,0,E,2
-Sodium,Enfants 1 à 8 ans,2443,des,Boissons (excluant laits),,,,,31.1,1.7,27.8,34.5,mg,1.5,0.1,,1
-Sodium,Enfants 1 à 8 ans,20,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0.1,mg,0,0,,2
-Sodium,Enfants 1 à 8 ans,141,des,Boissons (excluant laits),du,Café et thé,,,1.2,0.3,0.6,1.8,mg,0.1,0,E,2
-Sodium,Enfants 1 à 8 ans,,des,Boissons (excluant laits),des,Boissons Énergisantes,,,X,X,,,mg,X,X,<10,2
-Sodium,Enfants 1 à 8 ans,357,des,Boissons (excluant laits),des,Boissons aux fruits,,,3,0.3,2.4,3.7,mg,0.1,0,,2
-Sodium,Enfants 1 à 8 ans,1159,des,Boissons (excluant laits),des,Jus de fruit,,,4,0.2,3.6,4.4,mg,0.2,0,,2
-Sodium,Enfants 1 à 8 ans,77,des,Boissons (excluant laits),des,Autres boissons,,,3.8,1,1.9,5.7,mg,0.2,0,E,2
-Sodium,Enfants 1 à 8 ans,142,des,Boissons (excluant laits),des,Boissons gazeuses,,,1.1,0.2,0.8,1.4,mg,0.1,0,E,2
-Sodium,Enfants 1 à 8 ans,21,des,Boissons (excluant laits),des,Boissons pour sportifs,,,F,F,,,mg,F,F,F,2
-Sodium,Enfants 1 à 8 ans,52,des,Boissons (excluant laits),des,Jus de tomates et de légumes,,,4.8,1.3,2.2,7.4,mg,0.2,0.1,E,2
-Sodium,Enfants 1 à 8 ans,,des,Boissons (excluant laits),de l',Eau vitaminée,,,X,X,,,mg,X,X,<10,2
-Sodium,Enfants 1 à 8 ans,2344,des,Boissons (excluant laits),de l',Eau,,,12.6,0.4,11.8,13.5,mg,0.6,0,,2
-Sodium,Enfants 1 à 8 ans,133,des,Boissons (excluant laits),du,Café et thé,du,Thé,1.2,0.3,0.5,1.8,mg,0.1,0,E,3
-Sodium,Enfants 1 à 8 ans,,des,Boissons (excluant laits),du,Café et thé,du,Café,X,X,,,mg,X,X,<10,3
-Sodium,Enfants 1 à 8 ans,2436,des,Produits laitiers et Boissons à base de plantes,,,,,401.6,12.7,376.7,426.5,mg,19.6,0.5,,1
-Sodium,Enfants 1 à 8 ans,1632,des,Produits laitiers et Boissons à base de plantes,des,Fromages,,,217.9,11.8,194.7,241.2,mg,10.6,0.5,,2
-Sodium,Enfants 1 à 8 ans,2341,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,162.3,4.6,153.4,171.3,mg,7.9,0.2,,2
-Sodium,Enfants 1 à 8 ans,1032,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,,,21.4,1,19.3,23.4,mg,1,0.1,,2
-Sodium,Enfants 1 à 8 ans,1810,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,78.7,3.4,72,85.5,mg,3.8,0.2,,3
-Sodium,Enfants 1 à 8 ans,1078,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,46,2.9,40.4,51.7,mg,2.2,0.1,,3
-Sodium,Enfants 1 à 8 ans,854,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,26.8,3,21,32.7,mg,1.3,0.1,,3
-Sodium,Enfants 1 à 8 ans,128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,4.7,0.8,3.2,6.3,mg,0.2,0,E,3
-Sodium,Enfants 1 à 8 ans,739,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,4,0.7,2.7,5.3,mg,0.2,0,E,3
-Sodium,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,2,0.4,1.1,2.9,mg,0.1,0,E,3
-Sodium,Enfants 1 à 8 ans,2270,des,Graisses et huiles,,,,,55,2.7,49.7,60.3,mg,2.7,0.1,,1
-Sodium,Enfants 1 à 8 ans,83,des,Graisses et huiles,des,Graisses animales,,,F,F,,,mg,F,F,F,2
-Sodium,Enfants 1 à 8 ans,657,des,Graisses et huiles,du,Beurre,,,10.9,1,9,12.8,mg,0.5,0,,2
-Sodium,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Margarines,,,24.9,1.3,22.3,27.6,mg,1.2,0.1,,2
-Sodium,Enfants 1 à 8 ans,463,des,Graisses et huiles,des,Sauces pour salade,,,18.5,2.2,14.3,22.7,mg,0.9,0.1,,2
-Sodium,Enfants 1 à 8 ans,1035,des,Graisses et huiles,du,Shortening,,,0,0,0,0,mg,0,0,,2
-Sodium,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Huiles végétales,,,0,0,0,0,mg,0,0,,2
-Sodium,Enfants 1 à 8 ans,298,des,Poissons et fruits de mer,,,,,19.2,2.7,14,24.4,mg,0.9,0.1,,1
-Sodium,Enfants 1 à 8 ans,257,des,Poissons et fruits de mer,des,Poissons,,,13,1.8,9.4,16.5,mg,0.6,0.1,,2
-Sodium,Enfants 1 à 8 ans,50,des,Poissons et fruits de mer,des,Mollusques et crustacés,,,6.2,1.8,2.6,9.9,mg,0.3,0.1,E,2
-Sodium,Enfants 1 à 8 ans,2428,des,Fruits et légumes,,,,,141.6,8.7,124.6,158.6,mg,6.9,0.4,,1
-Sodium,Enfants 1 à 8 ans,2117,des,Fruits et légumes,des,Fruits,,,3.5,0.3,3,4,mg,0.2,0,,2
-Sodium,Enfants 1 à 8 ans,2240,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,138.1,8.6,121.1,155.1,mg,6.7,0.4,,2
-Sodium,Enfants 1 à 8 ans,219,des,Fruits et légumes,des,Fruits,des,Melons,1.3,0.2,0.8,1.7,mg,0.1,0,,3
-Sodium,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pommes,0.7,0,0.6,0.8,mg,0,0,,3
-Sodium,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Bananes,0.3,0,0.3,0.3,mg,0,0,,3
-Sodium,Enfants 1 à 8 ans,830,des,Fruits et légumes,des,Fruits,des,Baies,0.3,0,0.2,0.3,mg,0,0,,3
-Sodium,Enfants 1 à 8 ans,47,des,Fruits et légumes,des,Fruits,des,Cerises,0,0,0,0,mg,0,0,,3
-Sodium,Enfants 1 à 8 ans,421,des,Fruits et légumes,des,Fruits,des,Agrumes,0.1,0,0.1,0.1,mg,0,0,,3
-Sodium,Enfants 1 à 8 ans,572,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,0.4,0.1,0.3,0.5,mg,0,0,E,3
-Sodium,Enfants 1 à 8 ans,260,des,Fruits et légumes,des,Fruits,des,Autres fruits,0.3,0,0.2,0.4,mg,0,0,,3
-Sodium,Enfants 1 à 8 ans,118,des,Fruits et légumes,des,Fruits,des,Pêches et nectarines,0,0,0,0.1,mg,0,0,,3
-Sodium,Enfants 1 à 8 ans,133,des,Fruits et légumes,des,Fruits,des,Poires,0.1,0,0.1,0.1,mg,0,0,,3
-Sodium,Enfants 1 à 8 ans,94,des,Fruits et légumes,des,Fruits,des,Ananas,0,0,0,0,mg,0,0,,3
-Sodium,Enfants 1 à 8 ans,37,des,Fruits et légumes,des,Fruits,des,Prunes et pruneaux,0,0,0,0,mg,0,0,,3
-Sodium,Enfants 1 à 8 ans,927,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes en conserve,78.6,7.2,64.5,92.7,mg,3.8,0.4,,3
-Sodium,Enfants 1 à 8 ans,297,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Pommes de terre frites et mélanges de pommes de terre,27.7,3.2,21.4,33.9,mg,1.4,0.2,,3
-Sodium,Enfants 1 à 8 ans,2069,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes frais et surgelés,17.7,1.1,15.7,19.8,mg,0.9,0,,3
-Sodium,Enfants 1 à 8 ans,242,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes marinés,14.2,2.7,8.9,19.4,mg,0.7,0.1,E,3
-Sodium,Enfants 1 à 8 ans,2475,des,Produits céréaliers,,,,,494.1,12.1,470.3,517.9,mg,24.1,0.6,,1
-Sodium,Enfants 1 à 8 ans,2114,des,Produits céréaliers,des,Pains,,,356.9,11.5,334.3,379.6,mg,17.4,0.5,,2
-Sodium,Enfants 1 à 8 ans,1282,des,Produits céréaliers,des,Céréales pour déjeuner,,,63,2.9,57.3,68.7,mg,3.1,0.2,,2
-Sodium,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,46.4,3.3,39.9,52.9,mg,2.3,0.2,,2
-Sodium,Enfants 1 à 8 ans,2037,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,27.7,4,19.7,35.7,mg,1.4,0.2,,2
-Sodium,Enfants 1 à 8 ans,951,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,128.9,9.5,110.3,147.6,mg,6.3,0.5,,3
-Sodium,Enfants 1 à 8 ans,805,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,89.6,6.6,76.6,102.6,mg,4.4,0.3,,3
-Sodium,Enfants 1 à 8 ans,813,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,83,5.1,73,93,mg,4.1,0.3,,3
-Sodium,Enfants 1 à 8 ans,745,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,55.4,4.9,45.6,65.1,mg,2.7,0.2,,3
-Sodium,Enfants 1 à 8 ans,670,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),36,2.3,31.4,40.6,mg,1.8,0.1,,3
-Sodium,Enfants 1 à 8 ans,728,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,27,2.3,22.4,31.6,mg,1.3,0.1,,3
-Sodium,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,9.1,0.9,7.3,10.8,mg,0.4,0,,3
-Sodium,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,1.5,0.5,0.5,2.5,mg,0.1,0,E,3
-Sodium,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,F,F,,,mg,F,F,F,3
-Sodium,Enfants 1 à 8 ans,834,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,26.7,4,18.8,34.6,mg,1.3,0.2,,3
-Sodium,Enfants 1 à 8 ans,1461,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.1,0,0.1,0.2,mg,0,0,,3
-Sodium,Enfants 1 à 8 ans,654,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0.9,0.3,0.4,1.4,mg,0,0,E,3
-Sodium,Enfants 1 à 8 ans,2072,de la,Viandes et volailles,,,,,242.3,14.4,214,270.6,mg,11.8,0.6,,1
-Sodium,Enfants 1 à 8 ans,1003,de la,Viandes et volailles,de la,Volaille,,,24.3,3,18.5,30.1,mg,1.2,0.1,,2
-Sodium,Enfants 1 à 8 ans,942,de la,Viandes et volailles,des,Viandes transformées,,,204.3,14.1,176.5,232,mg,10,0.6,,2
-Sodium,Enfants 1 à 8 ans,999,de la,Viandes et volailles,de la,Viande rouge,,,13.7,0.9,11.9,15.4,mg,0.7,0,,2
-Sodium,Enfants 1 à 8 ans,933,de la,Viandes et volailles,de la,Volaille,du,Poulet,23.6,3,17.7,29.4,mg,1.2,0.1,,3
-Sodium,Enfants 1 à 8 ans,86,de la,Viandes et volailles,de la,Volaille,de la,Dinde et autres volailles,F,F,,,mg,F,F,F,3
-Sodium,Enfants 1 à 8 ans,513,de la,Viandes et volailles,des,Viandes transformées,des,Viandes froides,95.9,8.9,78.4,113.4,mg,4.7,0.4,,3
-Sodium,Enfants 1 à 8 ans,375,de la,Viandes et volailles,des,Viandes transformées,des,Saucisses,77,9.2,59,95,mg,3.8,0.4,,3
-Sodium,Enfants 1 à 8 ans,106,de la,Viandes et volailles,des,Viandes transformées,du,Porc salé,21.8,5.1,11.7,31.9,mg,1.1,0.2,E,3
-Sodium,Enfants 1 à 8 ans,135,de la,Viandes et volailles,des,Viandes transformées,du,Bacon,9.6,2,5.7,13.5,mg,0.5,0.1,E,3
-Sodium,Enfants 1 à 8 ans,779,de la,Viandes et volailles,de la,Viande rouge,du,Bœuf,8.7,0.7,7.4,9.9,mg,0.4,0,,3
-Sodium,Enfants 1 à 8 ans,284,de la,Viandes et volailles,de la,Viande rouge,du,Porc frais,3.5,0.6,2.4,4.6,mg,0.2,0,E,3
-Sodium,Enfants 1 à 8 ans,43,de la,Viandes et volailles,de la,Viande rouge,de l',Agneau - veau et gibiers,F,F,,,mg,F,F,F,3
-Sodium,Enfants 1 à 8 ans,,de la,Viandes et volailles,de la,Viande rouge,des,Abats - foies et pâtés,X,X,,,mg,X,X,<10,3
-Sodium,Enfants 1 à 8 ans,1789,des,Substituts de viande,,,,,44,3.3,37.4,50.6,mg,2.1,0.2,,1
-Sodium,Enfants 1 à 8 ans,1450,des,Substituts de viande,des,Œufs,,,19.7,1.5,16.8,22.7,mg,1,0.1,,2
-Sodium,Enfants 1 à 8 ans,210,des,Substituts de viande,des,Légumineuses,,,5.3,0.8,3.6,6.9,mg,0.3,0,,2
-Sodium,Enfants 1 à 8 ans,749,des,Substituts de viande,des,Noix - graines et beurre d'arachides,,,15.4,2.2,11.2,19.7,mg,0.8,0.1,,2
-Sodium,Enfants 1 à 8 ans,58,des,Substituts de viande,du,Tofu et produits sans viande,,,3.6,1.2,1.1,6,mg,0.2,0.1,E,2
-Sodium,Enfants 1 à 8 ans,45,des,Boissons et barres nutritionnelles,,,,,3.1,0.8,1.5,4.6,mg,0.1,0,E,1
-Sodium,Enfants 1 à 8 ans,40,des,Boissons et barres nutritionnelles,des,Substituts de repas et boissons nutritionnelles,,,2.9,0.8,1.4,4.5,mg,0.1,0,E,2
-Sodium,Enfants 1 à 8 ans,,des,Boissons et barres nutritionnelles,des,Barres nutritionnelles,,,X,X,,,mg,X,X,<10,2
-Sodium,Enfants 1 à 8 ans,2285,des,Soupes - sauces - Épices et autres ingrédients,,,,,542.5,18.7,505.7,579.3,mg,26.5,0.7,,1
-Sodium,Enfants 1 à 8 ans,761,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,79.6,9.3,61.3,97.9,mg,3.9,0.4,,2
-Sodium,Enfants 1 à 8 ans,532,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,91.6,9.5,73.1,110.2,mg,4.5,0.5,,2
-Sodium,Enfants 1 à 8 ans,2187,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,371.2,13.8,344.1,398.4,mg,18.1,0.6,,2
-Sodium,Enfants 1 à 8 ans,2106,des,Confiseries - sucres et grignotines salées,,,,,70.9,4.3,62.4,79.3,mg,3.5,0.2,,1
-Sodium,Enfants 1 à 8 ans,1048,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,16.5,1.6,13.3,19.7,mg,0.8,0.1,,2
-Sodium,Enfants 1 à 8 ans,497,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,12.1,1.1,9.9,14.3,mg,0.6,0.1,,2
-Sodium,Enfants 1 à 8 ans,615,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,37.5,3.6,30.5,44.5,mg,1.8,0.2,,2
-Sodium,Enfants 1 à 8 ans,1642,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,4.8,0.6,3.5,6,mg,0.2,0,,2
-Sodium,Enfants 1 à 8 ans,557,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,7,0.9,5.2,8.8,mg,0.3,0,,3
-Sodium,Enfants 1 à 8 ans,131,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,6.9,1.3,4.3,9.5,mg,0.3,0.1,E,3
-Sodium,Enfants 1 à 8 ans,548,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,2.6,0.3,2,3.2,mg,0.1,0,,3
-Sodium,Enfants 1 à 8 ans,346,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,10.4,1.1,8.3,12.5,mg,0.5,0.1,,3
-Sodium,Enfants 1 à 8 ans,184,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,1.7,0.3,1.1,2.3,mg,0.1,0,E,3
-Sodium,Enfants 1 à 8 ans,720,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,4.2,0.6,3,5.4,mg,0.2,0,,3
-Sodium,Enfants 1 à 8 ans,257,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.5,0.1,0.3,0.6,mg,0,0,E,3
-Sodium,Enfants 1 à 8 ans,1341,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0.1,0,0.1,0.2,mg,0,0,,3
-Sodium,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,mg,X,X,<10,3
+Sodium,Enfants 1 à 8 ans,122,des,Aliments pour bébés,,,,,2.2,0.6,1,3.4,mg,0.1,0,E,1
+Sodium,Enfants 1 à 8 ans,95,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,F,F,,,mg,F,F,F,2
+Sodium,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparations pour nourrissons,,,1.4,0.4,0.6,2.2,mg,0.1,0,E,2
+Sodium,Enfants 1 à 8 ans,2443,des,Boissons (excluant laits),,,,,31.1,1.7,27.8,34.5,mg,1.5,0.1,,1
+Sodium,Enfants 1 à 8 ans,20,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0.1,mg,0,0,,2
+Sodium,Enfants 1 à 8 ans,141,des,Boissons (excluant laits),du,Café et thé,,,1.2,0.3,0.6,1.8,mg,0.1,0,E,2
+Sodium,Enfants 1 à 8 ans,,des,Boissons (excluant laits),des,Boissons Énergisantes,,,X,X,,,mg,X,X,<10,2
+Sodium,Enfants 1 à 8 ans,357,des,Boissons (excluant laits),des,Boissons aux fruits,,,3,0.3,2.4,3.7,mg,0.1,0,,2
+Sodium,Enfants 1 à 8 ans,1159,des,Boissons (excluant laits),des,Jus de fruit,,,4,0.2,3.6,4.4,mg,0.2,0,,2
+Sodium,Enfants 1 à 8 ans,77,des,Boissons (excluant laits),des,Autres boissons,,,3.8,1,1.9,5.7,mg,0.2,0,E,2
+Sodium,Enfants 1 à 8 ans,142,des,Boissons (excluant laits),des,Boissons gazeuses,,,1.1,0.2,0.8,1.4,mg,0.1,0,E,2
+Sodium,Enfants 1 à 8 ans,21,des,Boissons (excluant laits),des,Boissons pour sportifs,,,F,F,,,mg,F,F,F,2
+Sodium,Enfants 1 à 8 ans,52,des,Boissons (excluant laits),des,Jus de tomates et de légumes,,,4.8,1.3,2.2,7.4,mg,0.2,0.1,E,2
+Sodium,Enfants 1 à 8 ans,,des,Boissons (excluant laits),de l',Eau vitaminée,,,X,X,,,mg,X,X,<10,2
+Sodium,Enfants 1 à 8 ans,2344,des,Boissons (excluant laits),de l',Eau,,,12.6,0.4,11.8,13.5,mg,0.6,0,,2
+Sodium,Enfants 1 à 8 ans,133,des,Boissons (excluant laits),du,Café et thé,du,Thé,1.2,0.3,0.5,1.8,mg,0.1,0,E,3
+Sodium,Enfants 1 à 8 ans,,des,Boissons (excluant laits),du,Café et thé,du,Café,X,X,,,mg,X,X,<10,3
+Sodium,Enfants 1 à 8 ans,2436,des,Produits laitiers et Boissons à base de plantes,,,,,401.6,12.7,376.7,426.5,mg,19.6,0.5,,1
+Sodium,Enfants 1 à 8 ans,1632,des,Produits laitiers et Boissons à base de plantes,des,Fromages,,,217.9,11.8,194.7,241.2,mg,10.6,0.5,,2
+Sodium,Enfants 1 à 8 ans,2341,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,162.3,4.6,153.4,171.3,mg,7.9,0.2,,2
+Sodium,Enfants 1 à 8 ans,1032,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,,,21.4,1,19.3,23.4,mg,1,0.1,,2
+Sodium,Enfants 1 à 8 ans,1810,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,78.7,3.4,72,85.5,mg,3.8,0.2,,3
+Sodium,Enfants 1 à 8 ans,1078,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,46,2.9,40.4,51.7,mg,2.2,0.1,,3
+Sodium,Enfants 1 à 8 ans,854,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,26.8,3,21,32.7,mg,1.3,0.1,,3
+Sodium,Enfants 1 à 8 ans,128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,4.7,0.8,3.2,6.3,mg,0.2,0,E,3
+Sodium,Enfants 1 à 8 ans,739,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,4,0.7,2.7,5.3,mg,0.2,0,E,3
+Sodium,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,2,0.4,1.1,2.9,mg,0.1,0,E,3
+Sodium,Enfants 1 à 8 ans,2270,des,Graisses et huiles,,,,,55,2.7,49.7,60.3,mg,2.7,0.1,,1
+Sodium,Enfants 1 à 8 ans,83,des,Graisses et huiles,des,Graisses animales,,,F,F,,,mg,F,F,F,2
+Sodium,Enfants 1 à 8 ans,657,des,Graisses et huiles,du,Beurre,,,10.9,1,9,12.8,mg,0.5,0,,2
+Sodium,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Margarines,,,24.9,1.3,22.3,27.6,mg,1.2,0.1,,2
+Sodium,Enfants 1 à 8 ans,463,des,Graisses et huiles,des,Sauces pour salade,,,18.5,2.2,14.3,22.7,mg,0.9,0.1,,2
+Sodium,Enfants 1 à 8 ans,1035,des,Graisses et huiles,du,Shortening,,,0,0,0,0,mg,0,0,,2
+Sodium,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Huiles végétales,,,0,0,0,0,mg,0,0,,2
+Sodium,Enfants 1 à 8 ans,298,des,Poissons et fruits de mer,,,,,19.2,2.7,14,24.4,mg,0.9,0.1,,1
+Sodium,Enfants 1 à 8 ans,257,des,Poissons et fruits de mer,des,Poissons,,,13,1.8,9.4,16.5,mg,0.6,0.1,,2
+Sodium,Enfants 1 à 8 ans,50,des,Poissons et fruits de mer,des,Mollusques et crustacés,,,6.2,1.8,2.6,9.9,mg,0.3,0.1,E,2
+Sodium,Enfants 1 à 8 ans,2428,des,Fruits et légumes,,,,,141.6,8.7,124.6,158.6,mg,6.9,0.4,,1
+Sodium,Enfants 1 à 8 ans,2117,des,Fruits et légumes,des,Fruits,,,3.5,0.3,3,4,mg,0.2,0,,2
+Sodium,Enfants 1 à 8 ans,2240,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,138.1,8.6,121.1,155.1,mg,6.7,0.4,,2
+Sodium,Enfants 1 à 8 ans,219,des,Fruits et légumes,des,Fruits,des,Melons,1.3,0.2,0.8,1.7,mg,0.1,0,,3
+Sodium,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pommes,0.7,0,0.6,0.8,mg,0,0,,3
+Sodium,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Bananes,0.3,0,0.3,0.3,mg,0,0,,3
+Sodium,Enfants 1 à 8 ans,830,des,Fruits et légumes,des,Fruits,des,Baies,0.3,0,0.2,0.3,mg,0,0,,3
+Sodium,Enfants 1 à 8 ans,47,des,Fruits et légumes,des,Fruits,des,Cerises,0,0,0,0,mg,0,0,,3
+Sodium,Enfants 1 à 8 ans,421,des,Fruits et légumes,des,Fruits,des,Agrumes,0.1,0,0.1,0.1,mg,0,0,,3
+Sodium,Enfants 1 à 8 ans,572,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,0.4,0.1,0.3,0.5,mg,0,0,E,3
+Sodium,Enfants 1 à 8 ans,260,des,Fruits et légumes,des,Fruits,des,Autres fruits,0.3,0,0.2,0.4,mg,0,0,,3
+Sodium,Enfants 1 à 8 ans,118,des,Fruits et légumes,des,Fruits,des,Pêches et nectarines,0,0,0,0.1,mg,0,0,,3
+Sodium,Enfants 1 à 8 ans,133,des,Fruits et légumes,des,Fruits,des,Poires,0.1,0,0.1,0.1,mg,0,0,,3
+Sodium,Enfants 1 à 8 ans,94,des,Fruits et légumes,des,Fruits,des,Ananas,0,0,0,0,mg,0,0,,3
+Sodium,Enfants 1 à 8 ans,37,des,Fruits et légumes,des,Fruits,des,Prunes et pruneaux,0,0,0,0,mg,0,0,,3
+Sodium,Enfants 1 à 8 ans,927,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes en conserve,78.6,7.2,64.5,92.7,mg,3.8,0.4,,3
+Sodium,Enfants 1 à 8 ans,297,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Pommes de terre frites et mélanges de pommes de terre,27.7,3.2,21.4,33.9,mg,1.4,0.2,,3
+Sodium,Enfants 1 à 8 ans,2069,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes frais et surgelés,17.7,1.1,15.7,19.8,mg,0.9,0,,3
+Sodium,Enfants 1 à 8 ans,242,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes marinés,14.2,2.7,8.9,19.4,mg,0.7,0.1,E,3
+Sodium,Enfants 1 à 8 ans,2475,des,Produits céréaliers,,,,,494.1,12.1,470.3,517.9,mg,24.1,0.6,,1
+Sodium,Enfants 1 à 8 ans,2114,des,Produits céréaliers,des,Pains,,,356.9,11.5,334.3,379.6,mg,17.4,0.5,,2
+Sodium,Enfants 1 à 8 ans,1282,des,Produits céréaliers,des,Céréales pour déjeuner,,,63,2.9,57.3,68.7,mg,3.1,0.2,,2
+Sodium,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,46.4,3.3,39.9,52.9,mg,2.3,0.2,,2
+Sodium,Enfants 1 à 8 ans,2037,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,27.7,4,19.7,35.7,mg,1.4,0.2,,2
+Sodium,Enfants 1 à 8 ans,951,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,128.9,9.5,110.3,147.6,mg,6.3,0.5,,3
+Sodium,Enfants 1 à 8 ans,805,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,89.6,6.6,76.6,102.6,mg,4.4,0.3,,3
+Sodium,Enfants 1 à 8 ans,813,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,83,5.1,73,93,mg,4.1,0.3,,3
+Sodium,Enfants 1 à 8 ans,745,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,55.4,4.9,45.6,65.1,mg,2.7,0.2,,3
+Sodium,Enfants 1 à 8 ans,670,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),36,2.3,31.4,40.6,mg,1.8,0.1,,3
+Sodium,Enfants 1 à 8 ans,728,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,27,2.3,22.4,31.6,mg,1.3,0.1,,3
+Sodium,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,9.1,0.9,7.3,10.8,mg,0.4,0,,3
+Sodium,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,1.5,0.5,0.5,2.5,mg,0.1,0,E,3
+Sodium,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,F,F,,,mg,F,F,F,3
+Sodium,Enfants 1 à 8 ans,834,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,26.7,4,18.8,34.6,mg,1.3,0.2,,3
+Sodium,Enfants 1 à 8 ans,1461,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.1,0,0.1,0.2,mg,0,0,,3
+Sodium,Enfants 1 à 8 ans,654,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0.9,0.3,0.4,1.4,mg,0,0,E,3
+Sodium,Enfants 1 à 8 ans,2072,de la,Viandes et volailles,,,,,242.3,14.4,214,270.6,mg,11.8,0.6,,1
+Sodium,Enfants 1 à 8 ans,1003,de la,Viandes et volailles,de la,Volaille,,,24.3,3,18.5,30.1,mg,1.2,0.1,,2
+Sodium,Enfants 1 à 8 ans,942,de la,Viandes et volailles,des,Viandes transformées,,,204.3,14.1,176.5,232,mg,10,0.6,,2
+Sodium,Enfants 1 à 8 ans,999,de la,Viandes et volailles,de la,Viande rouge,,,13.7,0.9,11.9,15.4,mg,0.7,0,,2
+Sodium,Enfants 1 à 8 ans,933,de la,Viandes et volailles,de la,Volaille,du,Poulet,23.6,3,17.7,29.4,mg,1.2,0.1,,3
+Sodium,Enfants 1 à 8 ans,86,de la,Viandes et volailles,de la,Volaille,de la,Dinde et autres volailles,F,F,,,mg,F,F,F,3
+Sodium,Enfants 1 à 8 ans,513,de la,Viandes et volailles,des,Viandes transformées,des,Viandes froides,95.9,8.9,78.4,113.4,mg,4.7,0.4,,3
+Sodium,Enfants 1 à 8 ans,375,de la,Viandes et volailles,des,Viandes transformées,des,Saucisses,77,9.2,59,95,mg,3.8,0.4,,3
+Sodium,Enfants 1 à 8 ans,106,de la,Viandes et volailles,des,Viandes transformées,du,Porc salé,21.8,5.1,11.7,31.9,mg,1.1,0.2,E,3
+Sodium,Enfants 1 à 8 ans,135,de la,Viandes et volailles,des,Viandes transformées,du,Bacon,9.6,2,5.7,13.5,mg,0.5,0.1,E,3
+Sodium,Enfants 1 à 8 ans,779,de la,Viandes et volailles,de la,Viande rouge,du,Bœuf,8.7,0.7,7.4,9.9,mg,0.4,0,,3
+Sodium,Enfants 1 à 8 ans,284,de la,Viandes et volailles,de la,Viande rouge,du,Porc frais,3.5,0.6,2.4,4.6,mg,0.2,0,E,3
+Sodium,Enfants 1 à 8 ans,43,de la,Viandes et volailles,de la,Viande rouge,de l',Agneau - veau et gibiers,F,F,,,mg,F,F,F,3
+Sodium,Enfants 1 à 8 ans,,de la,Viandes et volailles,de la,Viande rouge,des,Abats - foies et pâtés,X,X,,,mg,X,X,<10,3
+Sodium,Enfants 1 à 8 ans,1789,des,Substituts de viande,,,,,44,3.3,37.4,50.6,mg,2.1,0.2,,1
+Sodium,Enfants 1 à 8 ans,1450,des,Substituts de viande,des,Œufs,,,19.7,1.5,16.8,22.7,mg,1,0.1,,2
+Sodium,Enfants 1 à 8 ans,210,des,Substituts de viande,des,Légumineuses,,,5.3,0.8,3.6,6.9,mg,0.3,0,,2
+Sodium,Enfants 1 à 8 ans,749,des,Substituts de viande,des,Noix - graines et beurre d'arachides,,,15.4,2.2,11.2,19.7,mg,0.8,0.1,,2
+Sodium,Enfants 1 à 8 ans,58,des,Substituts de viande,du,Tofu et produits sans viande,,,3.6,1.2,1.1,6,mg,0.2,0.1,E,2
+Sodium,Enfants 1 à 8 ans,45,des,Boissons et barres nutritionnelles,,,,,3.1,0.8,1.5,4.6,mg,0.1,0,E,1
+Sodium,Enfants 1 à 8 ans,40,des,Boissons et barres nutritionnelles,des,Substituts de repas et boissons nutritionnelles,,,2.9,0.8,1.4,4.5,mg,0.1,0,E,2
+Sodium,Enfants 1 à 8 ans,,des,Boissons et barres nutritionnelles,des,Barres nutritionnelles,,,X,X,,,mg,X,X,<10,2
+Sodium,Enfants 1 à 8 ans,2285,des,Soupes - sauces - Épices et autres ingrédients,,,,,542.5,18.7,505.7,579.3,mg,26.5,0.7,,1
+Sodium,Enfants 1 à 8 ans,761,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,79.6,9.3,61.3,97.9,mg,3.9,0.4,,2
+Sodium,Enfants 1 à 8 ans,532,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,91.6,9.5,73.1,110.2,mg,4.5,0.5,,2
+Sodium,Enfants 1 à 8 ans,2187,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,371.2,13.8,344.1,398.4,mg,18.1,0.6,,2
+Sodium,Enfants 1 à 8 ans,2106,des,Confiseries - sucres et grignotines salées,,,,,70.9,4.3,62.4,79.3,mg,3.5,0.2,,1
+Sodium,Enfants 1 à 8 ans,1048,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,16.5,1.6,13.3,19.7,mg,0.8,0.1,,2
+Sodium,Enfants 1 à 8 ans,497,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,12.1,1.1,9.9,14.3,mg,0.6,0.1,,2
+Sodium,Enfants 1 à 8 ans,615,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,37.5,3.6,30.5,44.5,mg,1.8,0.2,,2
+Sodium,Enfants 1 à 8 ans,1642,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,4.8,0.6,3.5,6,mg,0.2,0,,2
+Sodium,Enfants 1 à 8 ans,557,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,7,0.9,5.2,8.8,mg,0.3,0,,3
+Sodium,Enfants 1 à 8 ans,131,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,6.9,1.3,4.3,9.5,mg,0.3,0.1,E,3
+Sodium,Enfants 1 à 8 ans,548,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,2.6,0.3,2,3.2,mg,0.1,0,,3
+Sodium,Enfants 1 à 8 ans,346,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,10.4,1.1,8.3,12.5,mg,0.5,0.1,,3
+Sodium,Enfants 1 à 8 ans,184,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,1.7,0.3,1.1,2.3,mg,0.1,0,E,3
+Sodium,Enfants 1 à 8 ans,720,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,4.2,0.6,3,5.4,mg,0.2,0,,3
+Sodium,Enfants 1 à 8 ans,257,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.5,0.1,0.3,0.6,mg,0,0,E,3
+Sodium,Enfants 1 à 8 ans,1341,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0.1,0,0.1,0.2,mg,0,0,,3
+Sodium,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,mg,X,X,<10,3
 Lipides totaux,Population 1 an et +,186,des,Aliments pour bébés,,,,,0,0,0,0.1,g,0.1,0,,1
 Lipides totaux,Population 1 an et +,154,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0,g,0,0,,2
 Lipides totaux,Population 1 an et +,51,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0,0,0,0,g,0,0,,2
@@ -4598,7 +4598,7 @@ Lipides totaux,Population 1 an et +,6318,des,Fruits et légumes,des,Légumes inc
 Lipides totaux,Population 1 an et +,19327,des,Produits céréaliers,,,,,7.4,0.1,7.2,7.7,g,10.8,0.2,,1
 Lipides totaux,Population 1 an et +,16168,des,Produits céréaliers,des,Pains,,,3.8,0.1,3.6,3.9,g,5.5,0.1,,2
 Lipides totaux,Population 1 an et +,6966,des,Produits céréaliers,des,Céréales pour déjeuner,,,0.7,0,0.7,0.8,g,1.1,0,,2
-Lipides totaux,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,1.7,0.1,1.5,1.8,g,2.4,0.1,,2
+Lipides totaux,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,1.7,0.1,1.5,1.8,g,2.4,0.1,,2
 Lipides totaux,Population 1 an et +,14820,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,1.3,0,1.2,1.3,g,1.8,0,,2
 Lipides totaux,Population 1 an et +,6257,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,1.4,0.1,1.3,1.5,g,2,0.1,,3
 Lipides totaux,Population 1 an et +,8159,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,1.2,0,1.1,1.3,g,1.8,0.1,,3
@@ -4606,10 +4606,10 @@ Lipides totaux,Population 1 an et +,5962,des,Produits céréaliers,des,Pains,des
 Lipides totaux,Population 1 an et +,2918,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.5,0,0.4,0.5,g,0.7,0,,3
 Lipides totaux,Population 1 an et +,4760,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.6,0,0.6,0.7,g,0.9,0,,3
 Lipides totaux,Population 1 an et +,2573,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.1,0,0.1,0.1,g,0.1,0,,3
-Lipides totaux,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.5,0,0.4,0.5,g,0.7,0,,3
-Lipides totaux,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0,0.1,g,0.1,0,,3
-Lipides totaux,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0.1,g,0.1,0,,3
-Lipides totaux,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
+Lipides totaux,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.5,0,0.4,0.5,g,0.7,0,,3
+Lipides totaux,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0,0.1,g,0.1,0,,3
+Lipides totaux,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0.1,g,0.1,0,,3
+Lipides totaux,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
 Lipides totaux,Population 1 an et +,11102,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.6,0,0.6,0.6,g,0.9,0,,3
 Lipides totaux,Population 1 an et +,4543,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.5,0,0.5,0.6,g,0.8,0,,3
 Lipides totaux,Population 1 an et +,4598,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0.2,0,0.1,0.2,g,0.2,0,,3
@@ -4712,7 +4712,7 @@ Lipides totaux,Hommes adultes 19 ans +,1991,des,Fruits et légumes,des,Légumes 
 Lipides totaux,Hommes adultes 19 ans +,6068,des,Produits céréaliers,,,,,8,0.2,7.6,8.4,g,9.9,0.2,,1
 Lipides totaux,Hommes adultes 19 ans +,5104,des,Produits céréaliers,des,Pains,,,4.2,0.2,3.9,4.5,g,5.2,0.2,,2
 Lipides totaux,Hommes adultes 19 ans +,1921,des,Produits céréaliers,des,Céréales pour déjeuner,,,0.8,0.1,0.7,0.9,g,1,0.1,,2
-Lipides totaux,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,1.6,0.1,1.4,1.9,g,2,0.1,,2
+Lipides totaux,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,1.6,0.1,1.4,1.9,g,2,0.1,,2
 Lipides totaux,Hommes adultes 19 ans +,4551,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,1.4,0,1.3,1.4,g,1.7,0.1,,2
 Lipides totaux,Hommes adultes 19 ans +,2752,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,1.6,0.1,1.4,1.8,g,2,0.1,,3
 Lipides totaux,Hommes adultes 19 ans +,1885,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,1.5,0.1,1.3,1.7,g,1.9,0.1,,3
@@ -4720,9 +4720,9 @@ Lipides totaux,Hommes adultes 19 ans +,1980,des,Produits céréaliers,des,Pains,
 Lipides totaux,Hommes adultes 19 ans +,593,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.3,0,0.2,0.3,g,0.4,0,,3
 Lipides totaux,Hommes adultes 19 ans +,1481,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.7,0.1,0.6,0.9,g,0.9,0.1,,3
 Lipides totaux,Hommes adultes 19 ans +,523,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.1,0,0,0.1,g,0.1,0,,3
-Lipides totaux,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.5,0.1,0.4,0.6,g,0.6,0.1,E,3
-Lipides totaux,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0,0.1,g,0.1,0,,3
-Lipides totaux,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0.1,g,0.1,0,,3
+Lipides totaux,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.5,0.1,0.4,0.6,g,0.6,0.1,E,3
+Lipides totaux,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0,0.1,g,0.1,0,,3
+Lipides totaux,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0.1,g,0.1,0,,3
 Lipides totaux,Hommes adultes 19 ans +,3442,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.7,0,0.6,0.7,g,0.9,0,,3
 Lipides totaux,Hommes adultes 19 ans +,1250,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.5,0,0.4,0.6,g,0.6,0,,3
 Lipides totaux,Hommes adultes 19 ans +,1449,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0.2,0,0.2,0.2,g,0.2,0,,3
@@ -4825,7 +4825,7 @@ Lipides totaux,Femmes adultes* 19 ans +,2348,des,Fruits et légumes,des,Légumes
 Lipides totaux,Femmes adultes* 19 ans +,6669,des,Produits céréaliers,,,,,6,0.1,5.8,6.3,g,10.3,0.2,,1
 Lipides totaux,Femmes adultes* 19 ans +,5520,des,Produits céréaliers,des,Pains,,,3.1,0.1,2.9,3.3,g,5.3,0.2,,2
 Lipides totaux,Femmes adultes* 19 ans +,2230,des,Produits céréaliers,des,Céréales pour déjeuner,,,0.6,0,0.5,0.7,g,1.1,0.1,,2
-Lipides totaux,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,1.3,0.1,1.1,1.4,g,2.2,0.1,,2
+Lipides totaux,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,1.3,0.1,1.1,1.4,g,2.2,0.1,,2
 Lipides totaux,Femmes adultes* 19 ans +,4893,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,1,0,0.9,1.1,g,1.8,0.1,,2
 Lipides totaux,Femmes adultes* 19 ans +,1994,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,1.2,0.1,1,1.3,g,2,0.1,,3
 Lipides totaux,Femmes adultes* 19 ans +,2551,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,0.9,0,0.8,1,g,1.6,0.1,,3
@@ -4833,10 +4833,10 @@ Lipides totaux,Femmes adultes* 19 ans +,2239,des,Produits céréaliers,des,Pains
 Lipides totaux,Femmes adultes* 19 ans +,914,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.3,0,0.3,0.4,g,0.6,0.1,,3
 Lipides totaux,Femmes adultes* 19 ans +,1756,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.6,0,0.5,0.6,g,1,0.1,,3
 Lipides totaux,Femmes adultes* 19 ans +,555,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0,0,0,0.1,g,0.1,0,,3
-Lipides totaux,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.3,0,0.2,0.3,g,0.5,0,,3
-Lipides totaux,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0.1,g,0.1,0,,3
-Lipides totaux,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0.1,g,0.1,0,,3
-Lipides totaux,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
+Lipides totaux,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.3,0,0.2,0.3,g,0.5,0,,3
+Lipides totaux,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0.1,g,0.1,0,,3
+Lipides totaux,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0.1,g,0.1,0,,3
+Lipides totaux,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
 Lipides totaux,Femmes adultes* 19 ans +,3664,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.5,0,0.4,0.5,g,0.8,0,,3
 Lipides totaux,Femmes adultes* 19 ans +,1358,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.4,0,0.4,0.5,g,0.7,0.1,,3
 Lipides totaux,Femmes adultes* 19 ans +,1522,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0.1,0,0.1,0.2,g,0.2,0,,3
@@ -4880,119 +4880,119 @@ Lipides totaux,Femmes adultes* 19 ans +,1529,des,Confiseries - sucres et grignot
 Lipides totaux,Femmes adultes* 19 ans +,773,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0,0,,3
 Lipides totaux,Femmes adultes* 19 ans +,360,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
 Lipides totaux,Femmes adultes* 19 ans +,4229,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
-Lipides totaux,Enfants 1 à 8 ans,122,des,Aliments pour bébés,,,,,0.3,0.1,0.2,0.5,g,0.6,0.1,E,1
-Lipides totaux,Enfants 1 à 8 ans,95,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0.1,0,0,0.1,g,0.1,0,,2
-Lipides totaux,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0.3,0.1,0.1,0.4,g,0.5,0.1,E,2
-Lipides totaux,Enfants 1 à 8 ans,2443,des,Boissons (excluant laits),,,,,0.2,0,0.2,0.3,g,0.4,0,,1
-Lipides totaux,Enfants 1 à 8 ans,20,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0,g,0,0,,2
-Lipides totaux,Enfants 1 à 8 ans,141,des,Boissons (excluant laits),du,Café et thé,,,0,0,0,0,g,0,0,,2
-Lipides totaux,Enfants 1 à 8 ans,,des,Boissons (excluant laits),des,Boissons Énergisantes,,,X,X,,,g,X,X,<10,2
-Lipides totaux,Enfants 1 à 8 ans,357,des,Boissons (excluant laits),des,Boissons aux fruits,,,0,0,0,0,g,0.1,0,,2
-Lipides totaux,Enfants 1 à 8 ans,1159,des,Boissons (excluant laits),des,Jus de fruit,,,0.2,0,0.1,0.2,g,0.3,0,,2
-Lipides totaux,Enfants 1 à 8 ans,77,des,Boissons (excluant laits),des,Autres boissons,,,0,0,0,0.1,g,0.1,0,,2
-Lipides totaux,Enfants 1 à 8 ans,142,des,Boissons (excluant laits),des,Boissons gazeuses,,,0,0,0,0,g,0,0,,2
-Lipides totaux,Enfants 1 à 8 ans,21,des,Boissons (excluant laits),des,Boissons pour sportifs,,,0,0,0,0,g,0,0,,2
-Lipides totaux,Enfants 1 à 8 ans,52,des,Boissons (excluant laits),des,Jus de tomates et de légumes,,,0,0,0,0,g,0,0,,2
-Lipides totaux,Enfants 1 à 8 ans,,des,Boissons (excluant laits),de l',Eau vitaminée,,,X,X,,,g,X,X,<10,2
-Lipides totaux,Enfants 1 à 8 ans,2344,des,Boissons (excluant laits),de l',Eau,,,0,0,0,0,g,0,0,,2
-Lipides totaux,Enfants 1 à 8 ans,133,des,Boissons (excluant laits),du,Café et thé,du,Thé,0,0,0,0,g,0,0,,3
-Lipides totaux,Enfants 1 à 8 ans,,des,Boissons (excluant laits),du,Café et thé,du,Café,X,X,,,g,X,X,<10,3
-Lipides totaux,Enfants 1 à 8 ans,2436,des,Produits laitiers et Boissons à base de plantes,,,,,14.6,0.4,13.8,15.4,g,27.5,0.7,,1
-Lipides totaux,Enfants 1 à 8 ans,1632,des,Produits laitiers et Boissons à base de plantes,des,Fromages,,,5.9,0.3,5.3,6.5,g,11.1,0.5,,2
-Lipides totaux,Enfants 1 à 8 ans,2341,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,7.8,0.2,7.3,8.2,g,14.6,0.4,,2
-Lipides totaux,Enfants 1 à 8 ans,1032,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,,,1,0.1,0.9,1.1,g,1.8,0.1,,2
-Lipides totaux,Enfants 1 à 8 ans,1078,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,3.5,0.2,3,3.9,g,6.5,0.4,,3
-Lipides totaux,Enfants 1 à 8 ans,1810,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,3.2,0.1,2.9,3.5,g,6.1,0.3,,3
-Lipides totaux,Enfants 1 à 8 ans,854,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,0.6,0.1,0.4,0.7,g,1.1,0.1,E,3
-Lipides totaux,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0.4,0.1,0.3,0.5,g,0.8,0.1,E,3
-Lipides totaux,Enfants 1 à 8 ans,128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0.1,0,0.1,0.1,g,0.2,0,,3
-Lipides totaux,Enfants 1 à 8 ans,739,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0,0,0,0,g,0,0,,3
-Lipides totaux,Enfants 1 à 8 ans,2270,des,Graisses et huiles,,,,,11.5,0.4,10.8,12.2,g,21.7,0.6,,1
-Lipides totaux,Enfants 1 à 8 ans,83,des,Graisses et huiles,des,Graisses animales,,,0.2,0,0.1,0.3,g,0.3,0.1,,2
-Lipides totaux,Enfants 1 à 8 ans,657,des,Graisses et huiles,du,Beurre,,,1.5,0.1,1.2,1.8,g,2.8,0.2,,2
-Lipides totaux,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Margarines,,,2.9,0.2,2.6,3.2,g,5.5,0.3,,2
-Lipides totaux,Enfants 1 à 8 ans,463,des,Graisses et huiles,des,Sauces pour salade,,,1,0.1,0.8,1.2,g,1.9,0.2,,2
-Lipides totaux,Enfants 1 à 8 ans,1035,des,Graisses et huiles,du,Shortening,,,2.8,0.2,2.4,3.2,g,5.3,0.3,,2
-Lipides totaux,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Huiles végétales,,,3.1,0.2,2.7,3.5,g,5.8,0.4,,2
-Lipides totaux,Enfants 1 à 8 ans,298,des,Poissons et fruits de mer,,,,,0.4,0.1,0.2,0.6,g,0.7,0.2,E,1
-Lipides totaux,Enfants 1 à 8 ans,257,des,Poissons et fruits de mer,des,Poissons,,,0.4,0.1,0.2,0.5,g,0.7,0.2,E,2
-Lipides totaux,Enfants 1 à 8 ans,50,des,Poissons et fruits de mer,des,Mollusques et crustacés,,,0,0,0,0,g,0,0,,2
-Lipides totaux,Enfants 1 à 8 ans,2428,des,Fruits et légumes,,,,,1.6,0.1,1.4,1.7,g,2.9,0.2,,1
-Lipides totaux,Enfants 1 à 8 ans,2117,des,Fruits et légumes,des,Fruits,,,0.6,0.1,0.5,0.8,g,1.2,0.1,E,2
-Lipides totaux,Enfants 1 à 8 ans,2235,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,0.9,0.1,0.8,1,g,1.7,0.1,,2
-Lipides totaux,Enfants 1 à 8 ans,260,des,Fruits et légumes,des,Fruits,des,Autres fruits,0.3,0.1,0.1,0.4,g,0.5,0.1,E,3
-Lipides totaux,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pommes,0.1,0,0.1,0.1,g,0.2,0,,3
-Lipides totaux,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Bananes,0.1,0,0.1,0.1,g,0.2,0,,3
-Lipides totaux,Enfants 1 à 8 ans,830,des,Fruits et légumes,des,Fruits,des,Baies,0.1,0,0.1,0.1,g,0.2,0,,3
-Lipides totaux,Enfants 1 à 8 ans,47,des,Fruits et légumes,des,Fruits,des,Cerises,0,0,0,0,g,0,0,,3
-Lipides totaux,Enfants 1 à 8 ans,421,des,Fruits et légumes,des,Fruits,des,Agrumes,0,0,0,0,g,0,0,,3
-Lipides totaux,Enfants 1 à 8 ans,572,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,0,0,0,0,g,0,0,,3
-Lipides totaux,Enfants 1 à 8 ans,219,des,Fruits et légumes,des,Fruits,des,Melons,0,0,0,0,g,0,0,,3
-Lipides totaux,Enfants 1 à 8 ans,118,des,Fruits et légumes,des,Fruits,des,Pêches et nectarines,0,0,0,0,g,0,0,,3
-Lipides totaux,Enfants 1 à 8 ans,133,des,Fruits et légumes,des,Fruits,des,Poires,0,0,0,0,g,0,0,,3
-Lipides totaux,Enfants 1 à 8 ans,94,des,Fruits et légumes,des,Fruits,des,Ananas,0,0,0,0,g,0,0,,3
-Lipides totaux,Enfants 1 à 8 ans,37,des,Fruits et légumes,des,Fruits,des,Prunes et pruneaux,0,0,0,0,g,0,0,,3
-Lipides totaux,Enfants 1 à 8 ans,1032,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes féculents,0.5,0.1,0.4,0.6,g,1,0.1,E,3
-Lipides totaux,Enfants 1 à 8 ans,1773,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Autres légumes,0.3,0,0.2,0.3,g,0.5,0,,3
-Lipides totaux,Enfants 1 à 8 ans,1068,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes vert foncé,0.1,0,0,0.1,g,0.1,0,,3
-Lipides totaux,Enfants 1 à 8 ans,875,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes jaune foncé ou orange,0,0,0,0,g,0.1,0,,3
-Lipides totaux,Enfants 1 à 8 ans,2475,des,Produits céréaliers,,,,,7.9,0.2,7.5,8.3,g,14.9,0.4,,1
-Lipides totaux,Enfants 1 à 8 ans,2114,des,Produits céréaliers,des,Pains,,,3.7,0.2,3.4,4.1,g,7,0.3,,2
-Lipides totaux,Enfants 1 à 8 ans,1282,des,Produits céréaliers,des,Céréales pour déjeuner,,,0.7,0,0.6,0.8,g,1.3,0.1,,2
-Lipides totaux,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,2.2,0.1,2,2.5,g,4.2,0.2,,2
-Lipides totaux,Enfants 1 à 8 ans,2037,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,1.3,0.1,1.1,1.4,g,2.4,0.1,,2
-Lipides totaux,Enfants 1 à 8 ans,745,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,1.3,0.1,1,1.5,g,2.4,0.2,,3
-Lipides totaux,Enfants 1 à 8 ans,805,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,1.1,0.1,0.9,1.3,g,2,0.2,,3
-Lipides totaux,Enfants 1 à 8 ans,951,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,0.9,0.1,0.7,1,g,1.6,0.1,,3
-Lipides totaux,Enfants 1 à 8 ans,813,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,0.5,0,0.5,0.6,g,1,0.1,,3
-Lipides totaux,Enfants 1 à 8 ans,728,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.4,0,0.4,0.5,g,0.8,0.1,,3
-Lipides totaux,Enfants 1 à 8 ans,670,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.3,0,0.2,0.3,g,0.5,0,,3
-Lipides totaux,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.5,0,0.4,0.6,g,1,0.1,,3
-Lipides totaux,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0,0.1,g,0.2,0.1,,3
-Lipides totaux,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0.1,g,0.1,0,,3
-Lipides totaux,Enfants 1 à 8 ans,834,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.7,0.1,0.6,0.8,g,1.3,0.1,,3
-Lipides totaux,Enfants 1 à 8 ans,1461,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.4,0,0.4,0.5,g,0.8,0.1,,3
-Lipides totaux,Enfants 1 à 8 ans,654,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0.1,0,0.1,0.1,g,0.2,0,,3
-Lipides totaux,Enfants 1 à 8 ans,2072,de la,Viandes et volailles,,,,,6.8,0.3,6.2,7.3,g,12.8,0.5,,1
-Lipides totaux,Enfants 1 à 8 ans,1003,de la,Viandes et volailles,de la,Volaille,,,1.9,0.2,1.6,2.2,g,3.6,0.3,,2
-Lipides totaux,Enfants 1 à 8 ans,942,de la,Viandes et volailles,des,Viandes transformées,,,2.7,0.2,2.4,3.1,g,5.1,0.3,,2
-Lipides totaux,Enfants 1 à 8 ans,999,de la,Viandes et volailles,de la,Viande rouge,,,2.1,0.1,1.9,2.4,g,4,0.3,,2
-Lipides totaux,Enfants 1 à 8 ans,933,de la,Viandes et volailles,de la,Volaille,du,Poulet,1.9,0.2,1.5,2.2,g,3.5,0.3,,3
-Lipides totaux,Enfants 1 à 8 ans,86,de la,Viandes et volailles,de la,Volaille,de la,Dinde et autres volailles,0.1,0,0,0.1,g,0.1,0,,3
-Lipides totaux,Enfants 1 à 8 ans,375,de la,Viandes et volailles,des,Viandes transformées,des,Saucisses,1.6,0.2,1.2,1.9,g,3,0.3,,3
-Lipides totaux,Enfants 1 à 8 ans,513,de la,Viandes et volailles,des,Viandes transformées,des,Viandes froides,0.8,0.1,0.6,1,g,1.5,0.2,,3
-Lipides totaux,Enfants 1 à 8 ans,135,de la,Viandes et volailles,des,Viandes transformées,du,Bacon,0.2,0,0.1,0.3,g,0.4,0.1,,3
-Lipides totaux,Enfants 1 à 8 ans,106,de la,Viandes et volailles,des,Viandes transformées,du,Porc salé,0.1,0,0.1,0.2,g,0.3,0.1,,3
-Lipides totaux,Enfants 1 à 8 ans,779,de la,Viandes et volailles,de la,Viande rouge,du,Bœuf,1.5,0.1,1.3,1.8,g,2.9,0.2,,3
-Lipides totaux,Enfants 1 à 8 ans,284,de la,Viandes et volailles,de la,Viande rouge,du,Porc frais,0.5,0.1,0.3,0.6,g,0.9,0.1,E,3
-Lipides totaux,Enfants 1 à 8 ans,43,de la,Viandes et volailles,de la,Viande rouge,de l',Agneau - veau et gibiers,0.1,0,0,0.2,g,0.2,0.1,,3
-Lipides totaux,Enfants 1 à 8 ans,,de la,Viandes et volailles,de la,Viande rouge,des,Abats - foies et pâtés,X,X,,,g,X,X,<10,3
-Lipides totaux,Enfants 1 à 8 ans,1789,des,Substituts de viande,,,,,4.4,0.3,3.8,4.9,g,8.2,0.5,,1
-Lipides totaux,Enfants 1 à 8 ans,1450,des,Substituts de viande,des,Œufs,,,1.5,0.1,1.3,1.6,g,2.7,0.2,,2
-Lipides totaux,Enfants 1 à 8 ans,210,des,Substituts de viande,des,Légumineuses,,,0.1,0,0.1,0.2,g,0.2,0,,2
-Lipides totaux,Enfants 1 à 8 ans,749,des,Substituts de viande,des,Noix - graines et beurre d'arachides,,,2.6,0.3,2.1,3.2,g,4.9,0.5,,2
-Lipides totaux,Enfants 1 à 8 ans,58,des,Substituts de viande,du,Tofu et produits sans viande,,,F,F,,,g,F,F,F,2
-Lipides totaux,Enfants 1 à 8 ans,45,des,Boissons et barres nutritionnelles,,,,,0.1,0,0.1,0.2,g,0.3,0.1,,1
-Lipides totaux,Enfants 1 à 8 ans,40,des,Boissons et barres nutritionnelles,des,Substituts de repas et boissons nutritionnelles,,,0.1,0,0.1,0.2,g,0.2,0.1,,2
-Lipides totaux,Enfants 1 à 8 ans,,des,Boissons et barres nutritionnelles,des,Barres nutritionnelles,,,X,X,,,g,X,X,<10,2
-Lipides totaux,Enfants 1 à 8 ans,2295,des,Soupes - sauces - Épices et autres ingrédients,,,,,0.6,0.1,0.4,0.8,g,1.2,0.2,E,1
-Lipides totaux,Enfants 1 à 8 ans,761,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.4,0.1,0.2,0.6,g,0.7,0.2,E,2
-Lipides totaux,Enfants 1 à 8 ans,532,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0.2,0,0.1,0.2,g,0.3,0,,2
-Lipides totaux,Enfants 1 à 8 ans,2205,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.1,0,0.1,0.1,g,0.2,0,,2
-Lipides totaux,Enfants 1 à 8 ans,2106,des,Confiseries - sucres et grignotines salées,,,,,4.6,0.3,4.1,5.2,g,8.8,0.5,,1
-Lipides totaux,Enfants 1 à 8 ans,1048,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,1.2,0.1,1,1.4,g,2.3,0.2,,2
-Lipides totaux,Enfants 1 à 8 ans,497,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,1.3,0.1,1.1,1.6,g,2.5,0.3,,2
-Lipides totaux,Enfants 1 à 8 ans,615,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,1.7,0.2,1.4,2,g,3.2,0.3,,2
-Lipides totaux,Enfants 1 à 8 ans,1642,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.4,0.1,0.3,0.5,g,0.7,0.1,E,2
-Lipides totaux,Enfants 1 à 8 ans,548,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,1,0.1,0.8,1.1,g,1.8,0.2,,3
-Lipides totaux,Enfants 1 à 8 ans,557,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0.2,0,0.1,0.2,g,0.3,0,,3
-Lipides totaux,Enfants 1 à 8 ans,131,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0.1,0,0.1,0.2,g,0.2,0,,3
-Lipides totaux,Enfants 1 à 8 ans,346,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,1.3,0.1,1,1.6,g,2.5,0.3,,3
-Lipides totaux,Enfants 1 à 8 ans,184,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0,0,,3
-Lipides totaux,Enfants 1 à 8 ans,720,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.4,0.1,0.3,0.5,g,0.7,0.1,E,3
-Lipides totaux,Enfants 1 à 8 ans,257,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0,0,,3
-Lipides totaux,Enfants 1 à 8 ans,1341,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
-Lipides totaux,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,g,X,X,<10,3
+Lipides totaux,Enfants 1 à 8 ans,122,des,Aliments pour bébés,,,,,0.3,0.1,0.2,0.5,g,0.6,0.1,E,1
+Lipides totaux,Enfants 1 à 8 ans,95,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0.1,0,0,0.1,g,0.1,0,,2
+Lipides totaux,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0.3,0.1,0.1,0.4,g,0.5,0.1,E,2
+Lipides totaux,Enfants 1 à 8 ans,2443,des,Boissons (excluant laits),,,,,0.2,0,0.2,0.3,g,0.4,0,,1
+Lipides totaux,Enfants 1 à 8 ans,20,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0,g,0,0,,2
+Lipides totaux,Enfants 1 à 8 ans,141,des,Boissons (excluant laits),du,Café et thé,,,0,0,0,0,g,0,0,,2
+Lipides totaux,Enfants 1 à 8 ans,,des,Boissons (excluant laits),des,Boissons Énergisantes,,,X,X,,,g,X,X,<10,2
+Lipides totaux,Enfants 1 à 8 ans,357,des,Boissons (excluant laits),des,Boissons aux fruits,,,0,0,0,0,g,0.1,0,,2
+Lipides totaux,Enfants 1 à 8 ans,1159,des,Boissons (excluant laits),des,Jus de fruit,,,0.2,0,0.1,0.2,g,0.3,0,,2
+Lipides totaux,Enfants 1 à 8 ans,77,des,Boissons (excluant laits),des,Autres boissons,,,0,0,0,0.1,g,0.1,0,,2
+Lipides totaux,Enfants 1 à 8 ans,142,des,Boissons (excluant laits),des,Boissons gazeuses,,,0,0,0,0,g,0,0,,2
+Lipides totaux,Enfants 1 à 8 ans,21,des,Boissons (excluant laits),des,Boissons pour sportifs,,,0,0,0,0,g,0,0,,2
+Lipides totaux,Enfants 1 à 8 ans,52,des,Boissons (excluant laits),des,Jus de tomates et de légumes,,,0,0,0,0,g,0,0,,2
+Lipides totaux,Enfants 1 à 8 ans,,des,Boissons (excluant laits),de l',Eau vitaminée,,,X,X,,,g,X,X,<10,2
+Lipides totaux,Enfants 1 à 8 ans,2344,des,Boissons (excluant laits),de l',Eau,,,0,0,0,0,g,0,0,,2
+Lipides totaux,Enfants 1 à 8 ans,133,des,Boissons (excluant laits),du,Café et thé,du,Thé,0,0,0,0,g,0,0,,3
+Lipides totaux,Enfants 1 à 8 ans,,des,Boissons (excluant laits),du,Café et thé,du,Café,X,X,,,g,X,X,<10,3
+Lipides totaux,Enfants 1 à 8 ans,2436,des,Produits laitiers et Boissons à base de plantes,,,,,14.6,0.4,13.8,15.4,g,27.5,0.7,,1
+Lipides totaux,Enfants 1 à 8 ans,1632,des,Produits laitiers et Boissons à base de plantes,des,Fromages,,,5.9,0.3,5.3,6.5,g,11.1,0.5,,2
+Lipides totaux,Enfants 1 à 8 ans,2341,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,7.8,0.2,7.3,8.2,g,14.6,0.4,,2
+Lipides totaux,Enfants 1 à 8 ans,1032,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,,,1,0.1,0.9,1.1,g,1.8,0.1,,2
+Lipides totaux,Enfants 1 à 8 ans,1078,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,3.5,0.2,3,3.9,g,6.5,0.4,,3
+Lipides totaux,Enfants 1 à 8 ans,1810,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,3.2,0.1,2.9,3.5,g,6.1,0.3,,3
+Lipides totaux,Enfants 1 à 8 ans,854,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,0.6,0.1,0.4,0.7,g,1.1,0.1,E,3
+Lipides totaux,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0.4,0.1,0.3,0.5,g,0.8,0.1,E,3
+Lipides totaux,Enfants 1 à 8 ans,128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0.1,0,0.1,0.1,g,0.2,0,,3
+Lipides totaux,Enfants 1 à 8 ans,739,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0,0,0,0,g,0,0,,3
+Lipides totaux,Enfants 1 à 8 ans,2270,des,Graisses et huiles,,,,,11.5,0.4,10.8,12.2,g,21.7,0.6,,1
+Lipides totaux,Enfants 1 à 8 ans,83,des,Graisses et huiles,des,Graisses animales,,,0.2,0,0.1,0.3,g,0.3,0.1,,2
+Lipides totaux,Enfants 1 à 8 ans,657,des,Graisses et huiles,du,Beurre,,,1.5,0.1,1.2,1.8,g,2.8,0.2,,2
+Lipides totaux,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Margarines,,,2.9,0.2,2.6,3.2,g,5.5,0.3,,2
+Lipides totaux,Enfants 1 à 8 ans,463,des,Graisses et huiles,des,Sauces pour salade,,,1,0.1,0.8,1.2,g,1.9,0.2,,2
+Lipides totaux,Enfants 1 à 8 ans,1035,des,Graisses et huiles,du,Shortening,,,2.8,0.2,2.4,3.2,g,5.3,0.3,,2
+Lipides totaux,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Huiles végétales,,,3.1,0.2,2.7,3.5,g,5.8,0.4,,2
+Lipides totaux,Enfants 1 à 8 ans,298,des,Poissons et fruits de mer,,,,,0.4,0.1,0.2,0.6,g,0.7,0.2,E,1
+Lipides totaux,Enfants 1 à 8 ans,257,des,Poissons et fruits de mer,des,Poissons,,,0.4,0.1,0.2,0.5,g,0.7,0.2,E,2
+Lipides totaux,Enfants 1 à 8 ans,50,des,Poissons et fruits de mer,des,Mollusques et crustacés,,,0,0,0,0,g,0,0,,2
+Lipides totaux,Enfants 1 à 8 ans,2428,des,Fruits et légumes,,,,,1.6,0.1,1.4,1.7,g,2.9,0.2,,1
+Lipides totaux,Enfants 1 à 8 ans,2117,des,Fruits et légumes,des,Fruits,,,0.6,0.1,0.5,0.8,g,1.2,0.1,E,2
+Lipides totaux,Enfants 1 à 8 ans,2235,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,0.9,0.1,0.8,1,g,1.7,0.1,,2
+Lipides totaux,Enfants 1 à 8 ans,260,des,Fruits et légumes,des,Fruits,des,Autres fruits,0.3,0.1,0.1,0.4,g,0.5,0.1,E,3
+Lipides totaux,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pommes,0.1,0,0.1,0.1,g,0.2,0,,3
+Lipides totaux,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Bananes,0.1,0,0.1,0.1,g,0.2,0,,3
+Lipides totaux,Enfants 1 à 8 ans,830,des,Fruits et légumes,des,Fruits,des,Baies,0.1,0,0.1,0.1,g,0.2,0,,3
+Lipides totaux,Enfants 1 à 8 ans,47,des,Fruits et légumes,des,Fruits,des,Cerises,0,0,0,0,g,0,0,,3
+Lipides totaux,Enfants 1 à 8 ans,421,des,Fruits et légumes,des,Fruits,des,Agrumes,0,0,0,0,g,0,0,,3
+Lipides totaux,Enfants 1 à 8 ans,572,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,0,0,0,0,g,0,0,,3
+Lipides totaux,Enfants 1 à 8 ans,219,des,Fruits et légumes,des,Fruits,des,Melons,0,0,0,0,g,0,0,,3
+Lipides totaux,Enfants 1 à 8 ans,118,des,Fruits et légumes,des,Fruits,des,Pêches et nectarines,0,0,0,0,g,0,0,,3
+Lipides totaux,Enfants 1 à 8 ans,133,des,Fruits et légumes,des,Fruits,des,Poires,0,0,0,0,g,0,0,,3
+Lipides totaux,Enfants 1 à 8 ans,94,des,Fruits et légumes,des,Fruits,des,Ananas,0,0,0,0,g,0,0,,3
+Lipides totaux,Enfants 1 à 8 ans,37,des,Fruits et légumes,des,Fruits,des,Prunes et pruneaux,0,0,0,0,g,0,0,,3
+Lipides totaux,Enfants 1 à 8 ans,1032,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes féculents,0.5,0.1,0.4,0.6,g,1,0.1,E,3
+Lipides totaux,Enfants 1 à 8 ans,1773,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Autres légumes,0.3,0,0.2,0.3,g,0.5,0,,3
+Lipides totaux,Enfants 1 à 8 ans,1068,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes vert foncé,0.1,0,0,0.1,g,0.1,0,,3
+Lipides totaux,Enfants 1 à 8 ans,875,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes jaune foncé ou orange,0,0,0,0,g,0.1,0,,3
+Lipides totaux,Enfants 1 à 8 ans,2475,des,Produits céréaliers,,,,,7.9,0.2,7.5,8.3,g,14.9,0.4,,1
+Lipides totaux,Enfants 1 à 8 ans,2114,des,Produits céréaliers,des,Pains,,,3.7,0.2,3.4,4.1,g,7,0.3,,2
+Lipides totaux,Enfants 1 à 8 ans,1282,des,Produits céréaliers,des,Céréales pour déjeuner,,,0.7,0,0.6,0.8,g,1.3,0.1,,2
+Lipides totaux,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,2.2,0.1,2,2.5,g,4.2,0.2,,2
+Lipides totaux,Enfants 1 à 8 ans,2037,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,1.3,0.1,1.1,1.4,g,2.4,0.1,,2
+Lipides totaux,Enfants 1 à 8 ans,745,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,1.3,0.1,1,1.5,g,2.4,0.2,,3
+Lipides totaux,Enfants 1 à 8 ans,805,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,1.1,0.1,0.9,1.3,g,2,0.2,,3
+Lipides totaux,Enfants 1 à 8 ans,951,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,0.9,0.1,0.7,1,g,1.6,0.1,,3
+Lipides totaux,Enfants 1 à 8 ans,813,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,0.5,0,0.5,0.6,g,1,0.1,,3
+Lipides totaux,Enfants 1 à 8 ans,728,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.4,0,0.4,0.5,g,0.8,0.1,,3
+Lipides totaux,Enfants 1 à 8 ans,670,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.3,0,0.2,0.3,g,0.5,0,,3
+Lipides totaux,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.5,0,0.4,0.6,g,1,0.1,,3
+Lipides totaux,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0,0.1,g,0.2,0.1,,3
+Lipides totaux,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0.1,g,0.1,0,,3
+Lipides totaux,Enfants 1 à 8 ans,834,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.7,0.1,0.6,0.8,g,1.3,0.1,,3
+Lipides totaux,Enfants 1 à 8 ans,1461,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.4,0,0.4,0.5,g,0.8,0.1,,3
+Lipides totaux,Enfants 1 à 8 ans,654,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0.1,0,0.1,0.1,g,0.2,0,,3
+Lipides totaux,Enfants 1 à 8 ans,2072,de la,Viandes et volailles,,,,,6.8,0.3,6.2,7.3,g,12.8,0.5,,1
+Lipides totaux,Enfants 1 à 8 ans,1003,de la,Viandes et volailles,de la,Volaille,,,1.9,0.2,1.6,2.2,g,3.6,0.3,,2
+Lipides totaux,Enfants 1 à 8 ans,942,de la,Viandes et volailles,des,Viandes transformées,,,2.7,0.2,2.4,3.1,g,5.1,0.3,,2
+Lipides totaux,Enfants 1 à 8 ans,999,de la,Viandes et volailles,de la,Viande rouge,,,2.1,0.1,1.9,2.4,g,4,0.3,,2
+Lipides totaux,Enfants 1 à 8 ans,933,de la,Viandes et volailles,de la,Volaille,du,Poulet,1.9,0.2,1.5,2.2,g,3.5,0.3,,3
+Lipides totaux,Enfants 1 à 8 ans,86,de la,Viandes et volailles,de la,Volaille,de la,Dinde et autres volailles,0.1,0,0,0.1,g,0.1,0,,3
+Lipides totaux,Enfants 1 à 8 ans,375,de la,Viandes et volailles,des,Viandes transformées,des,Saucisses,1.6,0.2,1.2,1.9,g,3,0.3,,3
+Lipides totaux,Enfants 1 à 8 ans,513,de la,Viandes et volailles,des,Viandes transformées,des,Viandes froides,0.8,0.1,0.6,1,g,1.5,0.2,,3
+Lipides totaux,Enfants 1 à 8 ans,135,de la,Viandes et volailles,des,Viandes transformées,du,Bacon,0.2,0,0.1,0.3,g,0.4,0.1,,3
+Lipides totaux,Enfants 1 à 8 ans,106,de la,Viandes et volailles,des,Viandes transformées,du,Porc salé,0.1,0,0.1,0.2,g,0.3,0.1,,3
+Lipides totaux,Enfants 1 à 8 ans,779,de la,Viandes et volailles,de la,Viande rouge,du,Bœuf,1.5,0.1,1.3,1.8,g,2.9,0.2,,3
+Lipides totaux,Enfants 1 à 8 ans,284,de la,Viandes et volailles,de la,Viande rouge,du,Porc frais,0.5,0.1,0.3,0.6,g,0.9,0.1,E,3
+Lipides totaux,Enfants 1 à 8 ans,43,de la,Viandes et volailles,de la,Viande rouge,de l',Agneau - veau et gibiers,0.1,0,0,0.2,g,0.2,0.1,,3
+Lipides totaux,Enfants 1 à 8 ans,,de la,Viandes et volailles,de la,Viande rouge,des,Abats - foies et pâtés,X,X,,,g,X,X,<10,3
+Lipides totaux,Enfants 1 à 8 ans,1789,des,Substituts de viande,,,,,4.4,0.3,3.8,4.9,g,8.2,0.5,,1
+Lipides totaux,Enfants 1 à 8 ans,1450,des,Substituts de viande,des,Œufs,,,1.5,0.1,1.3,1.6,g,2.7,0.2,,2
+Lipides totaux,Enfants 1 à 8 ans,210,des,Substituts de viande,des,Légumineuses,,,0.1,0,0.1,0.2,g,0.2,0,,2
+Lipides totaux,Enfants 1 à 8 ans,749,des,Substituts de viande,des,Noix - graines et beurre d'arachides,,,2.6,0.3,2.1,3.2,g,4.9,0.5,,2
+Lipides totaux,Enfants 1 à 8 ans,58,des,Substituts de viande,du,Tofu et produits sans viande,,,F,F,,,g,F,F,F,2
+Lipides totaux,Enfants 1 à 8 ans,45,des,Boissons et barres nutritionnelles,,,,,0.1,0,0.1,0.2,g,0.3,0.1,,1
+Lipides totaux,Enfants 1 à 8 ans,40,des,Boissons et barres nutritionnelles,des,Substituts de repas et boissons nutritionnelles,,,0.1,0,0.1,0.2,g,0.2,0.1,,2
+Lipides totaux,Enfants 1 à 8 ans,,des,Boissons et barres nutritionnelles,des,Barres nutritionnelles,,,X,X,,,g,X,X,<10,2
+Lipides totaux,Enfants 1 à 8 ans,2295,des,Soupes - sauces - Épices et autres ingrédients,,,,,0.6,0.1,0.4,0.8,g,1.2,0.2,E,1
+Lipides totaux,Enfants 1 à 8 ans,761,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.4,0.1,0.2,0.6,g,0.7,0.2,E,2
+Lipides totaux,Enfants 1 à 8 ans,532,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0.2,0,0.1,0.2,g,0.3,0,,2
+Lipides totaux,Enfants 1 à 8 ans,2205,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.1,0,0.1,0.1,g,0.2,0,,2
+Lipides totaux,Enfants 1 à 8 ans,2106,des,Confiseries - sucres et grignotines salées,,,,,4.6,0.3,4.1,5.2,g,8.8,0.5,,1
+Lipides totaux,Enfants 1 à 8 ans,1048,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,1.2,0.1,1,1.4,g,2.3,0.2,,2
+Lipides totaux,Enfants 1 à 8 ans,497,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,1.3,0.1,1.1,1.6,g,2.5,0.3,,2
+Lipides totaux,Enfants 1 à 8 ans,615,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,1.7,0.2,1.4,2,g,3.2,0.3,,2
+Lipides totaux,Enfants 1 à 8 ans,1642,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.4,0.1,0.3,0.5,g,0.7,0.1,E,2
+Lipides totaux,Enfants 1 à 8 ans,548,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,1,0.1,0.8,1.1,g,1.8,0.2,,3
+Lipides totaux,Enfants 1 à 8 ans,557,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0.2,0,0.1,0.2,g,0.3,0,,3
+Lipides totaux,Enfants 1 à 8 ans,131,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0.1,0,0.1,0.2,g,0.2,0,,3
+Lipides totaux,Enfants 1 à 8 ans,346,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,1.3,0.1,1,1.6,g,2.5,0.3,,3
+Lipides totaux,Enfants 1 à 8 ans,184,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0,0,,3
+Lipides totaux,Enfants 1 à 8 ans,720,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.4,0.1,0.3,0.5,g,0.7,0.1,E,3
+Lipides totaux,Enfants 1 à 8 ans,257,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0,0,,3
+Lipides totaux,Enfants 1 à 8 ans,1341,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
+Lipides totaux,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,g,X,X,<10,3
 Sucres totaux,Population 1 an et +,186,des,Aliments pour bébés,,,,,0.1,0,0,0.1,g,0.1,0,,1
 Sucres totaux,Population 1 an et +,154,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0.1,0,0,0.1,g,0.1,0,,2
 Sucres totaux,Population 1 an et +,51,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0,0,0,0,g,0,0,,2
@@ -5052,7 +5052,7 @@ Sucres totaux,Population 1 an et +,6318,des,Fruits et légumes,des,Légumes incl
 Sucres totaux,Population 1 an et +,19327,des,Produits céréaliers,,,,,9.6,0.1,9.3,9.9,g,10.6,0.1,,1
 Sucres totaux,Population 1 an et +,16168,des,Produits céréaliers,des,Pains,,,4.5,0.1,4.4,4.7,g,5,0.1,,2
 Sucres totaux,Population 1 an et +,6966,des,Produits céréaliers,des,Céréales pour déjeuner,,,2,0.1,1.8,2.1,g,2.1,0.1,,2
-Sucres totaux,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,2.7,0.1,2.5,2.9,g,2.9,0.1,,2
+Sucres totaux,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,2.7,0.1,2.5,2.9,g,2.9,0.1,,2
 Sucres totaux,Population 1 an et +,14820,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,0.4,0,0.4,0.5,g,0.5,0,,2
 Sucres totaux,Population 1 an et +,8159,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,2.2,0.1,2.1,2.3,g,2.4,0.1,,3
 Sucres totaux,Population 1 an et +,6257,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,1.3,0.1,1.2,1.4,g,1.5,0.1,,3
@@ -5060,10 +5060,10 @@ Sucres totaux,Population 1 an et +,5962,des,Produits céréaliers,des,Pains,des,
 Sucres totaux,Population 1 an et +,2918,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.1,0,0.1,0.2,g,0.1,0,,3
 Sucres totaux,Population 1 an et +,4760,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,1.1,0.1,1,1.2,g,1.2,0.1,,3
 Sucres totaux,Population 1 an et +,2573,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.8,0,0.7,0.9,g,0.9,0,,3
-Sucres totaux,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.9,0.1,0.8,1,g,1,0.1,,3
-Sucres totaux,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0.1,0.2,g,0.2,0,,3
-Sucres totaux,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.1,g,0.1,0,,3
-Sucres totaux,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
+Sucres totaux,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.9,0.1,0.8,1,g,1,0.1,,3
+Sucres totaux,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0.1,0.2,g,0.2,0,,3
+Sucres totaux,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.1,g,0.1,0,,3
+Sucres totaux,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
 Sucres totaux,Population 1 an et +,4543,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.3,0,0.2,0.3,g,0.3,0,,3
 Sucres totaux,Population 1 an et +,11102,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.1,0,0.1,0.2,g,0.2,0,,3
 Sucres totaux,Population 1 an et +,4598,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0,0,0,0,g,0,0,,3
@@ -5166,7 +5166,7 @@ Sucres totaux,Hommes adultes 19 ans +,1991,des,Fruits et légumes,des,Légumes i
 Sucres totaux,Hommes adultes 19 ans +,6068,des,Produits céréaliers,,,,,10.3,0.2,9.8,10.8,g,10.7,0.3,,1
 Sucres totaux,Hommes adultes 19 ans +,5104,des,Produits céréaliers,des,Pains,,,5.2,0.1,4.9,5.5,g,5.4,0.2,,2
 Sucres totaux,Hommes adultes 19 ans +,1921,des,Produits céréaliers,des,Céréales pour déjeuner,,,1.9,0.1,1.7,2.1,g,2,0.1,,2
-Sucres totaux,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,2.7,0.2,2.4,3.1,g,2.8,0.2,,2
+Sucres totaux,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,2.7,0.2,2.4,3.1,g,2.8,0.2,,2
 Sucres totaux,Hommes adultes 19 ans +,4551,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,0.5,0,0.4,0.5,g,0.5,0,,2
 Sucres totaux,Hommes adultes 19 ans +,2752,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,2.8,0.1,2.6,3,g,2.9,0.1,,3
 Sucres totaux,Hommes adultes 19 ans +,1885,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,1.4,0.1,1.2,1.6,g,1.5,0.1,,3
@@ -5174,9 +5174,9 @@ Sucres totaux,Hommes adultes 19 ans +,1980,des,Produits céréaliers,des,Pains,d
 Sucres totaux,Hommes adultes 19 ans +,593,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.1,0,0,0.1,g,0.1,0,,3
 Sucres totaux,Hommes adultes 19 ans +,1481,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,1.4,0.1,1.2,1.6,g,1.4,0.1,,3
 Sucres totaux,Hommes adultes 19 ans +,523,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.5,0.1,0.4,0.6,g,0.6,0.1,E,3
-Sucres totaux,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,1,0.1,0.8,1.2,g,1,0.1,,3
-Sucres totaux,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0.1,g,0.1,0,,3
-Sucres totaux,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,F,F,,,g,F,F,F,3
+Sucres totaux,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,1,0.1,0.8,1.2,g,1,0.1,,3
+Sucres totaux,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0.1,g,0.1,0,,3
+Sucres totaux,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,F,F,,,g,F,F,F,3
 Sucres totaux,Hommes adultes 19 ans +,1250,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.2,0,0.2,0.3,g,0.3,0,,3
 Sucres totaux,Hommes adultes 19 ans +,3442,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.2,0,0.2,0.2,g,0.2,0,,3
 Sucres totaux,Hommes adultes 19 ans +,1449,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0,0,0,0.1,g,0.1,0,,3
@@ -5279,7 +5279,7 @@ Sucres totaux,Femmes adultes* 19 ans +,2348,des,Fruits et légumes,des,Légumes 
 Sucres totaux,Femmes adultes* 19 ans +,6669,des,Produits céréaliers,,,,,7.3,0.2,7,7.7,g,9.5,0.2,,1
 Sucres totaux,Femmes adultes* 19 ans +,5520,des,Produits céréaliers,des,Pains,,,3.8,0.1,3.6,4,g,4.9,0.1,,2
 Sucres totaux,Femmes adultes* 19 ans +,2230,des,Produits céréaliers,des,Céréales pour déjeuner,,,1.3,0.1,1.2,1.5,g,1.7,0.1,,2
-Sucres totaux,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,1.8,0.1,1.6,2,g,2.4,0.1,,2
+Sucres totaux,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,1.8,0.1,1.6,2,g,2.4,0.1,,2
 Sucres totaux,Femmes adultes* 19 ans +,4893,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,0.4,0,0.3,0.4,g,0.5,0,,2
 Sucres totaux,Femmes adultes* 19 ans +,2551,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,1.8,0.1,1.6,1.9,g,2.3,0.1,,3
 Sucres totaux,Femmes adultes* 19 ans +,1994,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,1.1,0.1,1,1.2,g,1.4,0.1,,3
@@ -5287,10 +5287,10 @@ Sucres totaux,Femmes adultes* 19 ans +,2239,des,Produits céréaliers,des,Pains,
 Sucres totaux,Femmes adultes* 19 ans +,914,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.1,0,0.1,0.2,g,0.2,0,,3
 Sucres totaux,Femmes adultes* 19 ans +,1756,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.9,0.1,0.8,1,g,1.2,0.1,,3
 Sucres totaux,Femmes adultes* 19 ans +,555,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.4,0,0.3,0.5,g,0.6,0.1,,3
-Sucres totaux,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.5,0.1,0.4,0.6,g,0.7,0.1,E,3
-Sucres totaux,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0,0.1,g,0.1,0,,3
-Sucres totaux,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0.1,g,0.1,0,,3
-Sucres totaux,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
+Sucres totaux,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.5,0.1,0.4,0.6,g,0.7,0.1,E,3
+Sucres totaux,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0,0.1,g,0.1,0,,3
+Sucres totaux,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0.1,g,0.1,0,,3
+Sucres totaux,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
 Sucres totaux,Femmes adultes* 19 ans +,1358,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.2,0,0.2,0.2,g,0.3,0,,3
 Sucres totaux,Femmes adultes* 19 ans +,3664,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.1,0,0.1,0.1,g,0.2,0,,3
 Sucres totaux,Femmes adultes* 19 ans +,1522,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0,0,0,0,g,0.1,0,,3
@@ -5334,119 +5334,119 @@ Sucres totaux,Femmes adultes* 19 ans +,4229,des,Confiseries - sucres et grignoti
 Sucres totaux,Femmes adultes* 19 ans +,1529,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,3.2,0.2,2.7,3.6,g,4.1,0.3,,3
 Sucres totaux,Femmes adultes* 19 ans +,773,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.8,0.1,0.7,0.9,g,1,0.1,,3
 Sucres totaux,Femmes adultes* 19 ans +,360,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0.1,0,0,0.1,g,0.1,0,,3
-Sucres totaux,Enfants 1 à 8 ans,122,des,Aliments pour bébés,,,,,0.4,0.1,0.2,0.5,g,0.4,0.1,E,1
-Sucres totaux,Enfants 1 à 8 ans,95,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0.4,0.1,0.2,0.5,g,0.4,0.1,E,2
-Sucres totaux,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0,0,0,0,g,0,0,,2
-Sucres totaux,Enfants 1 à 8 ans,2443,des,Boissons (excluant laits),,,,,16.6,0.7,15.3,18,g,17.2,0.6,,1
-Sucres totaux,Enfants 1 à 8 ans,20,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0.1,g,0,0,,2
-Sucres totaux,Enfants 1 à 8 ans,141,des,Boissons (excluant laits),du,Café et thé,,,0.5,0.1,0.2,0.8,g,0.5,0.1,E,2
-Sucres totaux,Enfants 1 à 8 ans,,des,Boissons (excluant laits),des,Boissons Énergisantes,,,X,X,,,g,X,X,<10,2
-Sucres totaux,Enfants 1 à 8 ans,357,des,Boissons (excluant laits),des,Boissons aux fruits,,,3.6,0.4,2.8,4.4,g,3.7,0.4,,2
-Sucres totaux,Enfants 1 à 8 ans,1159,des,Boissons (excluant laits),des,Jus de fruit,,,10.5,0.5,9.5,11.5,g,10.9,0.5,,2
-Sucres totaux,Enfants 1 à 8 ans,77,des,Boissons (excluant laits),des,Autres boissons,,,0.7,0.2,0.4,1,g,0.7,0.2,E,2
-Sucres totaux,Enfants 1 à 8 ans,142,des,Boissons (excluant laits),des,Boissons gazeuses,,,1.1,0.2,0.7,1.5,g,1.2,0.2,E,2
-Sucres totaux,Enfants 1 à 8 ans,21,des,Boissons (excluant laits),des,Boissons pour sportifs,,,0.1,0,0,0.1,g,0.1,0,,2
-Sucres totaux,Enfants 1 à 8 ans,52,des,Boissons (excluant laits),des,Jus de tomates et de légumes,,,0.1,0,0,0.1,g,0.1,0,,2
-Sucres totaux,Enfants 1 à 8 ans,,des,Boissons (excluant laits),de l',Eau vitaminée,,,X,X,,,g,X,X,<10,2
-Sucres totaux,Enfants 1 à 8 ans,2344,des,Boissons (excluant laits),de l',Eau,,,0,0,0,0,g,0,0,,2
-Sucres totaux,Enfants 1 à 8 ans,133,des,Boissons (excluant laits),du,Café et thé,du,Thé,0.5,0.1,0.2,0.8,g,0.5,0.1,E,3
-Sucres totaux,Enfants 1 à 8 ans,,des,Boissons (excluant laits),du,Café et thé,du,Café,X,X,,,g,X,X,<10,3
-Sucres totaux,Enfants 1 à 8 ans,2436,des,Produits laitiers et Boissons à base de plantes,,,,,24.1,0.6,22.9,25.4,g,25,0.6,,1
-Sucres totaux,Enfants 1 à 8 ans,1632,des,Produits laitiers et Boissons à base de plantes,des,Fromages,,,0.5,0,0.4,0.6,g,0.5,0,,2
-Sucres totaux,Enfants 1 à 8 ans,2341,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,18.5,0.5,17.5,19.6,g,19.1,0.5,,2
-Sucres totaux,Enfants 1 à 8 ans,1032,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,,,5.1,0.3,4.6,5.7,g,5.3,0.3,,2
-Sucres totaux,Enfants 1 à 8 ans,2242,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait nature,16,0.5,15,16.9,g,16.5,0.5,,3
-Sucres totaux,Enfants 1 à 8 ans,217,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait aromatisé,2,0.2,1.5,2.4,g,2,0.2,,3
-Sucres totaux,Enfants 1 à 8 ans,128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0.4,0.1,0.3,0.6,g,0.5,0.1,E,3
-Sucres totaux,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,F,F,,,g,F,F,F,3
-Sucres totaux,Enfants 1 à 8 ans,948,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,du,Yogourt aromatisé,5,0.3,4.4,5.5,g,5.1,0.3,,3
-Sucres totaux,Enfants 1 à 8 ans,109,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,du,Yogourt nature,0.2,0,0.1,0.2,g,0.2,0,,3
-Sucres totaux,Enfants 1 à 8 ans,2270,des,Graisses et huiles,,,,,0.1,0,0.1,0.2,g,0.1,0,,1
-Sucres totaux,Enfants 1 à 8 ans,83,des,Graisses et huiles,des,Graisses animales,,,0,0,0,0,g,0,0,,2
-Sucres totaux,Enfants 1 à 8 ans,657,des,Graisses et huiles,du,Beurre,,,0,0,0,0,g,0,0,,2
-Sucres totaux,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Margarines,,,0,0,0,0,g,0,0,,2
-Sucres totaux,Enfants 1 à 8 ans,463,des,Graisses et huiles,des,Sauces pour salade,,,0.1,0,0.1,0.2,g,0.1,0,,2
-Sucres totaux,Enfants 1 à 8 ans,1035,des,Graisses et huiles,du,Shortening,,,0,0,0,0,g,0,0,,2
-Sucres totaux,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Huiles végétales,,,0,0,0,0,g,0,0,,2
-Sucres totaux,Enfants 1 à 8 ans,298,des,Poissons et fruits de mer,,,,,0,0,0,0,g,0,0,,1
-Sucres totaux,Enfants 1 à 8 ans,257,des,Poissons et fruits de mer,des,Poissons,,,0,0,0,0,g,0,0,,2
-Sucres totaux,Enfants 1 à 8 ans,50,des,Poissons et fruits de mer,des,Mollusques et crustacés,,,0,0,0,0,g,0,0,,2
-Sucres totaux,Enfants 1 à 8 ans,2428,des,Fruits et légumes,,,,,22.7,0.7,21.3,24.1,g,23.5,0.7,,1
-Sucres totaux,Enfants 1 à 8 ans,2117,des,Fruits et légumes,des,Fruits,,,19.3,0.7,18,20.6,g,19.9,0.6,,2
-Sucres totaux,Enfants 1 à 8 ans,2235,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,3.4,0.1,3.2,3.7,g,3.5,0.1,,2
-Sucres totaux,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pommes,6.1,0.4,5.3,6.9,g,6.3,0.4,,3
-Sucres totaux,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Bananes,3.6,0.2,3.1,4,g,3.7,0.2,,3
-Sucres totaux,Enfants 1 à 8 ans,572,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,2.5,0.4,1.8,3.2,g,2.6,0.4,,3
-Sucres totaux,Enfants 1 à 8 ans,830,des,Fruits et légumes,des,Fruits,des,Baies,1.6,0.2,1.3,2,g,1.7,0.2,,3
-Sucres totaux,Enfants 1 à 8 ans,421,des,Fruits et légumes,des,Fruits,des,Agrumes,1.6,0.1,1.4,1.9,g,1.7,0.1,,3
-Sucres totaux,Enfants 1 à 8 ans,219,des,Fruits et légumes,des,Fruits,des,Melons,1.1,0.1,0.8,1.4,g,1.1,0.2,,3
-Sucres totaux,Enfants 1 à 8 ans,260,des,Fruits et légumes,des,Fruits,des,Autres fruits,0.9,0.1,0.6,1.1,g,0.9,0.1,,3
-Sucres totaux,Enfants 1 à 8 ans,133,des,Fruits et légumes,des,Fruits,des,Poires,0.7,0.1,0.4,0.9,g,0.7,0.1,,3
-Sucres totaux,Enfants 1 à 8 ans,118,des,Fruits et légumes,des,Fruits,des,Pêches et nectarines,0.6,0.1,0.4,0.7,g,0.6,0.1,E,3
-Sucres totaux,Enfants 1 à 8 ans,94,des,Fruits et légumes,des,Fruits,des,Ananas,0.3,0.1,0.2,0.4,g,0.3,0.1,E,3
-Sucres totaux,Enfants 1 à 8 ans,47,des,Fruits et légumes,des,Fruits,des,Cerises,F,F,,,g,F,F,F,3
-Sucres totaux,Enfants 1 à 8 ans,37,des,Fruits et légumes,des,Fruits,des,Prunes et pruneaux,F,F,,,g,F,F,F,3
-Sucres totaux,Enfants 1 à 8 ans,1773,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Autres légumes,2.1,0.1,1.9,2.4,g,2.2,0.1,,3
-Sucres totaux,Enfants 1 à 8 ans,875,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes jaune foncé ou orange,0.5,0,0.4,0.6,g,0.5,0,,3
-Sucres totaux,Enfants 1 à 8 ans,1068,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes vert foncé,0.4,0,0.3,0.4,g,0.4,0,,3
-Sucres totaux,Enfants 1 à 8 ans,1032,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes féculents,0.4,0,0.3,0.4,g,0.4,0,,3
-Sucres totaux,Enfants 1 à 8 ans,2475,des,Produits céréaliers,,,,,10.9,0.3,10.2,11.6,g,11.2,0.4,,1
-Sucres totaux,Enfants 1 à 8 ans,2114,des,Produits céréaliers,des,Pains,,,3.9,0.2,3.5,4.4,g,4.1,0.2,,2
-Sucres totaux,Enfants 1 à 8 ans,1282,des,Produits céréaliers,des,Céréales pour déjeuner,,,2.6,0.1,2.3,2.9,g,2.7,0.2,,2
-Sucres totaux,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,3.8,0.2,3.4,4.3,g,3.9,0.2,,2
-Sucres totaux,Enfants 1 à 8 ans,2037,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,0.5,0,0.4,0.6,g,0.5,0,,2
-Sucres totaux,Enfants 1 à 8 ans,951,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,1.8,0.2,1.5,2.1,g,1.8,0.2,,3
-Sucres totaux,Enfants 1 à 8 ans,805,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,1.2,0.1,0.9,1.4,g,1.2,0.1,,3
-Sucres totaux,Enfants 1 à 8 ans,813,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,0.6,0,0.5,0.7,g,0.6,0,,3
-Sucres totaux,Enfants 1 à 8 ans,745,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.4,0,0.3,0.4,g,0.4,0,,3
-Sucres totaux,Enfants 1 à 8 ans,670,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),1.9,0.1,1.6,2.1,g,2,0.1,,3
-Sucres totaux,Enfants 1 à 8 ans,728,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.7,0.1,0.6,0.9,g,0.8,0.1,,3
-Sucres totaux,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,1.1,0.1,0.9,1.3,g,1.1,0.1,,3
-Sucres totaux,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.2,g,0.1,0,,3
-Sucres totaux,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,F,F,,,g,F,F,F,3
-Sucres totaux,Enfants 1 à 8 ans,834,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.4,0,0.3,0.4,g,0.4,0,,3
-Sucres totaux,Enfants 1 à 8 ans,1461,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.1,0,0.1,0.1,g,0.1,0,,3
-Sucres totaux,Enfants 1 à 8 ans,654,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0,0,0,0,g,0,0,,3
-Sucres totaux,Enfants 1 à 8 ans,2072,de la,Viandes et volailles,,,,,0.2,0,0.2,0.3,g,0.2,0,,1
-Sucres totaux,Enfants 1 à 8 ans,1003,de la,Viandes et volailles,de la,Volaille,,,0,0,0,0,g,0,0,,2
-Sucres totaux,Enfants 1 à 8 ans,942,de la,Viandes et volailles,des,Viandes transformées,,,0.2,0,0.2,0.3,g,0.2,0,,2
-Sucres totaux,Enfants 1 à 8 ans,999,de la,Viandes et volailles,de la,Viande rouge,,,0,0,0,0,g,0,0,,2
-Sucres totaux,Enfants 1 à 8 ans,933,de la,Viandes et volailles,de la,Volaille,du,Poulet,0,0,0,0,g,0,0,,3
-Sucres totaux,Enfants 1 à 8 ans,86,de la,Viandes et volailles,de la,Volaille,de la,Dinde et autres volailles,0,0,0,0,g,0,0,,3
-Sucres totaux,Enfants 1 à 8 ans,513,de la,Viandes et volailles,des,Viandes transformées,des,Viandes froides,0.1,0,0.1,0.1,g,0.1,0,,3
-Sucres totaux,Enfants 1 à 8 ans,375,de la,Viandes et volailles,des,Viandes transformées,des,Saucisses,0.1,0,0.1,0.2,g,0.1,0,,3
-Sucres totaux,Enfants 1 à 8 ans,135,de la,Viandes et volailles,des,Viandes transformées,du,Bacon,0,0,0,0,g,0,0,,3
-Sucres totaux,Enfants 1 à 8 ans,106,de la,Viandes et volailles,des,Viandes transformées,du,Porc salé,0,0,0,0,g,0,0,,3
-Sucres totaux,Enfants 1 à 8 ans,779,de la,Viandes et volailles,de la,Viande rouge,du,Bœuf,0,0,0,0,g,0,0,,3
-Sucres totaux,Enfants 1 à 8 ans,43,de la,Viandes et volailles,de la,Viande rouge,de l',Agneau - veau et gibiers,0,0,0,0,g,0,0,,3
-Sucres totaux,Enfants 1 à 8 ans,284,de la,Viandes et volailles,de la,Viande rouge,du,Porc frais,0,0,0,0,g,0,0,,3
-Sucres totaux,Enfants 1 à 8 ans,,de la,Viandes et volailles,de la,Viande rouge,des,Abats - foies et pâtés,X,X,,,g,X,X,<10,3
-Sucres totaux,Enfants 1 à 8 ans,1789,des,Substituts de viande,,,,,0.6,0.1,0.5,0.7,g,0.7,0.1,E,1
-Sucres totaux,Enfants 1 à 8 ans,1450,des,Substituts de viande,des,Œufs,,,0.1,0,0.1,0.1,g,0.1,0,,2
-Sucres totaux,Enfants 1 à 8 ans,210,des,Substituts de viande,des,Légumineuses,,,0.1,0,0.1,0.1,g,0.1,0,,2
-Sucres totaux,Enfants 1 à 8 ans,749,des,Substituts de viande,des,Noix - graines et beurre d'arachides,,,0.4,0.1,0.3,0.5,g,0.4,0.1,E,2
-Sucres totaux,Enfants 1 à 8 ans,58,des,Substituts de viande,du,Tofu et produits sans viande,,,0,0,0,0,g,0,0,,2
-Sucres totaux,Enfants 1 à 8 ans,45,des,Boissons et barres nutritionnelles,,,,,0.3,0.1,0.1,0.4,g,0.3,0.1,E,1
-Sucres totaux,Enfants 1 à 8 ans,40,des,Boissons et barres nutritionnelles,des,Substituts de repas et boissons nutritionnelles,,,F,F,,,g,F,F,F,2
-Sucres totaux,Enfants 1 à 8 ans,,des,Boissons et barres nutritionnelles,des,Barres nutritionnelles,,,X,X,,,g,X,X,<10,2
-Sucres totaux,Enfants 1 à 8 ans,2295,des,Soupes - sauces - Épices et autres ingrédients,,,,,1,0.1,0.8,1.3,g,1.1,0.1,,1
-Sucres totaux,Enfants 1 à 8 ans,761,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.8,0.1,0.6,1,g,0.8,0.1,,2
-Sucres totaux,Enfants 1 à 8 ans,532,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0.2,0,0.1,0.3,g,0.2,0,,2
-Sucres totaux,Enfants 1 à 8 ans,2205,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.1,0,0.1,0.1,g,0.1,0,,2
-Sucres totaux,Enfants 1 à 8 ans,2106,des,Confiseries - sucres et grignotines salées,,,,,19.7,1,17.8,21.6,g,20.4,0.8,,1
-Sucres totaux,Enfants 1 à 8 ans,1048,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,4.6,0.3,4,5.3,g,4.8,0.3,,2
-Sucres totaux,Enfants 1 à 8 ans,497,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,5.2,0.5,4.2,6.3,g,5.4,0.5,,2
-Sucres totaux,Enfants 1 à 8 ans,615,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0.2,0,0.1,0.2,g,0.2,0,,2
-Sucres totaux,Enfants 1 à 8 ans,1642,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,9.7,0.6,8.4,11,g,10,0.6,,2
-Sucres totaux,Enfants 1 à 8 ans,557,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,2.1,0.2,1.7,2.5,g,2.2,0.2,,3
-Sucres totaux,Enfants 1 à 8 ans,548,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,1.8,0.2,1.4,2.1,g,1.8,0.2,,3
-Sucres totaux,Enfants 1 à 8 ans,131,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0.8,0.1,0.5,1,g,0.8,0.1,,3
-Sucres totaux,Enfants 1 à 8 ans,346,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,2.8,0.3,2.3,3.4,g,2.9,0.3,,3
-Sucres totaux,Enfants 1 à 8 ans,184,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,2.4,0.4,1.6,3.2,g,2.5,0.4,E,3
-Sucres totaux,Enfants 1 à 8 ans,720,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,4.5,0.4,3.7,5.3,g,4.6,0.4,,3
-Sucres totaux,Enfants 1 à 8 ans,1341,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,4.5,0.3,3.8,5.2,g,4.6,0.3,,3
-Sucres totaux,Enfants 1 à 8 ans,257,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.7,0.1,0.5,1,g,0.8,0.1,,3
-Sucres totaux,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,g,X,X,<10,3
+Sucres totaux,Enfants 1 à 8 ans,122,des,Aliments pour bébés,,,,,0.4,0.1,0.2,0.5,g,0.4,0.1,E,1
+Sucres totaux,Enfants 1 à 8 ans,95,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0.4,0.1,0.2,0.5,g,0.4,0.1,E,2
+Sucres totaux,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0,0,0,0,g,0,0,,2
+Sucres totaux,Enfants 1 à 8 ans,2443,des,Boissons (excluant laits),,,,,16.6,0.7,15.3,18,g,17.2,0.6,,1
+Sucres totaux,Enfants 1 à 8 ans,20,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0.1,g,0,0,,2
+Sucres totaux,Enfants 1 à 8 ans,141,des,Boissons (excluant laits),du,Café et thé,,,0.5,0.1,0.2,0.8,g,0.5,0.1,E,2
+Sucres totaux,Enfants 1 à 8 ans,,des,Boissons (excluant laits),des,Boissons Énergisantes,,,X,X,,,g,X,X,<10,2
+Sucres totaux,Enfants 1 à 8 ans,357,des,Boissons (excluant laits),des,Boissons aux fruits,,,3.6,0.4,2.8,4.4,g,3.7,0.4,,2
+Sucres totaux,Enfants 1 à 8 ans,1159,des,Boissons (excluant laits),des,Jus de fruit,,,10.5,0.5,9.5,11.5,g,10.9,0.5,,2
+Sucres totaux,Enfants 1 à 8 ans,77,des,Boissons (excluant laits),des,Autres boissons,,,0.7,0.2,0.4,1,g,0.7,0.2,E,2
+Sucres totaux,Enfants 1 à 8 ans,142,des,Boissons (excluant laits),des,Boissons gazeuses,,,1.1,0.2,0.7,1.5,g,1.2,0.2,E,2
+Sucres totaux,Enfants 1 à 8 ans,21,des,Boissons (excluant laits),des,Boissons pour sportifs,,,0.1,0,0,0.1,g,0.1,0,,2
+Sucres totaux,Enfants 1 à 8 ans,52,des,Boissons (excluant laits),des,Jus de tomates et de légumes,,,0.1,0,0,0.1,g,0.1,0,,2
+Sucres totaux,Enfants 1 à 8 ans,,des,Boissons (excluant laits),de l',Eau vitaminée,,,X,X,,,g,X,X,<10,2
+Sucres totaux,Enfants 1 à 8 ans,2344,des,Boissons (excluant laits),de l',Eau,,,0,0,0,0,g,0,0,,2
+Sucres totaux,Enfants 1 à 8 ans,133,des,Boissons (excluant laits),du,Café et thé,du,Thé,0.5,0.1,0.2,0.8,g,0.5,0.1,E,3
+Sucres totaux,Enfants 1 à 8 ans,,des,Boissons (excluant laits),du,Café et thé,du,Café,X,X,,,g,X,X,<10,3
+Sucres totaux,Enfants 1 à 8 ans,2436,des,Produits laitiers et Boissons à base de plantes,,,,,24.1,0.6,22.9,25.4,g,25,0.6,,1
+Sucres totaux,Enfants 1 à 8 ans,1632,des,Produits laitiers et Boissons à base de plantes,des,Fromages,,,0.5,0,0.4,0.6,g,0.5,0,,2
+Sucres totaux,Enfants 1 à 8 ans,2341,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,18.5,0.5,17.5,19.6,g,19.1,0.5,,2
+Sucres totaux,Enfants 1 à 8 ans,1032,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,,,5.1,0.3,4.6,5.7,g,5.3,0.3,,2
+Sucres totaux,Enfants 1 à 8 ans,2242,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait nature,16,0.5,15,16.9,g,16.5,0.5,,3
+Sucres totaux,Enfants 1 à 8 ans,217,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait aromatisé,2,0.2,1.5,2.4,g,2,0.2,,3
+Sucres totaux,Enfants 1 à 8 ans,128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0.4,0.1,0.3,0.6,g,0.5,0.1,E,3
+Sucres totaux,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,F,F,,,g,F,F,F,3
+Sucres totaux,Enfants 1 à 8 ans,948,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,du,Yogourt aromatisé,5,0.3,4.4,5.5,g,5.1,0.3,,3
+Sucres totaux,Enfants 1 à 8 ans,109,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,du,Yogourt nature,0.2,0,0.1,0.2,g,0.2,0,,3
+Sucres totaux,Enfants 1 à 8 ans,2270,des,Graisses et huiles,,,,,0.1,0,0.1,0.2,g,0.1,0,,1
+Sucres totaux,Enfants 1 à 8 ans,83,des,Graisses et huiles,des,Graisses animales,,,0,0,0,0,g,0,0,,2
+Sucres totaux,Enfants 1 à 8 ans,657,des,Graisses et huiles,du,Beurre,,,0,0,0,0,g,0,0,,2
+Sucres totaux,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Margarines,,,0,0,0,0,g,0,0,,2
+Sucres totaux,Enfants 1 à 8 ans,463,des,Graisses et huiles,des,Sauces pour salade,,,0.1,0,0.1,0.2,g,0.1,0,,2
+Sucres totaux,Enfants 1 à 8 ans,1035,des,Graisses et huiles,du,Shortening,,,0,0,0,0,g,0,0,,2
+Sucres totaux,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Huiles végétales,,,0,0,0,0,g,0,0,,2
+Sucres totaux,Enfants 1 à 8 ans,298,des,Poissons et fruits de mer,,,,,0,0,0,0,g,0,0,,1
+Sucres totaux,Enfants 1 à 8 ans,257,des,Poissons et fruits de mer,des,Poissons,,,0,0,0,0,g,0,0,,2
+Sucres totaux,Enfants 1 à 8 ans,50,des,Poissons et fruits de mer,des,Mollusques et crustacés,,,0,0,0,0,g,0,0,,2
+Sucres totaux,Enfants 1 à 8 ans,2428,des,Fruits et légumes,,,,,22.7,0.7,21.3,24.1,g,23.5,0.7,,1
+Sucres totaux,Enfants 1 à 8 ans,2117,des,Fruits et légumes,des,Fruits,,,19.3,0.7,18,20.6,g,19.9,0.6,,2
+Sucres totaux,Enfants 1 à 8 ans,2235,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,3.4,0.1,3.2,3.7,g,3.5,0.1,,2
+Sucres totaux,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pommes,6.1,0.4,5.3,6.9,g,6.3,0.4,,3
+Sucres totaux,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Bananes,3.6,0.2,3.1,4,g,3.7,0.2,,3
+Sucres totaux,Enfants 1 à 8 ans,572,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,2.5,0.4,1.8,3.2,g,2.6,0.4,,3
+Sucres totaux,Enfants 1 à 8 ans,830,des,Fruits et légumes,des,Fruits,des,Baies,1.6,0.2,1.3,2,g,1.7,0.2,,3
+Sucres totaux,Enfants 1 à 8 ans,421,des,Fruits et légumes,des,Fruits,des,Agrumes,1.6,0.1,1.4,1.9,g,1.7,0.1,,3
+Sucres totaux,Enfants 1 à 8 ans,219,des,Fruits et légumes,des,Fruits,des,Melons,1.1,0.1,0.8,1.4,g,1.1,0.2,,3
+Sucres totaux,Enfants 1 à 8 ans,260,des,Fruits et légumes,des,Fruits,des,Autres fruits,0.9,0.1,0.6,1.1,g,0.9,0.1,,3
+Sucres totaux,Enfants 1 à 8 ans,133,des,Fruits et légumes,des,Fruits,des,Poires,0.7,0.1,0.4,0.9,g,0.7,0.1,,3
+Sucres totaux,Enfants 1 à 8 ans,118,des,Fruits et légumes,des,Fruits,des,Pêches et nectarines,0.6,0.1,0.4,0.7,g,0.6,0.1,E,3
+Sucres totaux,Enfants 1 à 8 ans,94,des,Fruits et légumes,des,Fruits,des,Ananas,0.3,0.1,0.2,0.4,g,0.3,0.1,E,3
+Sucres totaux,Enfants 1 à 8 ans,47,des,Fruits et légumes,des,Fruits,des,Cerises,F,F,,,g,F,F,F,3
+Sucres totaux,Enfants 1 à 8 ans,37,des,Fruits et légumes,des,Fruits,des,Prunes et pruneaux,F,F,,,g,F,F,F,3
+Sucres totaux,Enfants 1 à 8 ans,1773,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Autres légumes,2.1,0.1,1.9,2.4,g,2.2,0.1,,3
+Sucres totaux,Enfants 1 à 8 ans,875,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes jaune foncé ou orange,0.5,0,0.4,0.6,g,0.5,0,,3
+Sucres totaux,Enfants 1 à 8 ans,1068,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes vert foncé,0.4,0,0.3,0.4,g,0.4,0,,3
+Sucres totaux,Enfants 1 à 8 ans,1032,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes féculents,0.4,0,0.3,0.4,g,0.4,0,,3
+Sucres totaux,Enfants 1 à 8 ans,2475,des,Produits céréaliers,,,,,10.9,0.3,10.2,11.6,g,11.2,0.4,,1
+Sucres totaux,Enfants 1 à 8 ans,2114,des,Produits céréaliers,des,Pains,,,3.9,0.2,3.5,4.4,g,4.1,0.2,,2
+Sucres totaux,Enfants 1 à 8 ans,1282,des,Produits céréaliers,des,Céréales pour déjeuner,,,2.6,0.1,2.3,2.9,g,2.7,0.2,,2
+Sucres totaux,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,3.8,0.2,3.4,4.3,g,3.9,0.2,,2
+Sucres totaux,Enfants 1 à 8 ans,2037,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,0.5,0,0.4,0.6,g,0.5,0,,2
+Sucres totaux,Enfants 1 à 8 ans,951,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,1.8,0.2,1.5,2.1,g,1.8,0.2,,3
+Sucres totaux,Enfants 1 à 8 ans,805,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,1.2,0.1,0.9,1.4,g,1.2,0.1,,3
+Sucres totaux,Enfants 1 à 8 ans,813,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,0.6,0,0.5,0.7,g,0.6,0,,3
+Sucres totaux,Enfants 1 à 8 ans,745,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.4,0,0.3,0.4,g,0.4,0,,3
+Sucres totaux,Enfants 1 à 8 ans,670,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),1.9,0.1,1.6,2.1,g,2,0.1,,3
+Sucres totaux,Enfants 1 à 8 ans,728,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.7,0.1,0.6,0.9,g,0.8,0.1,,3
+Sucres totaux,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,1.1,0.1,0.9,1.3,g,1.1,0.1,,3
+Sucres totaux,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.2,g,0.1,0,,3
+Sucres totaux,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,F,F,,,g,F,F,F,3
+Sucres totaux,Enfants 1 à 8 ans,834,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.4,0,0.3,0.4,g,0.4,0,,3
+Sucres totaux,Enfants 1 à 8 ans,1461,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.1,0,0.1,0.1,g,0.1,0,,3
+Sucres totaux,Enfants 1 à 8 ans,654,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0,0,0,0,g,0,0,,3
+Sucres totaux,Enfants 1 à 8 ans,2072,de la,Viandes et volailles,,,,,0.2,0,0.2,0.3,g,0.2,0,,1
+Sucres totaux,Enfants 1 à 8 ans,1003,de la,Viandes et volailles,de la,Volaille,,,0,0,0,0,g,0,0,,2
+Sucres totaux,Enfants 1 à 8 ans,942,de la,Viandes et volailles,des,Viandes transformées,,,0.2,0,0.2,0.3,g,0.2,0,,2
+Sucres totaux,Enfants 1 à 8 ans,999,de la,Viandes et volailles,de la,Viande rouge,,,0,0,0,0,g,0,0,,2
+Sucres totaux,Enfants 1 à 8 ans,933,de la,Viandes et volailles,de la,Volaille,du,Poulet,0,0,0,0,g,0,0,,3
+Sucres totaux,Enfants 1 à 8 ans,86,de la,Viandes et volailles,de la,Volaille,de la,Dinde et autres volailles,0,0,0,0,g,0,0,,3
+Sucres totaux,Enfants 1 à 8 ans,513,de la,Viandes et volailles,des,Viandes transformées,des,Viandes froides,0.1,0,0.1,0.1,g,0.1,0,,3
+Sucres totaux,Enfants 1 à 8 ans,375,de la,Viandes et volailles,des,Viandes transformées,des,Saucisses,0.1,0,0.1,0.2,g,0.1,0,,3
+Sucres totaux,Enfants 1 à 8 ans,135,de la,Viandes et volailles,des,Viandes transformées,du,Bacon,0,0,0,0,g,0,0,,3
+Sucres totaux,Enfants 1 à 8 ans,106,de la,Viandes et volailles,des,Viandes transformées,du,Porc salé,0,0,0,0,g,0,0,,3
+Sucres totaux,Enfants 1 à 8 ans,779,de la,Viandes et volailles,de la,Viande rouge,du,Bœuf,0,0,0,0,g,0,0,,3
+Sucres totaux,Enfants 1 à 8 ans,43,de la,Viandes et volailles,de la,Viande rouge,de l',Agneau - veau et gibiers,0,0,0,0,g,0,0,,3
+Sucres totaux,Enfants 1 à 8 ans,284,de la,Viandes et volailles,de la,Viande rouge,du,Porc frais,0,0,0,0,g,0,0,,3
+Sucres totaux,Enfants 1 à 8 ans,,de la,Viandes et volailles,de la,Viande rouge,des,Abats - foies et pâtés,X,X,,,g,X,X,<10,3
+Sucres totaux,Enfants 1 à 8 ans,1789,des,Substituts de viande,,,,,0.6,0.1,0.5,0.7,g,0.7,0.1,E,1
+Sucres totaux,Enfants 1 à 8 ans,1450,des,Substituts de viande,des,Œufs,,,0.1,0,0.1,0.1,g,0.1,0,,2
+Sucres totaux,Enfants 1 à 8 ans,210,des,Substituts de viande,des,Légumineuses,,,0.1,0,0.1,0.1,g,0.1,0,,2
+Sucres totaux,Enfants 1 à 8 ans,749,des,Substituts de viande,des,Noix - graines et beurre d'arachides,,,0.4,0.1,0.3,0.5,g,0.4,0.1,E,2
+Sucres totaux,Enfants 1 à 8 ans,58,des,Substituts de viande,du,Tofu et produits sans viande,,,0,0,0,0,g,0,0,,2
+Sucres totaux,Enfants 1 à 8 ans,45,des,Boissons et barres nutritionnelles,,,,,0.3,0.1,0.1,0.4,g,0.3,0.1,E,1
+Sucres totaux,Enfants 1 à 8 ans,40,des,Boissons et barres nutritionnelles,des,Substituts de repas et boissons nutritionnelles,,,F,F,,,g,F,F,F,2
+Sucres totaux,Enfants 1 à 8 ans,,des,Boissons et barres nutritionnelles,des,Barres nutritionnelles,,,X,X,,,g,X,X,<10,2
+Sucres totaux,Enfants 1 à 8 ans,2295,des,Soupes - sauces - Épices et autres ingrédients,,,,,1,0.1,0.8,1.3,g,1.1,0.1,,1
+Sucres totaux,Enfants 1 à 8 ans,761,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.8,0.1,0.6,1,g,0.8,0.1,,2
+Sucres totaux,Enfants 1 à 8 ans,532,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0.2,0,0.1,0.3,g,0.2,0,,2
+Sucres totaux,Enfants 1 à 8 ans,2205,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.1,0,0.1,0.1,g,0.1,0,,2
+Sucres totaux,Enfants 1 à 8 ans,2106,des,Confiseries - sucres et grignotines salées,,,,,19.7,1,17.8,21.6,g,20.4,0.8,,1
+Sucres totaux,Enfants 1 à 8 ans,1048,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,4.6,0.3,4,5.3,g,4.8,0.3,,2
+Sucres totaux,Enfants 1 à 8 ans,497,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,5.2,0.5,4.2,6.3,g,5.4,0.5,,2
+Sucres totaux,Enfants 1 à 8 ans,615,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0.2,0,0.1,0.2,g,0.2,0,,2
+Sucres totaux,Enfants 1 à 8 ans,1642,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,9.7,0.6,8.4,11,g,10,0.6,,2
+Sucres totaux,Enfants 1 à 8 ans,557,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,2.1,0.2,1.7,2.5,g,2.2,0.2,,3
+Sucres totaux,Enfants 1 à 8 ans,548,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,1.8,0.2,1.4,2.1,g,1.8,0.2,,3
+Sucres totaux,Enfants 1 à 8 ans,131,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0.8,0.1,0.5,1,g,0.8,0.1,,3
+Sucres totaux,Enfants 1 à 8 ans,346,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,2.8,0.3,2.3,3.4,g,2.9,0.3,,3
+Sucres totaux,Enfants 1 à 8 ans,184,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,2.4,0.4,1.6,3.2,g,2.5,0.4,E,3
+Sucres totaux,Enfants 1 à 8 ans,720,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,4.5,0.4,3.7,5.3,g,4.6,0.4,,3
+Sucres totaux,Enfants 1 à 8 ans,1341,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,4.5,0.3,3.8,5.2,g,4.6,0.3,,3
+Sucres totaux,Enfants 1 à 8 ans,257,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.7,0.1,0.5,1,g,0.8,0.1,,3
+Sucres totaux,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,g,X,X,<10,3
 Vitamine D,Population 1 an et +,186,des,Aliments pour bébés,,,,,0,0,0,0,mcg,0,0,,1
 Vitamine D,Population 1 an et +,154,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0,mcg,0,0,,2
 Vitamine D,Population 1 an et +,51,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0,0,0,0,mcg,0,0,,2
@@ -5506,7 +5506,7 @@ Vitamine D,Population 1 an et +,8457,des,Fruits et légumes,des,Légumes incluan
 Vitamine D,Population 1 an et +,19327,des,Produits céréaliers,,,,,0.2,0,0.2,0.2,mcg,4.4,0.1,,1
 Vitamine D,Population 1 an et +,16168,des,Produits céréaliers,des,Pains,,,0.1,0,0.1,0.1,mcg,2.8,0.1,,2
 Vitamine D,Population 1 an et +,6966,des,Produits céréaliers,des,Céréales pour déjeuner,,,0.1,0,0.1,0.1,mcg,1.4,0.1,,2
-Vitamine D,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0,0,0,0,mcg,0,0,,2
 Vitamine D,Population 1 an et +,14820,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,0,0,0,0,mcg,0.1,0,,2
 Vitamine D,Population 1 an et +,5962,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,0.1,0,0.1,0.1,mcg,1.4,0,,3
 Vitamine D,Population 1 an et +,8159,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,0.1,0,0.1,0.1,mcg,1.3,0,,3
@@ -5514,10 +5514,10 @@ Vitamine D,Population 1 an et +,6257,des,Produits céréaliers,des,Pains,des,Aut
 Vitamine D,Population 1 an et +,2918,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0,0,0,0,mcg,0,0,,3
 Vitamine D,Population 1 an et +,2573,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.1,0,0.1,0.1,mcg,1.2,0.1,,3
 Vitamine D,Population 1 an et +,4760,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0,0,0,0,mcg,0.2,0,,3
-Vitamine D,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mcg,0,0,,3
-Vitamine D,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mcg,0,0,,3
-Vitamine D,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0,0,0,0,mcg,0,0,,3
-Vitamine D,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mcg,X,X,<10,3
+Vitamine D,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mcg,0,0,,3
+Vitamine D,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mcg,0,0,,3
+Vitamine D,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0,0,0,0,mcg,0,0,,3
+Vitamine D,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mcg,X,X,<10,3
 Vitamine D,Population 1 an et +,4543,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0,0,0,0,mcg,0.1,0,,3
 Vitamine D,Population 1 an et +,11102,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0,0,0,0,mcg,0,0,,3
 Vitamine D,Population 1 an et +,4598,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0,0,0,0,mcg,0,0,,3
@@ -5620,7 +5620,7 @@ Vitamine D,Hommes adultes 19 ans +,2838,des,Fruits et légumes,des,Légumes incl
 Vitamine D,Hommes adultes 19 ans +,6068,des,Produits céréaliers,,,,,0.2,0,0.2,0.2,mcg,4.3,0.2,,1
 Vitamine D,Hommes adultes 19 ans +,5104,des,Produits céréaliers,des,Pains,,,0.2,0,0.1,0.2,mcg,3,0.1,,2
 Vitamine D,Hommes adultes 19 ans +,1921,des,Produits céréaliers,des,Céréales pour déjeuner,,,0.1,0,0,0.1,mcg,1.1,0.1,,2
-Vitamine D,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0,0,0,0,mcg,0,0,,2
 Vitamine D,Hommes adultes 19 ans +,4551,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,0,0,0,0,mcg,0.1,0,,2
 Vitamine D,Hommes adultes 19 ans +,2752,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,0.1,0,0.1,0.1,mcg,1.5,0.1,,3
 Vitamine D,Hommes adultes 19 ans +,1980,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,0.1,0,0.1,0.1,mcg,1.5,0.1,,3
@@ -5628,9 +5628,9 @@ Vitamine D,Hommes adultes 19 ans +,593,des,Produits céréaliers,des,Pains,des,C
 Vitamine D,Hommes adultes 19 ans +,1885,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,0,0,0,0,mcg,0,0,,3
 Vitamine D,Hommes adultes 19 ans +,523,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0,0,0,0.1,mcg,0.8,0.1,,3
 Vitamine D,Hommes adultes 19 ans +,1481,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0,0,0,0,mcg,0.3,0,,3
-Vitamine D,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mcg,0,0,,3
-Vitamine D,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mcg,0,0,,3
-Vitamine D,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0,0,0,0,mcg,0,0,,3
+Vitamine D,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mcg,0,0,,3
+Vitamine D,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mcg,0,0,,3
+Vitamine D,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0,0,0,0,mcg,0,0,,3
 Vitamine D,Hommes adultes 19 ans +,1250,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0,0,0,0,mcg,0.1,0,,3
 Vitamine D,Hommes adultes 19 ans +,3442,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0,0,0,0,mcg,0,0,,3
 Vitamine D,Hommes adultes 19 ans +,1449,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0,0,0,0,mcg,0,0,,3
@@ -5733,7 +5733,7 @@ Vitamine D,Femmes adultes* 19 ans +,2959,des,Fruits et légumes,des,Légumes inc
 Vitamine D,Femmes adultes* 19 ans +,6669,des,Produits céréaliers,,,,,0.2,0,0.2,0.2,mcg,4.2,0.2,,1
 Vitamine D,Femmes adultes* 19 ans +,5520,des,Produits céréaliers,des,Pains,,,0.1,0,0.1,0.1,mcg,3,0.1,,2
 Vitamine D,Femmes adultes* 19 ans +,2230,des,Produits céréaliers,des,Céréales pour déjeuner,,,0,0,0,0.1,mcg,1.1,0.1,,2
-Vitamine D,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0,0,0,0,mcg,0,0,,2
 Vitamine D,Femmes adultes* 19 ans +,4893,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,0,0,0,0,mcg,0.1,0,,2
 Vitamine D,Femmes adultes* 19 ans +,2239,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,0.1,0,0.1,0.1,mcg,1.6,0.1,,3
 Vitamine D,Femmes adultes* 19 ans +,2551,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,0.1,0,0,0.1,mcg,1.3,0.1,,3
@@ -5741,10 +5741,10 @@ Vitamine D,Femmes adultes* 19 ans +,914,des,Produits céréaliers,des,Pains,des,
 Vitamine D,Femmes adultes* 19 ans +,1994,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,0,0,0,0,mcg,0,0,,3
 Vitamine D,Femmes adultes* 19 ans +,555,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0,0,0,0,mcg,0.9,0.1,,3
 Vitamine D,Femmes adultes* 19 ans +,1756,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0,0,0,0,mcg,0.2,0,,3
-Vitamine D,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mcg,0,0,,3
-Vitamine D,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mcg,0,0,,3
-Vitamine D,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0,0,0,0,mcg,0,0,,3
-Vitamine D,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mcg,X,X,<10,3
+Vitamine D,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mcg,0,0,,3
+Vitamine D,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mcg,0,0,,3
+Vitamine D,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0,0,0,0,mcg,0,0,,3
+Vitamine D,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mcg,X,X,<10,3
 Vitamine D,Femmes adultes* 19 ans +,1358,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0,0,0,0,mcg,0.1,0,,3
 Vitamine D,Femmes adultes* 19 ans +,3664,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0,0,0,0,mcg,0,0,,3
 Vitamine D,Femmes adultes* 19 ans +,1522,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0,0,0,0,mcg,0,0,,3
@@ -5788,119 +5788,119 @@ Vitamine D,Femmes adultes* 19 ans +,773,des,Confiseries - sucres et grignotines 
 Vitamine D,Femmes adultes* 19 ans +,1529,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0,0,0,0,mcg,0,0,,3
 Vitamine D,Femmes adultes* 19 ans +,360,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mcg,0,0,,3
 Vitamine D,Femmes adultes* 19 ans +,4229,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,122,des,Aliments pour bébés,,,,,0,0,0,0,mcg,0.2,0.1,,1
-Vitamine D,Enfants 1 à 8 ans,95,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0,0,0,0,mcg,0.2,0.1,,2
-Vitamine D,Enfants 1 à 8 ans,2443,des,Boissons (excluant laits),,,,,0.1,0,0,0.1,mcg,1.3,0.2,,1
-Vitamine D,Enfants 1 à 8 ans,20,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Enfants 1 à 8 ans,141,des,Boissons (excluant laits),du,Café et thé,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Enfants 1 à 8 ans,,des,Boissons (excluant laits),des,Boissons Énergisantes,,,X,X,,,mcg,X,X,<10,2
-Vitamine D,Enfants 1 à 8 ans,357,des,Boissons (excluant laits),des,Boissons aux fruits,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Enfants 1 à 8 ans,1159,des,Boissons (excluant laits),des,Jus de fruit,,,0.1,0,0,0.1,mcg,1.3,0.2,,2
-Vitamine D,Enfants 1 à 8 ans,77,des,Boissons (excluant laits),des,Autres boissons,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Enfants 1 à 8 ans,142,des,Boissons (excluant laits),des,Boissons gazeuses,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Enfants 1 à 8 ans,21,des,Boissons (excluant laits),des,Boissons pour sportifs,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Enfants 1 à 8 ans,52,des,Boissons (excluant laits),des,Jus de tomates et de légumes,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Enfants 1 à 8 ans,,des,Boissons (excluant laits),de l',Eau vitaminée,,,X,X,,,mcg,X,X,<10,2
-Vitamine D,Enfants 1 à 8 ans,2344,des,Boissons (excluant laits),de l',Eau,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Enfants 1 à 8 ans,133,des,Boissons (excluant laits),du,Café et thé,du,Thé,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,,des,Boissons (excluant laits),du,Café et thé,du,Café,X,X,,,mcg,X,X,<10,3
-Vitamine D,Enfants 1 à 8 ans,2436,des,Produits laitiers et Boissons à base de plantes,,,,,3.8,0.1,3.6,4,mcg,67.3,1.4,,1
-Vitamine D,Enfants 1 à 8 ans,1632,des,Produits laitiers et Boissons à base de plantes,des,Fromages,,,0.1,0,0.1,0.1,mcg,1.1,0.1,,2
-Vitamine D,Enfants 1 à 8 ans,2341,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,3.4,0.1,3.2,3.6,mcg,61.1,1.3,,2
-Vitamine D,Enfants 1 à 8 ans,1032,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,,,0.3,0,0.2,0.3,mcg,5,0.3,,2
-Vitamine D,Enfants 1 à 8 ans,1810,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,1.6,0.1,1.5,1.8,mcg,29,1.2,,3
-Vitamine D,Enfants 1 à 8 ans,1078,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,1,0.1,0.9,1.2,mcg,18.6,1.1,,3
-Vitamine D,Enfants 1 à 8 ans,854,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,0.6,0.1,0.4,0.7,mcg,10.2,1.1,E,3
-Vitamine D,Enfants 1 à 8 ans,739,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0.1,0,0.1,0.1,mcg,1.6,0.3,,3
-Vitamine D,Enfants 1 à 8 ans,128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0.1,0,0,0.1,mcg,1.3,0.2,,3
-Vitamine D,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0,0,0,0,mcg,0.3,0.1,,3
-Vitamine D,Enfants 1 à 8 ans,2270,des,Graisses et huiles,,,,,0.7,0,0.6,0.7,mcg,11.7,0.6,,1
-Vitamine D,Enfants 1 à 8 ans,83,des,Graisses et huiles,des,Graisses animales,,,0,0,0,0,mcg,0.1,0,,2
-Vitamine D,Enfants 1 à 8 ans,657,des,Graisses et huiles,du,Beurre,,,0,0,0,0,mcg,0.2,0,,2
-Vitamine D,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Margarines,,,0.6,0,0.6,0.7,mcg,11.3,0.6,,2
-Vitamine D,Enfants 1 à 8 ans,463,des,Graisses et huiles,des,Sauces pour salade,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Enfants 1 à 8 ans,1035,des,Graisses et huiles,du,Shortening,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Huiles végétales,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Enfants 1 à 8 ans,298,des,Poissons et fruits de mer,,,,,0.4,0.1,0.2,0.5,mcg,6.9,1.3,E,1
-Vitamine D,Enfants 1 à 8 ans,257,des,Poissons et fruits de mer,des,Poissons,,,0.4,0.1,0.2,0.5,mcg,6.9,1.3,E,2
-Vitamine D,Enfants 1 à 8 ans,50,des,Poissons et fruits de mer,des,Mollusques et crustacés,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Enfants 1 à 8 ans,2428,des,Fruits et légumes,,,,,0,0,0,0,mcg,0.1,0,,1
-Vitamine D,Enfants 1 à 8 ans,2117,des,Fruits et légumes,des,Fruits,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Enfants 1 à 8 ans,2235,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,0,0,0,0,mcg,0.1,0,,2
-Vitamine D,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pommes,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Bananes,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,830,des,Fruits et légumes,des,Fruits,des,Baies,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,47,des,Fruits et légumes,des,Fruits,des,Cerises,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,421,des,Fruits et légumes,des,Fruits,des,Agrumes,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,572,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,219,des,Fruits et légumes,des,Fruits,des,Melons,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,260,des,Fruits et légumes,des,Fruits,des,Autres fruits,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,118,des,Fruits et légumes,des,Fruits,des,Pêches et nectarines,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,133,des,Fruits et légumes,des,Fruits,des,Poires,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,94,des,Fruits et légumes,des,Fruits,des,Ananas,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,37,des,Fruits et légumes,des,Fruits,des,Prunes et pruneaux,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,1773,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Autres légumes,0,0,0,0,mcg,0.1,0,,3
-Vitamine D,Enfants 1 à 8 ans,1068,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes vert foncé,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,875,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes jaune foncé ou orange,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,1032,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes féculents,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,2475,des,Produits céréaliers,,,,,0.2,0,0.2,0.3,mcg,4.4,0.2,,1
-Vitamine D,Enfants 1 à 8 ans,2114,des,Produits céréaliers,des,Pains,,,0.1,0,0.1,0.1,mcg,2,0.1,,2
-Vitamine D,Enfants 1 à 8 ans,1282,des,Produits céréaliers,des,Céréales pour déjeuner,,,0.1,0,0.1,0.1,mcg,2.3,0.2,,2
-Vitamine D,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Enfants 1 à 8 ans,2037,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,0,0,0,0,mcg,0.1,0,,2
-Vitamine D,Enfants 1 à 8 ans,951,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,0.1,0,0,0.1,mcg,1,0.1,,3
-Vitamine D,Enfants 1 à 8 ans,813,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,0,0,0,0.1,mcg,0.9,0.1,,3
-Vitamine D,Enfants 1 à 8 ans,805,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,0,0,0,0,mcg,0.2,0,,3
-Vitamine D,Enfants 1 à 8 ans,745,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,670,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.1,0,0.1,0.1,mcg,2.2,0.2,,3
-Vitamine D,Enfants 1 à 8 ans,728,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0,0,0,0,mcg,0.1,0,,3
-Vitamine D,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,834,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0,0,0,0,mcg,0.1,0,,3
-Vitamine D,Enfants 1 à 8 ans,1461,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,654,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,2072,de la,Viandes et volailles,,,,,0.1,0,0.1,0.1,mcg,2.2,0.2,,1
-Vitamine D,Enfants 1 à 8 ans,1003,de la,Viandes et volailles,de la,Volaille,,,0,0,0,0,mcg,0.4,0,,2
-Vitamine D,Enfants 1 à 8 ans,942,de la,Viandes et volailles,des,Viandes transformées,,,0.1,0,0,0.1,mcg,0.9,0.1,,2
-Vitamine D,Enfants 1 à 8 ans,999,de la,Viandes et volailles,de la,Viande rouge,,,0.1,0,0,0.1,mcg,0.9,0.1,,2
-Vitamine D,Enfants 1 à 8 ans,933,de la,Viandes et volailles,de la,Volaille,du,Poulet,0,0,0,0,mcg,0.4,0,,3
-Vitamine D,Enfants 1 à 8 ans,86,de la,Viandes et volailles,de la,Volaille,de la,Dinde et autres volailles,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,375,de la,Viandes et volailles,des,Viandes transformées,des,Saucisses,0,0,0,0,mcg,0.4,0.1,,3
-Vitamine D,Enfants 1 à 8 ans,106,de la,Viandes et volailles,des,Viandes transformées,du,Porc salé,0,0,0,0,mcg,0.2,0.1,,3
-Vitamine D,Enfants 1 à 8 ans,513,de la,Viandes et volailles,des,Viandes transformées,des,Viandes froides,0,0,0,0,mcg,0.2,0,,3
-Vitamine D,Enfants 1 à 8 ans,135,de la,Viandes et volailles,des,Viandes transformées,du,Bacon,0,0,0,0,mcg,0.1,0,,3
-Vitamine D,Enfants 1 à 8 ans,284,de la,Viandes et volailles,de la,Viande rouge,du,Porc frais,0,0,0,0,mcg,0.6,0.1,,3
-Vitamine D,Enfants 1 à 8 ans,779,de la,Viandes et volailles,de la,Viande rouge,du,Bœuf,0,0,0,0,mcg,0.2,0,,3
-Vitamine D,Enfants 1 à 8 ans,43,de la,Viandes et volailles,de la,Viande rouge,de l',Agneau - veau et gibiers,0,0,0,0,mcg,0.1,0,,3
-Vitamine D,Enfants 1 à 8 ans,,de la,Viandes et volailles,de la,Viande rouge,des,Abats - foies et pâtés,X,X,,,mcg,X,X,<10,3
-Vitamine D,Enfants 1 à 8 ans,1789,des,Substituts de viande,,,,,0.2,0,0.2,0.2,mcg,3.7,0.2,,1
-Vitamine D,Enfants 1 à 8 ans,1450,des,Substituts de viande,des,Œufs,,,0.2,0,0.2,0.2,mcg,3.7,0.2,,2
-Vitamine D,Enfants 1 à 8 ans,210,des,Substituts de viande,des,Légumineuses,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Enfants 1 à 8 ans,749,des,Substituts de viande,des,Noix - graines et beurre d'arachides,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Enfants 1 à 8 ans,58,des,Substituts de viande,du,Tofu et produits sans viande,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Enfants 1 à 8 ans,45,des,Boissons et barres nutritionnelles,,,,,0,0,0,0,mcg,0.4,0.2,,1
-Vitamine D,Enfants 1 à 8 ans,40,des,Boissons et barres nutritionnelles,des,Substituts de repas et boissons nutritionnelles,,,0,0,0,0,mcg,0.4,0.2,,2
-Vitamine D,Enfants 1 à 8 ans,,des,Boissons et barres nutritionnelles,des,Barres nutritionnelles,,,X,X,,,mcg,X,X,<10,2
-Vitamine D,Enfants 1 à 8 ans,2295,des,Soupes - sauces - Épices et autres ingrédients,,,,,0,0,0,0.1,mcg,0.6,0.2,,1
-Vitamine D,Enfants 1 à 8 ans,761,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0,0,0,0,mcg,0.5,0.2,,2
-Vitamine D,Enfants 1 à 8 ans,532,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0,0,0,0,mcg,0.1,0,,2
-Vitamine D,Enfants 1 à 8 ans,2205,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Enfants 1 à 8 ans,2106,des,Confiseries - sucres et grignotines salées,,,,,0.1,0,0,0.1,mcg,1.2,0.5,,1
-Vitamine D,Enfants 1 à 8 ans,1048,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Enfants 1 à 8 ans,497,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,0,0,0,0,mcg,0.4,0,,2
-Vitamine D,Enfants 1 à 8 ans,615,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Enfants 1 à 8 ans,1642,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0,0,0,0.1,mcg,0.7,0.5,,2
-Vitamine D,Enfants 1 à 8 ans,557,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,548,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,131,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,346,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0,0,0,0,mcg,0.4,0,,3
-Vitamine D,Enfants 1 à 8 ans,184,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,720,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0,0,0,0.1,mcg,0.7,0.5,,3
-Vitamine D,Enfants 1 à 8 ans,257,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,1341,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,mcg,X,X,<10,3
+Vitamine D,Enfants 1 à 8 ans,122,des,Aliments pour bébés,,,,,0,0,0,0,mcg,0.2,0.1,,1
+Vitamine D,Enfants 1 à 8 ans,95,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0,0,0,0,mcg,0.2,0.1,,2
+Vitamine D,Enfants 1 à 8 ans,2443,des,Boissons (excluant laits),,,,,0.1,0,0,0.1,mcg,1.3,0.2,,1
+Vitamine D,Enfants 1 à 8 ans,20,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Enfants 1 à 8 ans,141,des,Boissons (excluant laits),du,Café et thé,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Enfants 1 à 8 ans,,des,Boissons (excluant laits),des,Boissons Énergisantes,,,X,X,,,mcg,X,X,<10,2
+Vitamine D,Enfants 1 à 8 ans,357,des,Boissons (excluant laits),des,Boissons aux fruits,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Enfants 1 à 8 ans,1159,des,Boissons (excluant laits),des,Jus de fruit,,,0.1,0,0,0.1,mcg,1.3,0.2,,2
+Vitamine D,Enfants 1 à 8 ans,77,des,Boissons (excluant laits),des,Autres boissons,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Enfants 1 à 8 ans,142,des,Boissons (excluant laits),des,Boissons gazeuses,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Enfants 1 à 8 ans,21,des,Boissons (excluant laits),des,Boissons pour sportifs,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Enfants 1 à 8 ans,52,des,Boissons (excluant laits),des,Jus de tomates et de légumes,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Enfants 1 à 8 ans,,des,Boissons (excluant laits),de l',Eau vitaminée,,,X,X,,,mcg,X,X,<10,2
+Vitamine D,Enfants 1 à 8 ans,2344,des,Boissons (excluant laits),de l',Eau,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Enfants 1 à 8 ans,133,des,Boissons (excluant laits),du,Café et thé,du,Thé,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,,des,Boissons (excluant laits),du,Café et thé,du,Café,X,X,,,mcg,X,X,<10,3
+Vitamine D,Enfants 1 à 8 ans,2436,des,Produits laitiers et Boissons à base de plantes,,,,,3.8,0.1,3.6,4,mcg,67.3,1.4,,1
+Vitamine D,Enfants 1 à 8 ans,1632,des,Produits laitiers et Boissons à base de plantes,des,Fromages,,,0.1,0,0.1,0.1,mcg,1.1,0.1,,2
+Vitamine D,Enfants 1 à 8 ans,2341,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,3.4,0.1,3.2,3.6,mcg,61.1,1.3,,2
+Vitamine D,Enfants 1 à 8 ans,1032,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,,,0.3,0,0.2,0.3,mcg,5,0.3,,2
+Vitamine D,Enfants 1 à 8 ans,1810,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,1.6,0.1,1.5,1.8,mcg,29,1.2,,3
+Vitamine D,Enfants 1 à 8 ans,1078,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,1,0.1,0.9,1.2,mcg,18.6,1.1,,3
+Vitamine D,Enfants 1 à 8 ans,854,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,0.6,0.1,0.4,0.7,mcg,10.2,1.1,E,3
+Vitamine D,Enfants 1 à 8 ans,739,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0.1,0,0.1,0.1,mcg,1.6,0.3,,3
+Vitamine D,Enfants 1 à 8 ans,128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0.1,0,0,0.1,mcg,1.3,0.2,,3
+Vitamine D,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0,0,0,0,mcg,0.3,0.1,,3
+Vitamine D,Enfants 1 à 8 ans,2270,des,Graisses et huiles,,,,,0.7,0,0.6,0.7,mcg,11.7,0.6,,1
+Vitamine D,Enfants 1 à 8 ans,83,des,Graisses et huiles,des,Graisses animales,,,0,0,0,0,mcg,0.1,0,,2
+Vitamine D,Enfants 1 à 8 ans,657,des,Graisses et huiles,du,Beurre,,,0,0,0,0,mcg,0.2,0,,2
+Vitamine D,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Margarines,,,0.6,0,0.6,0.7,mcg,11.3,0.6,,2
+Vitamine D,Enfants 1 à 8 ans,463,des,Graisses et huiles,des,Sauces pour salade,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Enfants 1 à 8 ans,1035,des,Graisses et huiles,du,Shortening,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Enfants 1 à 8 ans,1330,des,Graisses et huiles,des,Huiles végétales,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Enfants 1 à 8 ans,298,des,Poissons et fruits de mer,,,,,0.4,0.1,0.2,0.5,mcg,6.9,1.3,E,1
+Vitamine D,Enfants 1 à 8 ans,257,des,Poissons et fruits de mer,des,Poissons,,,0.4,0.1,0.2,0.5,mcg,6.9,1.3,E,2
+Vitamine D,Enfants 1 à 8 ans,50,des,Poissons et fruits de mer,des,Mollusques et crustacés,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Enfants 1 à 8 ans,2428,des,Fruits et légumes,,,,,0,0,0,0,mcg,0.1,0,,1
+Vitamine D,Enfants 1 à 8 ans,2117,des,Fruits et légumes,des,Fruits,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Enfants 1 à 8 ans,2235,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,0,0,0,0,mcg,0.1,0,,2
+Vitamine D,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pommes,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Bananes,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,830,des,Fruits et légumes,des,Fruits,des,Baies,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,47,des,Fruits et légumes,des,Fruits,des,Cerises,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,421,des,Fruits et légumes,des,Fruits,des,Agrumes,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,572,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,219,des,Fruits et légumes,des,Fruits,des,Melons,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,260,des,Fruits et légumes,des,Fruits,des,Autres fruits,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,118,des,Fruits et légumes,des,Fruits,des,Pêches et nectarines,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,133,des,Fruits et légumes,des,Fruits,des,Poires,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,94,des,Fruits et légumes,des,Fruits,des,Ananas,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,37,des,Fruits et légumes,des,Fruits,des,Prunes et pruneaux,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,1773,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Autres légumes,0,0,0,0,mcg,0.1,0,,3
+Vitamine D,Enfants 1 à 8 ans,1068,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes vert foncé,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,875,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes jaune foncé ou orange,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,1032,des,Fruits et légumes,des,Légumes incluant pommes de terre,des,Légumes féculents,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,2475,des,Produits céréaliers,,,,,0.2,0,0.2,0.3,mcg,4.4,0.2,,1
+Vitamine D,Enfants 1 à 8 ans,2114,des,Produits céréaliers,des,Pains,,,0.1,0,0.1,0.1,mcg,2,0.1,,2
+Vitamine D,Enfants 1 à 8 ans,1282,des,Produits céréaliers,des,Céréales pour déjeuner,,,0.1,0,0.1,0.1,mcg,2.3,0.2,,2
+Vitamine D,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Enfants 1 à 8 ans,2037,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,0,0,0,0,mcg,0.1,0,,2
+Vitamine D,Enfants 1 à 8 ans,951,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,0.1,0,0,0.1,mcg,1,0.1,,3
+Vitamine D,Enfants 1 à 8 ans,813,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,0,0,0,0.1,mcg,0.9,0.1,,3
+Vitamine D,Enfants 1 à 8 ans,805,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,0,0,0,0,mcg,0.2,0,,3
+Vitamine D,Enfants 1 à 8 ans,745,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,670,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.1,0,0.1,0.1,mcg,2.2,0.2,,3
+Vitamine D,Enfants 1 à 8 ans,728,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0,0,0,0,mcg,0.1,0,,3
+Vitamine D,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,834,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0,0,0,0,mcg,0.1,0,,3
+Vitamine D,Enfants 1 à 8 ans,1461,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,654,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,2072,de la,Viandes et volailles,,,,,0.1,0,0.1,0.1,mcg,2.2,0.2,,1
+Vitamine D,Enfants 1 à 8 ans,1003,de la,Viandes et volailles,de la,Volaille,,,0,0,0,0,mcg,0.4,0,,2
+Vitamine D,Enfants 1 à 8 ans,942,de la,Viandes et volailles,des,Viandes transformées,,,0.1,0,0,0.1,mcg,0.9,0.1,,2
+Vitamine D,Enfants 1 à 8 ans,999,de la,Viandes et volailles,de la,Viande rouge,,,0.1,0,0,0.1,mcg,0.9,0.1,,2
+Vitamine D,Enfants 1 à 8 ans,933,de la,Viandes et volailles,de la,Volaille,du,Poulet,0,0,0,0,mcg,0.4,0,,3
+Vitamine D,Enfants 1 à 8 ans,86,de la,Viandes et volailles,de la,Volaille,de la,Dinde et autres volailles,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,375,de la,Viandes et volailles,des,Viandes transformées,des,Saucisses,0,0,0,0,mcg,0.4,0.1,,3
+Vitamine D,Enfants 1 à 8 ans,106,de la,Viandes et volailles,des,Viandes transformées,du,Porc salé,0,0,0,0,mcg,0.2,0.1,,3
+Vitamine D,Enfants 1 à 8 ans,513,de la,Viandes et volailles,des,Viandes transformées,des,Viandes froides,0,0,0,0,mcg,0.2,0,,3
+Vitamine D,Enfants 1 à 8 ans,135,de la,Viandes et volailles,des,Viandes transformées,du,Bacon,0,0,0,0,mcg,0.1,0,,3
+Vitamine D,Enfants 1 à 8 ans,284,de la,Viandes et volailles,de la,Viande rouge,du,Porc frais,0,0,0,0,mcg,0.6,0.1,,3
+Vitamine D,Enfants 1 à 8 ans,779,de la,Viandes et volailles,de la,Viande rouge,du,Bœuf,0,0,0,0,mcg,0.2,0,,3
+Vitamine D,Enfants 1 à 8 ans,43,de la,Viandes et volailles,de la,Viande rouge,de l',Agneau - veau et gibiers,0,0,0,0,mcg,0.1,0,,3
+Vitamine D,Enfants 1 à 8 ans,,de la,Viandes et volailles,de la,Viande rouge,des,Abats - foies et pâtés,X,X,,,mcg,X,X,<10,3
+Vitamine D,Enfants 1 à 8 ans,1789,des,Substituts de viande,,,,,0.2,0,0.2,0.2,mcg,3.7,0.2,,1
+Vitamine D,Enfants 1 à 8 ans,1450,des,Substituts de viande,des,Œufs,,,0.2,0,0.2,0.2,mcg,3.7,0.2,,2
+Vitamine D,Enfants 1 à 8 ans,210,des,Substituts de viande,des,Légumineuses,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Enfants 1 à 8 ans,749,des,Substituts de viande,des,Noix - graines et beurre d'arachides,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Enfants 1 à 8 ans,58,des,Substituts de viande,du,Tofu et produits sans viande,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Enfants 1 à 8 ans,45,des,Boissons et barres nutritionnelles,,,,,0,0,0,0,mcg,0.4,0.2,,1
+Vitamine D,Enfants 1 à 8 ans,40,des,Boissons et barres nutritionnelles,des,Substituts de repas et boissons nutritionnelles,,,0,0,0,0,mcg,0.4,0.2,,2
+Vitamine D,Enfants 1 à 8 ans,,des,Boissons et barres nutritionnelles,des,Barres nutritionnelles,,,X,X,,,mcg,X,X,<10,2
+Vitamine D,Enfants 1 à 8 ans,2295,des,Soupes - sauces - Épices et autres ingrédients,,,,,0,0,0,0.1,mcg,0.6,0.2,,1
+Vitamine D,Enfants 1 à 8 ans,761,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0,0,0,0,mcg,0.5,0.2,,2
+Vitamine D,Enfants 1 à 8 ans,532,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0,0,0,0,mcg,0.1,0,,2
+Vitamine D,Enfants 1 à 8 ans,2205,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Enfants 1 à 8 ans,2106,des,Confiseries - sucres et grignotines salées,,,,,0.1,0,0,0.1,mcg,1.2,0.5,,1
+Vitamine D,Enfants 1 à 8 ans,1048,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Enfants 1 à 8 ans,497,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,0,0,0,0,mcg,0.4,0,,2
+Vitamine D,Enfants 1 à 8 ans,615,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Enfants 1 à 8 ans,1642,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0,0,0,0.1,mcg,0.7,0.5,,2
+Vitamine D,Enfants 1 à 8 ans,557,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,548,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,131,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,346,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0,0,0,0,mcg,0.4,0,,3
+Vitamine D,Enfants 1 à 8 ans,184,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,720,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0,0,0,0.1,mcg,0.7,0.5,,3
+Vitamine D,Enfants 1 à 8 ans,257,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,1341,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,mcg,X,X,<10,3
 Énergie,Jeunes et adolescents* 9 à 18 ans  ,19,des,Aliments pour bébés,,,,,0.6,0.2,0.2,1,kcal,0,0,E,1
 Énergie,Jeunes et adolescents* 9 à 18 ans  ,17,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,F,F,,,kcal,F,F,F,2
 Énergie,Jeunes et adolescents* 9 à 18 ans  ,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,kcal,X,X,<10,2
@@ -5966,11 +5966,11 @@ Vitamine D,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,
 Énergie,Jeunes et adolescents* 9 à 18 ans  ,1416,des,Produits céréaliers,des,Céréales pour déjeuner,,,62.6,3.1,56.5,68.7,kcal,3.1,0.1,,2
 Énergie,Jeunes et adolescents* 9 à 18 ans  ,794,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),31.1,2.3,26.5,35.7,kcal,1.5,0.1,,3
 Énergie,Jeunes et adolescents* 9 à 18 ans  ,700,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,31.5,2.1,27.4,35.6,kcal,1.5,0.1,,3
-Énergie,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,65.9,3.3,59.4,72.4,kcal,3.2,0.2,,2
-Énergie,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,2.7,0.6,1.6,3.9,kcal,0.1,0,E,3
-Énergie,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,1.9,0.5,1,2.9,kcal,0.1,0,E,3
-Énergie,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,26.4,2.3,21.9,30.8,kcal,1.3,0.1,,3
-Énergie,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,kcal,X,X,<10,3
+Énergie,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,65.9,3.3,59.4,72.4,kcal,3.2,0.2,,2
+Énergie,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,2.7,0.6,1.6,3.9,kcal,0.1,0,E,3
+Énergie,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,1.9,0.5,1,2.9,kcal,0.1,0,E,3
+Énergie,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,26.4,2.3,21.9,30.8,kcal,1.3,0.1,,3
+Énergie,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,kcal,X,X,<10,3
 Énergie,Jeunes et adolescents* 9 à 18 ans  ,3103,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,233.2,6.1,221.3,245.1,kcal,11.4,0.3,,2
 Énergie,Jeunes et adolescents* 9 à 18 ans  ,2364,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,106.4,4.9,96.9,116,kcal,5.2,0.2,,3
 Énergie,Jeunes et adolescents* 9 à 18 ans  ,1020,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,69,4.2,60.7,77.3,kcal,3.4,0.2,,3
@@ -6080,11 +6080,11 @@ Glucides,Jeunes et adolescents* 9 à 18 ans  ,828,des,Produits céréaliers,des,
 Glucides,Jeunes et adolescents* 9 à 18 ans  ,1416,des,Produits céréaliers,des,Céréales pour déjeuner,,,12.7,0.6,11.5,13.9,g,4.7,0.2,,2
 Glucides,Jeunes et adolescents* 9 à 18 ans  ,794,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),6.7,0.5,5.7,7.6,g,2.5,0.2,,3
 Glucides,Jeunes et adolescents* 9 à 18 ans  ,700,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,6,0.4,5.3,6.8,g,2.3,0.1,,3
-Glucides,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,10.3,0.5,9.3,11.4,g,3.8,0.2,,2
-Glucides,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.4,0.1,0.2,0.6,g,0.2,0,E,3
-Glucides,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.3,0.1,0.2,0.5,g,0.1,0,E,3
-Glucides,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,4.4,0.4,3.7,5.2,g,1.6,0.1,,3
-Glucides,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
+Glucides,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,10.3,0.5,9.3,11.4,g,3.8,0.2,,2
+Glucides,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.4,0.1,0.2,0.6,g,0.2,0,E,3
+Glucides,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.3,0.1,0.2,0.5,g,0.1,0,E,3
+Glucides,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,4.4,0.4,3.7,5.2,g,1.6,0.1,,3
+Glucides,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
 Glucides,Jeunes et adolescents* 9 à 18 ans  ,3103,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,46.2,1.2,43.8,48.5,g,17.2,0.4,,2
 Glucides,Jeunes et adolescents* 9 à 18 ans  ,2364,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,20.9,1,19,22.8,g,7.8,0.3,,3
 Glucides,Jeunes et adolescents* 9 à 18 ans  ,1020,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,12.8,0.8,11.2,14.3,g,4.8,0.3,,3
@@ -6194,11 +6194,11 @@ Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,828,des,Produits céré
 Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,1416,des,Produits céréaliers,des,Céréales pour déjeuner,,,1.2,0.1,1.1,1.4,g,7.5,0.4,,2
 Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,794,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.4,0,0.4,0.5,g,2.6,0.2,,3
 Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,700,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.8,0.1,0.7,0.9,g,4.9,0.3,,3
-Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.5,0,0.5,0.6,g,3.3,0.2,,2
-Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0.1,0,,3
-Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.3,0,0.3,0.4,g,2.1,0.2,,3
-Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
+Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.5,0,0.5,0.6,g,3.3,0.2,,2
+Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0.1,0,,3
+Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.3,0,0.3,0.4,g,2.1,0.2,,3
+Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
 Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,3103,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,1.8,0.1,1.7,1.9,g,10.8,0.3,,2
 Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,2364,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.9,0,0.8,1,g,5.4,0.3,,3
 Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,1020,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.6,0,0.5,0.7,g,3.8,0.3,,3
@@ -6308,11 +6308,11 @@ Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,828,des,Produits céréaliers
 Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,1416,des,Produits céréaliers,des,Céréales pour déjeuner,,,3.4,0.2,3,3.8,g,2.9,0.2,,2
 Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,794,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),2.3,0.2,1.9,2.7,g,2,0.2,,3
 Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,700,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,1.1,0.1,0.9,1.3,g,0.9,0.1,,3
-Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,4.6,0.2,4.1,5.1,g,4,0.2,,2
-Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,F,F,,,g,F,F,F,3
-Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0.1,0.2,g,0.1,0,,3
-Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,2,0.2,1.6,2.3,g,1.7,0.1,,3
-Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
+Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,4.6,0.2,4.1,5.1,g,4,0.2,,2
+Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,F,F,,,g,F,F,F,3
+Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0.1,0.2,g,0.1,0,,3
+Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,2,0.2,1.6,2.3,g,1.7,0.1,,3
+Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
 Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,3103,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,0.6,0,0.6,0.7,g,0.5,0,,2
 Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,2364,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.2,0,0.2,0.2,g,0.2,0,,3
 Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,1020,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.4,0,0.3,0.5,g,0.3,0,,3
@@ -6422,11 +6422,11 @@ Protéine,Jeunes et adolescents* 9 à 18 ans  ,828,des,Produits céréaliers,des
 Protéine,Jeunes et adolescents* 9 à 18 ans  ,1416,des,Produits céréaliers,des,Céréales pour déjeuner,,,1.4,0.1,1.3,1.6,g,1.8,0.1,,2
 Protéine,Jeunes et adolescents* 9 à 18 ans  ,794,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.5,0,0.5,0.6,g,0.7,0.1,,3
 Protéine,Jeunes et adolescents* 9 à 18 ans  ,700,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.9,0.1,0.8,1,g,1.1,0.1,,3
-Protéine,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.8,0,0.8,0.9,g,1.1,0.1,,2
-Protéine,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0,0,,3
-Protéine,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
-Protéine,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.4,0,0.3,0.4,g,0.5,0,,3
-Protéine,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
+Protéine,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.8,0,0.8,0.9,g,1.1,0.1,,2
+Protéine,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0,0,,3
+Protéine,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
+Protéine,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.4,0,0.3,0.4,g,0.5,0,,3
+Protéine,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
 Protéine,Jeunes et adolescents* 9 à 18 ans  ,3103,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,7.2,0.2,6.8,7.6,g,9.1,0.2,,2
 Protéine,Jeunes et adolescents* 9 à 18 ans  ,2364,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,3.5,0.2,3.2,3.8,g,4.4,0.2,,3
 Protéine,Jeunes et adolescents* 9 à 18 ans  ,1020,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,2.5,0.2,2.2,2.8,g,3.1,0.2,,3
@@ -6536,11 +6536,11 @@ Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,828,des,Produits céréalier
 Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,1416,des,Produits céréaliers,des,Céréales pour déjeuner,,,0.8,0,0.7,0.9,g,1.1,0.1,,2
 Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,794,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.3,0,0.2,0.3,g,0.4,0,,3
 Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,700,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.5,0,0.4,0.6,g,0.7,0.1,,3
-Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,2.7,0.1,2.4,2.9,g,3.6,0.2,,2
-Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0.1,0.2,g,0.1,0,,3
-Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.1,g,0.1,0,,3
-Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,1,0.1,0.8,1.2,g,1.4,0.1,,3
-Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
+Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,2.7,0.1,2.4,2.9,g,3.6,0.2,,2
+Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0.1,0.2,g,0.1,0,,3
+Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.1,g,0.1,0,,3
+Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,1,0.1,0.8,1.2,g,1.4,0.1,,3
+Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
 Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,3103,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,1.7,0.1,1.6,1.8,g,2.3,0.1,,2
 Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,2364,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.7,0,0.7,0.8,g,1,0,,3
 Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,1020,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.8,0.1,0.7,0.9,g,1.1,0.1,,3
@@ -6650,11 +6650,11 @@ Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,828,des,Produits cér�
 Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,1416,des,Produits céréaliers,des,Céréales pour déjeuner,,,0.2,0,0.2,0.3,g,0.9,0.1,,2
 Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,794,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.1,0,0.1,0.1,g,0.2,0,,3
 Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,700,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.2,0,0.1,0.2,g,0.7,0.1,,3
-Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.8,0,0.7,0.9,g,3.1,0.2,,2
-Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0.1,0,,3
-Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0.1,0,,3
-Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.3,0,0.2,0.3,g,1,0.1,,3
-Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
+Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.8,0,0.7,0.9,g,3.1,0.2,,2
+Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0.1,0,,3
+Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0.1,0,,3
+Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.3,0,0.2,0.3,g,1,0.1,,3
+Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
 Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,3103,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,0.3,0,0.3,0.3,g,1.1,0,,2
 Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,2364,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.1,0,0.1,0.1,g,0.4,0,,3
 Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,1020,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.1,0,0.1,0.2,g,0.5,0,,3
@@ -6764,11 +6764,11 @@ Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,828,des,Produits céréaliers,de
 Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,1416,des,Produits céréaliers,des,Céréales pour déjeuner,,,0.2,0,0.1,0.2,mcg,2.7,0.3,,2
 Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,794,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.1,0,0.1,0.2,mcg,2.5,0.3,,3
 Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,700,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0,0,0,0,mcg,0.2,0,,3
-Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mcg,0,0,,3
-Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mcg,0,0,,3
-Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0,0,0,0,mcg,0,0,,3
-Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mcg,X,X,<10,3
+Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mcg,0,0,,3
+Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mcg,0,0,,3
+Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0,0,0,0,mcg,0,0,,3
+Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mcg,X,X,<10,3
 Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,3103,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,0,0,0,0,mcg,0.1,0,,2
 Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,2364,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0,0,0,0,mcg,0,0,,3
 Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,1020,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0,0,0,0,mcg,0.1,0,,3
@@ -6878,11 +6878,11 @@ Folate,Jeunes et adolescents* 9 à 18 ans  ,828,des,Produits céréaliers,des,Pa
 Folate,Jeunes et adolescents* 9 à 18 ans  ,1416,des,Produits céréaliers,des,Céréales pour déjeuner,,,22.1,1.3,19.6,24.6,mcg (ÉFA),5.1,0.3,,2
 Folate,Jeunes et adolescents* 9 à 18 ans  ,794,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),13.2,1,11.1,15.2,mcg (ÉFA),3,0.2,,3
 Folate,Jeunes et adolescents* 9 à 18 ans  ,700,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,8.9,0.7,7.5,10.3,mcg (ÉFA),2.1,0.2,,3
-Folate,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,9.3,0.5,8.4,10.3,mcg (ÉFA),2.2,0.1,,2
-Folate,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.5,0.1,0.3,0.7,mcg (ÉFA),0.1,0,E,3
-Folate,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.4,0.1,0.2,0.5,mcg (ÉFA),0.1,0,E,3
-Folate,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.8,0.1,0.7,0.9,mcg (ÉFA),0.2,0,,3
-Folate,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mcg (ÉFA),X,X,<10,3
+Folate,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,9.3,0.5,8.4,10.3,mcg (ÉFA),2.2,0.1,,2
+Folate,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.5,0.1,0.3,0.7,mcg (ÉFA),0.1,0,E,3
+Folate,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.4,0.1,0.2,0.5,mcg (ÉFA),0.1,0,E,3
+Folate,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.8,0.1,0.7,0.9,mcg (ÉFA),0.2,0,,3
+Folate,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mcg (ÉFA),X,X,<10,3
 Folate,Jeunes et adolescents* 9 à 18 ans  ,3103,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,123.1,4.1,115.1,131,mcg (ÉFA),28.4,0.8,,2
 Folate,Jeunes et adolescents* 9 à 18 ans  ,2364,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,65.1,3.1,59,71.2,mcg (ÉFA),15,0.7,,3
 Folate,Jeunes et adolescents* 9 à 18 ans  ,1020,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,54.6,3.3,48,61.1,mcg (ÉFA),12.6,0.7,,3
@@ -6992,11 +6992,11 @@ Calcium,Jeunes et adolescents* 9 à 18 ans  ,828,des,Produits céréaliers,des,P
 Calcium,Jeunes et adolescents* 9 à 18 ans  ,1416,des,Produits céréaliers,des,Céréales pour déjeuner,,,23.6,1.8,20.1,27,mg,2.4,0.2,,2
 Calcium,Jeunes et adolescents* 9 à 18 ans  ,794,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),14.2,1.4,11.4,16.9,mg,1.4,0.1,,3
 Calcium,Jeunes et adolescents* 9 à 18 ans  ,700,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,9.4,0.8,7.7,11.1,mg,1,0.1,,3
-Calcium,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,8.9,0.6,7.7,10.1,mg,0.9,0.1,,2
-Calcium,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.2,0,0.1,0.3,mg,0,0,,3
-Calcium,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.1,mg,0,0,,3
-Calcium,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,6.1,0.5,5,7.1,mg,0.6,0.1,,3
-Calcium,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
+Calcium,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,8.9,0.6,7.7,10.1,mg,0.9,0.1,,2
+Calcium,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.2,0,0.1,0.3,mg,0,0,,3
+Calcium,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.1,mg,0,0,,3
+Calcium,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,6.1,0.5,5,7.1,mg,0.6,0.1,,3
+Calcium,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
 Calcium,Jeunes et adolescents* 9 à 18 ans  ,3103,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,16.6,0.8,15,18.2,mg,1.7,0.1,,2
 Calcium,Jeunes et adolescents* 9 à 18 ans  ,2364,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,4.6,0.2,4.2,5,mg,0.5,0,,3
 Calcium,Jeunes et adolescents* 9 à 18 ans  ,1020,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,7.5,0.8,6,9.1,mg,0.8,0.1,,3
@@ -7106,11 +7106,11 @@ Fer,Jeunes et adolescents* 9 à 18 ans  ,828,des,Produits céréaliers,des,Pains
 Fer,Jeunes et adolescents* 9 à 18 ans  ,1416,des,Produits céréaliers,des,Céréales pour déjeuner,,,1.9,0.1,1.7,2.1,mg,14.4,0.7,,2
 Fer,Jeunes et adolescents* 9 à 18 ans  ,794,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),1.1,0.1,1,1.3,mg,8.5,0.6,,3
 Fer,Jeunes et adolescents* 9 à 18 ans  ,700,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.8,0.1,0.7,0.9,mg,5.9,0.4,,3
-Fer,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.6,0,0.5,0.6,mg,4.3,0.2,,2
-Fer,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mg,0.1,0,,3
-Fer,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mg,0.1,0,,3
-Fer,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.2,mg,1,0.1,,3
-Fer,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
+Fer,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.6,0,0.5,0.6,mg,4.3,0.2,,2
+Fer,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mg,0.1,0,,3
+Fer,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mg,0.1,0,,3
+Fer,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.2,mg,1,0.1,,3
+Fer,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
 Fer,Jeunes et adolescents* 9 à 18 ans  ,3103,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,2.1,0.1,1.9,2.2,mg,15.3,0.4,,2
 Fer,Jeunes et adolescents* 9 à 18 ans  ,2364,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,1.4,0.1,1.3,1.5,mg,10.3,0.5,,3
 Fer,Jeunes et adolescents* 9 à 18 ans  ,1020,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.6,0,0.5,0.6,mg,4.2,0.3,,3
@@ -7220,11 +7220,11 @@ Sodium,Jeunes et adolescents* 9 à 18 ans  ,828,des,Produits céréaliers,des,Pa
 Sodium,Jeunes et adolescents* 9 à 18 ans  ,1416,des,Produits céréaliers,des,Céréales pour déjeuner,,,66.3,3.8,58.8,73.8,mg,2.3,0.1,,2
 Sodium,Jeunes et adolescents* 9 à 18 ans  ,794,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),41.8,3.1,35.7,47.9,mg,1.4,0.1,,3
 Sodium,Jeunes et adolescents* 9 à 18 ans  ,700,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,24.5,2,20.5,28.5,mg,0.8,0.1,,3
-Sodium,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,47.9,2.6,42.8,53,mg,1.6,0.1,,2
-Sodium,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,1.9,0.4,1.1,2.7,mg,0.1,0,E,3
-Sodium,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,1.7,0.4,0.9,2.5,mg,0.1,0,E,3
-Sodium,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,15.3,1.3,12.8,17.8,mg,0.5,0,,3
-Sodium,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
+Sodium,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,47.9,2.6,42.8,53,mg,1.6,0.1,,2
+Sodium,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,1.9,0.4,1.1,2.7,mg,0.1,0,E,3
+Sodium,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,1.7,0.4,0.9,2.5,mg,0.1,0,E,3
+Sodium,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,15.3,1.3,12.8,17.8,mg,0.5,0,,3
+Sodium,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
 Sodium,Jeunes et adolescents* 9 à 18 ans  ,3103,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,33.6,4.6,24.6,42.5,mg,1.2,0.2,,2
 Sodium,Jeunes et adolescents* 9 à 18 ans  ,2364,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.2,0,0.2,0.3,mg,0,0,,3
 Sodium,Jeunes et adolescents* 9 à 18 ans  ,1020,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,29.5,4.2,21.2,37.8,mg,1,0.1,,3
@@ -7334,11 +7334,11 @@ Potassium,Jeunes et adolescents* 9 à 18 ans  ,828,des,Produits céréaliers,des
 Potassium,Jeunes et adolescents* 9 à 18 ans  ,1416,des,Produits céréaliers,des,Céréales pour déjeuner,,,44.8,2.4,40,49.6,mg,1.8,0.1,,2
 Potassium,Jeunes et adolescents* 9 à 18 ans  ,794,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),13.6,1.1,11.4,15.8,mg,0.5,0,,3
 Potassium,Jeunes et adolescents* 9 à 18 ans  ,700,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,31.2,2.2,26.9,35.4,mg,1.2,0.1,,3
-Potassium,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,31,1.7,27.6,34.3,mg,1.2,0.1,,2
-Potassium,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,1,0.2,0.6,1.4,mg,0,0,E,3
-Potassium,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.4,0.1,0.2,0.6,mg,0,0,E,3
-Potassium,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,15.7,1.4,13,18.4,mg,0.6,0.1,,3
-Potassium,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
+Potassium,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,31,1.7,27.6,34.3,mg,1.2,0.1,,2
+Potassium,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,1,0.2,0.6,1.4,mg,0,0,E,3
+Potassium,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.4,0.1,0.2,0.6,mg,0,0,E,3
+Potassium,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,15.7,1.4,13,18.4,mg,0.6,0.1,,3
+Potassium,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
 Potassium,Jeunes et adolescents* 9 à 18 ans  ,3103,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,72.3,2,68.4,76.1,mg,2.8,0.1,,2
 Potassium,Jeunes et adolescents* 9 à 18 ans  ,2364,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,33.4,1.6,30.3,36.4,mg,1.3,0.1,,3
 Potassium,Jeunes et adolescents* 9 à 18 ans  ,1020,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,22.3,1.4,19.5,25.1,mg,0.9,0.1,,3
@@ -7383,133 +7383,133 @@ Potassium,Jeunes et adolescents* 9 à 18 ans  ,269,des,Confiseries - sucres et g
 Potassium,Jeunes et adolescents* 9 à 18 ans  ,1069,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,18.1,2.4,13.4,22.8,mg,0.7,0.1,,3
 Potassium,Jeunes et adolescents* 9 à 18 ans  ,19,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mg,0,0,,3
 Potassium,Jeunes et adolescents* 9 à 18 ans  ,2377,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,1.1,0.1,0.8,1.3,mg,0,0,,3
-Calcium,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,1.8,0.1,1.6,1.9,mg,0.2,0,,3
-Calcium,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.5,0.1,0.2,0.7,mg,0.1,0,E,3
-Calcium,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,1.7,0.1,1.4,2,mg,0.2,0,,3
-Calcium,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,mg,F,F,F,3
-Calcium,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,1.4,0.1,1.2,1.7,mg,0.2,0,,3
-Calcium,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.7,0.2,0.2,1.1,mg,0.1,0,E,3
-Calcium,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,2.8,0.2,2.3,3.3,mg,0.3,0,,3
-Calcium,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,mg,X,X,<10,3
-Glucides,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,3.5,0.1,3.3,3.8,g,1.6,0.1,,3
-Glucides,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.3,0.1,0.2,0.5,g,0.1,0,E,3
-Glucides,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,3.4,0.2,2.9,3.8,g,1.3,0.1,,3
-Glucides,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.3,0.1,0,0.5,g,0.1,0.1,E,3
-Glucides,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,2.8,0.2,2.4,3.3,g,1.5,0.1,,3
-Glucides,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.5,0.1,0.2,0.7,g,0.2,0.1,E,3
-Glucides,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,5.7,0.4,4.9,6.5,g,2.7,0.2,,3
-Glucides,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,g,X,X,<10,3
-Fibres alimentaires,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.1,0,0.1,0.1,g,0.7,0,,3
-Fibres alimentaires,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,g,0.1,0,,3
-Fibres alimentaires,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.1,0,0.1,0.1,g,0.6,0.1,,3
-Fibres alimentaires,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,g,0.1,0,,3
-Fibres alimentaires,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.1,0,0.1,0.1,g,0.6,0,,3
-Fibres alimentaires,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,g,0.1,0,,3
-Fibres alimentaires,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.2,0,0.2,0.2,g,1.4,0.1,,3
-Fibres alimentaires,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,g,X,X,<10,3
-Énergie,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,23.5,0.9,21.8,25.2,kcal,1.3,0,,3
-Énergie,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,2.7,0.7,1.4,4,kcal,0.1,0,E,3
-Énergie,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,22.3,1.5,19.4,25.2,kcal,1,0.1,,3
-Énergie,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,kcal,F,F,F,3
-Énergie,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,18.7,1.4,16,21.5,kcal,1.2,0.1,,3
-Énergie,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,3.8,1.2,1.4,6.1,kcal,0.2,0.1,E,3
-Énergie,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,37.5,2.8,32.1,43,kcal,2.5,0.2,,3
-Énergie,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,kcal,X,X,<10,3
-Folate,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,5.4,0.2,5,5.8,mcg (DFE),1.2,0,,3
-Folate,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.1,0,0.1,0.2,mcg (DFE),0,0,,3
-Folate,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,4.9,0.3,4.2,5.5,mcg (DFE),1,0.1,,3
-Folate,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.1,0,0,0.2,mcg (DFE),0,0,,3
-Folate,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,4.6,0.4,3.8,5.4,mcg (DFE),1.2,0.1,,3
-Folate,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,mcg (DFE),F,F,F,3
-Folate,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,8.9,0.6,7.6,10.1,mcg (DFE),2.5,0.2,,3
-Folate,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,mcg (DFE),X,X,<10,3
-Fer,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.2,0,0.2,0.2,mg,1.9,0.1,,3
-Fer,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,mg,0.2,0,,3
-Fer,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.2,0,0.2,0.2,mg,1.5,0.1,,3
-Fer,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,mg,0.1,0.1,,3
-Fer,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.2,0,0.1,0.2,mg,1.6,0.1,,3
-Fer,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,mg,0.3,0.1,,3
-Fer,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.4,0,0.3,0.4,mg,3.7,0.3,,3
-Fer,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,mg,X,X,<10,3
-Potassium,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,8.5,0.3,7.9,9.2,mg,0.3,0,,3
-Potassium,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,1.1,0.2,0.6,1.5,mg,0,0,E,3
-Potassium,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,8.1,0.6,6.9,9.3,mg,0.3,0,,3
-Potassium,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,mg,F,F,F,3
-Potassium,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,6.5,0.5,5.6,7.4,mg,0.3,0,,3
-Potassium,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,1.5,0.4,0.7,2.4,mg,0.1,0,E,3
-Potassium,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,13.9,1.1,11.8,16,mg,0.6,0,,3
-Potassium,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,mg,X,X,<10,3
-Protéine,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.3,0,0.3,0.3,g,0.4,0,,3
-Protéine,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.1,0,0,0.1,g,0.1,0,,3
-Protéine,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.3,0,0.2,0.3,g,0.3,0,,3
-Protéine,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0.1,g,0.1,0,,3
-Protéine,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.2,0,0.2,0.3,g,0.4,0,,3
-Protéine,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.1,0,0,0.1,g,0.1,0,,3
-Protéine,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.5,0,0.4,0.5,g,0.8,0.1,,3
-Protéine,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,g,X,X,<10,3
-Acides gras saturés,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.3,0,0.3,0.3,g,1.4,0.1,,3
-Acides gras saturés,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.1,0,0,0.1,g,0.3,0.1,,3
-Acides gras saturés,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.3,0,0.3,0.3,g,1.2,0.1,,3
-Acides gras saturés,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.1,0,0,0.1,g,0.3,0.1,,3
-Acides gras saturés,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.2,0,0.2,0.3,g,1.3,0.1,,3
-Acides gras saturés,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.1,0,0,0.2,g,0.5,0.2,,3
-Acides gras saturés,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.5,0,0.4,0.5,g,2.4,0.2,,3
-Acides gras saturés,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,g,X,X,<10,3
-Sodium,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,18.9,0.7,17.5,20.4,mg,0.7,0,,3
-Sodium,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,7.2,1.7,3.8,10.5,mg,0.3,0.1,E,3
-Sodium,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,17.8,1.2,15.4,20.2,mg,0.6,0,,3
-Sodium,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,mg,F,F,F,3
-Sodium,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,15.4,1.2,13.1,17.7,mg,0.7,0.1,,3
-Sodium,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,10.1,3.2,3.9,16.3,mg,0.4,0.1,E,3
-Sodium,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,31.1,2.4,26.4,35.9,mg,1.5,0.1,,3
-Sodium,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,mg,X,X,<10,3
-Lipides totaux,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,1,0,0.9,1,g,1.4,0.1,,3
-Lipides totaux,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.1,0,0.1,0.2,g,0.2,0,,3
-Lipides totaux,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.9,0.1,0.8,1,g,1.1,0.1,,3
-Lipides totaux,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,g,F,F,F,3
-Lipides totaux,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.7,0.1,0.6,0.9,g,1.3,0.1,,3
-Lipides totaux,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,g,F,F,F,3
-Lipides totaux,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,1.5,0.1,1.3,1.7,g,2.8,0.2,,3
-Lipides totaux,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,g,X,X,<10,3
-Sucres totaux,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,1.5,0.1,1.4,1.6,g,1.7,0.1,,3
-Sucres totaux,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,g,0,0,,3
-Sucres totaux,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,1.5,0.1,1.3,1.8,g,1.6,0.1,,3
-Sucres totaux,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,g,0,0,,3
-Sucres totaux,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,1.1,0.1,1,1.3,g,1.4,0.1,,3
-Sucres totaux,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0.1,g,0.1,0,,3
-Sucres totaux,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,2.4,0.2,2,2.8,g,2.5,0.2,,3
-Sucres totaux,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,g,X,X,<10,3
-Vitamine D,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,mcg,0,0,,3
-Vitamine D,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0,0,0,0,mcg,0,0,,3
-Vitamine D,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,mcg,0,0,,3
-Vitamine D,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0,0,0,0,mcg,0,0,,3
-Vitamine D,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,mcg,0,0,,3
-Vitamine D,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,mcg,X,X,<10,3
-Énergie,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,kcal,F,F,F,3
-Énergie,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,33.5,2,29.6,37.5,kcal,1.6,0.1,,3
-Glucides,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,g,F,F,F,3
-Glucides,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,5,0.3,4.4,5.5,g,1.8,0.1,,3
-Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.2,0,0.1,0.2,g,1,0.1,,3
-Sucres totaux,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,g,0,0,,3
-Sucres totaux,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,2.2,0.1,2,2.5,g,1.9,0.1,,3
-Protéine,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,g,0,0,,3
-Protéine,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.4,0,0.3,0.4,g,0.5,0,,3
-Lipides totaux,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0.1,g,0.1,0,,3
-Lipides totaux,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,1.4,0.1,1.3,1.6,g,1.9,0.1,,3
-Acides gras saturés,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,g,0.1,0,,3
-Acides gras saturés,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.5,0,0.4,0.5,g,1.8,0.1,,3
-Vitamine D,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,mcg,0,0,,3
-Vitamine D,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0,0,0,0,mcg,0,0,,3
-Folate,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,mcg (DFE,F,F,F,3
-Folate,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,7.5,0.5,6.6,8.4,mcg (DFE,1.6,0.1,,3
-Calcium,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,mg,F,F,F,3
-Calcium,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,2.4,0.2,2,2.8,mg,0.2,0,,3
-Fer,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,mg,0.1,0,,3
-Fer,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.4,0,0.3,0.5,mg,3,0.2,,3
-Sodium,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,mg,F,F,F,3
-Sodium,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,26,1.6,22.8,29.2,mg,0.9,0.1,,3
-Potassium,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,mg,F,F,F,3
-Potassium,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,13.1,0.9,11.4,14.8,mg,0.5,0,,3
+Calcium,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,1.8,0.1,1.6,1.9,mg,0.2,0,,3
+Calcium,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.5,0.1,0.2,0.7,mg,0.1,0,E,3
+Calcium,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,1.7,0.1,1.4,2,mg,0.2,0,,3
+Calcium,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,mg,F,F,F,3
+Calcium,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,1.4,0.1,1.2,1.7,mg,0.2,0,,3
+Calcium,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.7,0.2,0.2,1.1,mg,0.1,0,E,3
+Calcium,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,2.8,0.2,2.3,3.3,mg,0.3,0,,3
+Calcium,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,mg,X,X,<10,3
+Glucides,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,3.5,0.1,3.3,3.8,g,1.6,0.1,,3
+Glucides,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.3,0.1,0.2,0.5,g,0.1,0,E,3
+Glucides,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,3.4,0.2,2.9,3.8,g,1.3,0.1,,3
+Glucides,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.3,0.1,0,0.5,g,0.1,0.1,E,3
+Glucides,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,2.8,0.2,2.4,3.3,g,1.5,0.1,,3
+Glucides,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.5,0.1,0.2,0.7,g,0.2,0.1,E,3
+Glucides,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,5.7,0.4,4.9,6.5,g,2.7,0.2,,3
+Glucides,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,g,X,X,<10,3
+Fibres alimentaires,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.1,0,0.1,0.1,g,0.7,0,,3
+Fibres alimentaires,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,g,0.1,0,,3
+Fibres alimentaires,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.1,0,0.1,0.1,g,0.6,0.1,,3
+Fibres alimentaires,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,g,0.1,0,,3
+Fibres alimentaires,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.1,0,0.1,0.1,g,0.6,0,,3
+Fibres alimentaires,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,g,0.1,0,,3
+Fibres alimentaires,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.2,0,0.2,0.2,g,1.4,0.1,,3
+Fibres alimentaires,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,g,X,X,<10,3
+Énergie,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,23.5,0.9,21.8,25.2,kcal,1.3,0,,3
+Énergie,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,2.7,0.7,1.4,4,kcal,0.1,0,E,3
+Énergie,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,22.3,1.5,19.4,25.2,kcal,1,0.1,,3
+Énergie,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,kcal,F,F,F,3
+Énergie,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,18.7,1.4,16,21.5,kcal,1.2,0.1,,3
+Énergie,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,3.8,1.2,1.4,6.1,kcal,0.2,0.1,E,3
+Énergie,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,37.5,2.8,32.1,43,kcal,2.5,0.2,,3
+Énergie,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,kcal,X,X,<10,3
+Folate,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,5.4,0.2,5,5.8,mcg (DFE),1.2,0,,3
+Folate,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.1,0,0.1,0.2,mcg (DFE),0,0,,3
+Folate,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,4.9,0.3,4.2,5.5,mcg (DFE),1,0.1,,3
+Folate,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.1,0,0,0.2,mcg (DFE),0,0,,3
+Folate,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,4.6,0.4,3.8,5.4,mcg (DFE),1.2,0.1,,3
+Folate,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,mcg (DFE),F,F,F,3
+Folate,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,8.9,0.6,7.6,10.1,mcg (DFE),2.5,0.2,,3
+Folate,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,mcg (DFE),X,X,<10,3
+Fer,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.2,0,0.2,0.2,mg,1.9,0.1,,3
+Fer,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,mg,0.2,0,,3
+Fer,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.2,0,0.2,0.2,mg,1.5,0.1,,3
+Fer,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,mg,0.1,0.1,,3
+Fer,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.2,0,0.1,0.2,mg,1.6,0.1,,3
+Fer,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,mg,0.3,0.1,,3
+Fer,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.4,0,0.3,0.4,mg,3.7,0.3,,3
+Fer,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,mg,X,X,<10,3
+Potassium,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,8.5,0.3,7.9,9.2,mg,0.3,0,,3
+Potassium,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,1.1,0.2,0.6,1.5,mg,0,0,E,3
+Potassium,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,8.1,0.6,6.9,9.3,mg,0.3,0,,3
+Potassium,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,mg,F,F,F,3
+Potassium,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,6.5,0.5,5.6,7.4,mg,0.3,0,,3
+Potassium,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,1.5,0.4,0.7,2.4,mg,0.1,0,E,3
+Potassium,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,13.9,1.1,11.8,16,mg,0.6,0,,3
+Potassium,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,mg,X,X,<10,3
+Protéine,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.3,0,0.3,0.3,g,0.4,0,,3
+Protéine,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.1,0,0,0.1,g,0.1,0,,3
+Protéine,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.3,0,0.2,0.3,g,0.3,0,,3
+Protéine,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0.1,g,0.1,0,,3
+Protéine,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.2,0,0.2,0.3,g,0.4,0,,3
+Protéine,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.1,0,0,0.1,g,0.1,0,,3
+Protéine,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.5,0,0.4,0.5,g,0.8,0.1,,3
+Protéine,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,g,X,X,<10,3
+Acides gras saturés,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.3,0,0.3,0.3,g,1.4,0.1,,3
+Acides gras saturés,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.1,0,0,0.1,g,0.3,0.1,,3
+Acides gras saturés,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.3,0,0.3,0.3,g,1.2,0.1,,3
+Acides gras saturés,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.1,0,0,0.1,g,0.3,0.1,,3
+Acides gras saturés,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.2,0,0.2,0.3,g,1.3,0.1,,3
+Acides gras saturés,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.1,0,0,0.2,g,0.5,0.2,,3
+Acides gras saturés,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.5,0,0.4,0.5,g,2.4,0.2,,3
+Acides gras saturés,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,g,X,X,<10,3
+Sodium,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,18.9,0.7,17.5,20.4,mg,0.7,0,,3
+Sodium,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,7.2,1.7,3.8,10.5,mg,0.3,0.1,E,3
+Sodium,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,17.8,1.2,15.4,20.2,mg,0.6,0,,3
+Sodium,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,mg,F,F,F,3
+Sodium,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,15.4,1.2,13.1,17.7,mg,0.7,0.1,,3
+Sodium,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,10.1,3.2,3.9,16.3,mg,0.4,0.1,E,3
+Sodium,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,31.1,2.4,26.4,35.9,mg,1.5,0.1,,3
+Sodium,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,mg,X,X,<10,3
+Lipides totaux,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,1,0,0.9,1,g,1.4,0.1,,3
+Lipides totaux,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.1,0,0.1,0.2,g,0.2,0,,3
+Lipides totaux,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.9,0.1,0.8,1,g,1.1,0.1,,3
+Lipides totaux,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,g,F,F,F,3
+Lipides totaux,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.7,0.1,0.6,0.9,g,1.3,0.1,,3
+Lipides totaux,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,g,F,F,F,3
+Lipides totaux,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,1.5,0.1,1.3,1.7,g,2.8,0.2,,3
+Lipides totaux,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,g,X,X,<10,3
+Sucres totaux,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,1.5,0.1,1.4,1.6,g,1.7,0.1,,3
+Sucres totaux,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,g,0,0,,3
+Sucres totaux,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,1.5,0.1,1.3,1.8,g,1.6,0.1,,3
+Sucres totaux,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,g,0,0,,3
+Sucres totaux,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,1.1,0.1,1,1.3,g,1.4,0.1,,3
+Sucres totaux,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0.1,g,0.1,0,,3
+Sucres totaux,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,2.4,0.2,2,2.8,g,2.5,0.2,,3
+Sucres totaux,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,g,X,X,<10,3
+Vitamine D,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,mcg,0,0,,3
+Vitamine D,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0,0,0,0,mcg,0,0,,3
+Vitamine D,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,mcg,0,0,,3
+Vitamine D,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0,0,0,0,mcg,0,0,,3
+Vitamine D,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,mcg,0,0,,3
+Vitamine D,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,mcg,X,X,<10,3
+Énergie,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,kcal,F,F,F,3
+Énergie,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,33.5,2,29.6,37.5,kcal,1.6,0.1,,3
+Glucides,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,g,F,F,F,3
+Glucides,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,5,0.3,4.4,5.5,g,1.8,0.1,,3
+Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.2,0,0.1,0.2,g,1,0.1,,3
+Sucres totaux,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,g,0,0,,3
+Sucres totaux,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,2.2,0.1,2,2.5,g,1.9,0.1,,3
+Protéine,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,g,0,0,,3
+Protéine,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.4,0,0.3,0.4,g,0.5,0,,3
+Lipides totaux,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0.1,g,0.1,0,,3
+Lipides totaux,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,1.4,0.1,1.3,1.6,g,1.9,0.1,,3
+Acides gras saturés,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,g,0.1,0,,3
+Acides gras saturés,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.5,0,0.4,0.5,g,1.8,0.1,,3
+Vitamine D,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,mcg,0,0,,3
+Vitamine D,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0,0,0,0,mcg,0,0,,3
+Folate,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,mcg (DFE,F,F,F,3
+Folate,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,7.5,0.5,6.6,8.4,mcg (DFE,1.6,0.1,,3
+Calcium,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,mg,F,F,F,3
+Calcium,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,2.4,0.2,2,2.8,mg,0.2,0,,3
+Fer,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,mg,0.1,0,,3
+Fer,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.4,0,0.3,0.5,mg,3,0.2,,3
+Sodium,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,mg,F,F,F,3
+Sodium,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,26,1.6,22.8,29.2,mg,0.9,0.1,,3
+Potassium,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,mg,F,F,F,3
+Potassium,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,13.1,0.9,11.4,14.8,mg,0.5,0,,3


### PR DESCRIPTION
- [Corrected_TABLE_FSCT-data_Food_ingredients CCHS 2015-20240624-en.csv](https://github.com/BFSSI-Bioinformatics-Lab/CCHS-food-source-contribution/blob/master/data/Corrected_TABLE_FSCT-data_Food_ingredients%20CCHS%202015-20240624-fr.csv) file contains this weird invisible space character " " that is usually preceded by the "à" character while
[Corrected_GRAPH_FSCT-data_Food_ingredients CCHS 2015-20240624-fr.csv](https://github.com/BFSSI-Bioinformatics-Lab/CCHS-food-source-contribution/blob/master/data/Corrected_GRAPH_FSCT-data_Food_ingredients%20CCHS%202015-20240624-fr.csv) does not contain this weird invisible space character

- This issue caused the "Enfants 1 à 8 ans" column to not be displayed in the bar graph table for the French site