### PR TITLE
Shrink font sizes for small phones

### DIFF
--- a/index-fr.html
+++ b/index-fr.html
@@ -325,9 +325,9 @@ What it contains:
             <br>
     
             <div class="row" id="notes-section">
-                <section class="alert alert-info barchart-legend">
+                <section class="alert alert-info chart-legend">
                     <h3>Notes et Légende</h3>
-                    <table class="table table-condensed table-responsive">
+                    <table class="table table-condensed table-responsive" id="notes-table">
                         <tbody>
                         <tr >
                             <td style=" padding-top: 15px; padding-bottom:10px "><strong>Sources des données</strong></td>

--- a/index.html
+++ b/index.html
@@ -328,9 +328,9 @@ What it contains:
             <br>
     
             <div class="row" id="notes-section">
-                <section class="alert alert-info barchart-legend">
+                <section class="alert alert-info chart-legend">
                     <h3>Notes & Legend</h3>
-                    <table class="table table-condensed table-responsive">
+                    <table class="table table-condensed table-responsive" id="notes-table">
                         <tbody>
                         <tr >
                             <td style=" padding-top: 15px; padding-bottom:10px "><strong>Data

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -10,11 +10,11 @@
 /* For small phone screeens */
 @media screen and (max-width: 600px) {
     body { 
-        font-size: calc(1em + 1vw) !important; 
+        font-size: calc(0.8em + 1vw) !important; 
     }
 
     main {
-        font-size: calc(1em + 1vw) !important;
+        font-size: calc(0.8em + 1vw) !important;
     }
     
     h1 {
@@ -40,6 +40,10 @@
 
     .chart-legend {
         width: 90%;
+    }
+
+    .interestedLinkIcon {
+        height: calc(2.5em + 1vw) !important;
     }
 }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -7,6 +7,41 @@
  *          graphs                                                   *
  *********************************************************************/
 
+/* For small phone screeens */
+@media screen and (max-width: 600px) {
+    body { 
+        font-size: calc(1em + 1vw) !important; 
+    }
+
+    main {
+        font-size: calc(1em + 1vw) !important;
+    }
+    
+    h1 {
+        font-size: calc(1.7em + 1vw) !important; 
+    }
+    
+    h3 {
+        font-size: calc(1em + 1vw) !important; 
+    }
+
+    .btn {
+        font-size: calc(0.6em + 1vw) !important;
+        margin: 3px 0;
+    }
+
+    .graphExtra {
+        float: left !important;
+    }
+
+    #notes-table {
+        table-layout:fixed !important;
+    }
+
+    .chart-legend {
+        width: 90%;
+    }
+}
 
 .graphExtra {
     margin: 10px 0 0 0;


### PR DESCRIPTION
- Although the WET toolkit does include some CSS features to have the font-sizes shrink for smaller screens, its font-size is still too big for screens with widths smaller than about 500-600px.
- Our benchmark for the smallest screen size would be an Iphone5 (width of 320px)