### PR TITLE
Add food group name mismatch check to CSV files

### DIFF
--- a/app/assets.js
+++ b/app/assets.js
@@ -353,12 +353,12 @@ export const TranslationObj = {
             //  any keys in the food description CSV file
             // Note: Copy the exact food group name from the food description CSV file
             FoodDescriptionExceptionKeys: {
-                "Spices - Seasonings & Other Ingredients": {
+                "spices - seasonings & other ingredients": {
                     "OtherNutrients": "Spices - Seasonings & Other Ingredients (all nutrients excluding sodium)",
                     "Sodium": "Spices - Seasonings & Other Ingredients (sodium only)"
                 },
 
-                "Vegetables Including Potatoes": {
+                "vegetables including potatoes": {
                     "OtherNutrients": "Vegetables Including Potatoes (all nutrients excluding sodium)",
                     "Sodium": "Vegetables Including Potatoes (sodium only)"
                 }
@@ -517,12 +517,12 @@ export const TranslationObj = {
             //  any keys in the food description CSV file
             // Note: Copy the exact food group names (for both keys and values) from the food description CSV file
             FoodDescriptionExceptionKeys: {
-                "Épices - assaisonnements et autres ingrédients": {
+                "épices - assaisonnements et autres ingrédients": {
                     "OtherNutrients": "Épices - assaisonnements et autres ingrédients  (tous les nutriments excluant sodium)",
                     "Sodium": "Épices - assaisonnements et autres ingrédients (sodium uniquement)"
                 },
 
-                "Légumes incluant pommes de terre": {
+                "légumes incluant pommes de terre": {
                     "OtherNutrients": "Légumes incluant pommes de terre (tous les nutriments excluant sodium)",
                     "Sodium": "Légumes incluant pommes de terre  (sodium uniquement)"
                 }

--- a/data/Corrected_TABLE_FSCT-data_Food_ingredients CCHS 2015-20240624-fr.csv
+++ b/data/Corrected_TABLE_FSCT-data_Food_ingredients CCHS 2015-20240624-fr.csv
@@ -1,7 +1,7 @@
 Nutrient,Age-sex group (*: excludes pregnant or breastfeeding),N,Article_group1,Food group_level1,Article_group2,Food group_level2,Article_group3,Food group_level3,Amount,Amount_SE,L95%CI,U95%CI,Unit,Percentage,Percentage_SE,Interpretation_Notes,Food_Group_Level
 Calcium,Population 1 an et +,186,des,Aliments pour bébés,,,,,1.8,0.5,0.8,2.8,mg,0.2,0.1,E,1
 Calcium,Population 1 an et +,154,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,F,F,,,mg,F,F,F,2
-Calcium,Population 1 an et +,51,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0.4,0.1,0.2,0.6,mg,0,0,E,2
+Calcium,Population 1 an et +,51,des,Aliments pour bébés,des,Préparation pour nourrissons,,,0.4,0.1,0.2,0.6,mg,0,0,E,2
 Calcium,Population 1 an et +,19574,des,Boissons (excluant laits),,,,,58.3,1,56.3,60.3,mg,7.1,0.1,,1
 Calcium,Population 1 an et +,3540,des,Boissons (excluant laits),de l',Alcool,,,5.6,0.2,5.1,6.1,mg,0.7,0,,2
 Calcium,Population 1 an et +,12127,des,Boissons (excluant laits),du,Café et thé,,,6.5,0.2,6.1,6.9,mg,0.8,0,,2
@@ -25,7 +25,7 @@ Calcium,Population 1 an et +,6481,des,Produits laitiers et Boissons à base de p
 Calcium,Population 1 an et +,5835,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,34.2,2.1,30.1,38.2,mg,4.2,0.2,,3
 Calcium,Population 1 an et +,6026,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,19.5,1.1,17.4,21.6,mg,2.4,0.1,,3
 Calcium,Population 1 an et +,814,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,11.8,1,9.9,13.8,mg,1.4,0.1,,3
-Calcium,Population 1 an et +,4411,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,10,0.6,8.9,11.1,mg,1.2,0.1,,3
+Calcium,Population 1 an et +,4411,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,10,0.6,8.9,11.1,mg,1.2,0.1,,3
 Calcium,Population 1 an et +,18258,des,Graisses et huiles,,,,,2.5,0.1,2.4,2.7,mg,0.3,0,,1
 Calcium,Population 1 an et +,944,des,Graisses et huiles,des,Graisses animales,,,0,0,0,0,mg,0,0,,2
 Calcium,Population 1 an et +,5492,des,Graisses et huiles,du,Beurre,,,0.7,0,0.7,0.8,mg,0.1,0,,2
@@ -40,9 +40,9 @@ Calcium,Population 1 an et +,18914,des,Fruits et légumes,,,,,66.4,1.1,64.3,68.5
 Calcium,Population 1 an et +,13689,des,Fruits et légumes,des,Fruits,,,18.6,0.4,17.8,19.5,mg,2.3,0.1,,2
 Calcium,Population 1 an et +,17977,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,47.8,0.9,46.1,49.5,mg,5.8,0.1,,2
 Calcium,Population 1 an et +,3372,des,Fruits et légumes,des,Fruits,des,Agrumes,6.7,0.3,6.2,7.3,mg,0.8,0,,3
-Calcium,Population 1 an et +,5026,des,Fruits et légumes,des,Fruits,des,Pommes,2.4,0.1,2.2,2.5,mg,0.3,0,,3
+Calcium,Population 1 an et +,5026,des,Fruits et légumes,des,Fruits,des,Pomme,2.4,0.1,2.2,2.5,mg,0.3,0,,3
 Calcium,Population 1 an et +,2103,des,Fruits et légumes,des,Fruits,des,Autres fruits,2.3,0.2,1.8,2.8,mg,0.3,0,,3
-Calcium,Population 1 an et +,5308,des,Fruits et légumes,des,Fruits,des,Bananes,1.5,0,1.4,1.5,mg,0.2,0,,3
+Calcium,Population 1 an et +,5308,des,Fruits et légumes,des,Fruits,des,Banane,1.5,0,1.4,1.5,mg,0.2,0,,3
 Calcium,Population 1 an et +,4326,des,Fruits et légumes,des,Fruits,des,Baies,2,0.1,1.8,2.1,mg,0.2,0,,3
 Calcium,Population 1 an et +,2881,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,1.2,0.1,1,1.3,mg,0.1,0,,3
 Calcium,Population 1 an et +,982,des,Fruits et légumes,des,Fruits,des,Melons,0.9,0.1,0.8,1.1,mg,0.1,0,,3
@@ -58,7 +58,7 @@ Calcium,Population 1 an et +,6318,des,Fruits et légumes,des,Légumes incluant p
 Calcium,Population 1 an et +,19327,des,Produits céréaliers,,,,,102.9,1.2,100.6,105.2,mg,12.6,0.1,,1
 Calcium,Population 1 an et +,16168,des,Produits céréaliers,des,Pains,,,69.6,1.1,67.5,71.7,mg,8.5,0.1,,2
 Calcium,Population 1 an et +,6966,des,Produits céréaliers,des,Céréales pour déjeuner,,,15.5,0.5,14.4,16.5,mg,1.9,0.1,,2
-Calcium,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,5.2,0.2,4.8,5.7,mg,0.6,0,,2
+Calcium,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,5.2,0.2,4.8,5.7,mg,0.6,0,,2
 Calcium,Population 1 an et +,14820,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,12.7,0.3,12.1,13.3,mg,1.5,0,,2
 Calcium,Population 1 an et +,8159,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,31.2,0.7,29.7,32.7,mg,3.8,0.1,,3
 Calcium,Population 1 an et +,5962,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,19.3,0.6,18.2,20.4,mg,2.4,0.1,,3
@@ -66,10 +66,10 @@ Calcium,Population 1 an et +,6257,des,Produits céréaliers,des,Pains,des,Autres
 Calcium,Population 1 an et +,2918,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,2.2,0.1,2,2.5,mg,0.3,0,,3
 Calcium,Population 1 an et +,4760,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,10.4,0.5,9.5,11.3,mg,1.3,0.1,,3
 Calcium,Population 1 an et +,2573,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),5,0.3,4.4,5.6,mg,0.6,0,,3
-Calcium,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,2.8,0.2,2.4,3.1,mg,0.3,0,,3
-Calcium,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0.1,0.2,mg,0,0,,3
-Calcium,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.1,mg,0,0,,3
-Calcium,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
+Calcium,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,2.8,0.2,2.4,3.1,mg,0.3,0,,3
+Calcium,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0.1,0.2,mg,0,0,,3
+Calcium,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.1,mg,0,0,,3
+Calcium,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
 Calcium,Population 1 an et +,4543,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,4.7,0.3,4.2,5.2,mg,0.6,0,,3
 Calcium,Population 1 an et +,11102,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,3.9,0.1,3.7,4.1,mg,0.5,0,,3
 Calcium,Population 1 an et +,4598,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,4.1,0.2,3.8,4.4,mg,0.5,0,,3
@@ -99,23 +99,23 @@ Calcium,Population 1 an et +,18438,des,Soupes - sauces - Épices et autres ingr�
 Calcium,Population 1 an et +,7054,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,4.1,0.2,3.7,4.4,mg,0.5,0,,2
 Calcium,Population 1 an et +,4710,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,3.6,0.2,3.2,4,mg,0.4,0,,2
 Calcium,Population 1 an et +,17547,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,21.2,0.9,19.4,23,mg,2.6,0.1,,2
-Calcium,Population 1 an et +,16725,des,Confiseries - sucres et grignotines salées,,,,,34.8,1,32.8,36.9,mg,4.3,0.1,,1
-Calcium,Population 1 an et +,6211,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,7.6,0.6,6.6,8.7,mg,0.9,0.1,,2
-Calcium,Population 1 an et +,2912,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,17.8,0.8,16.2,19.5,mg,2.2,0.1,,2
-Calcium,Population 1 an et +,4652,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,5.1,0.3,4.4,5.7,mg,0.6,0,,2
-Calcium,Population 1 an et +,14214,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,4.3,0.3,3.8,4.8,mg,0.5,0,,2
-Calcium,Population 1 an et +,3815,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,5.5,0.4,4.7,6.2,mg,0.7,0,,3
-Calcium,Population 1 an et +,2559,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,1.2,0.4,0.4,2,mg,0.1,0.1,E,3
-Calcium,Population 1 an et +,703,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,1,0.1,0.8,1.2,mg,0.1,0,,3
-Calcium,Population 1 an et +,2447,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,17.6,0.8,16,19.2,mg,2.2,0.1,,3
-Calcium,Population 1 an et +,560,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0.3,0,0.2,0.3,mg,0,0,,3
-Calcium,Population 1 an et +,4750,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,3.2,0.3,2.7,3.7,mg,0.4,0,,3
-Calcium,Population 1 an et +,12217,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0.7,0,0.6,0.8,mg,0.1,0,,3
-Calcium,Population 1 an et +,2044,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.4,0,0.3,0.5,mg,0,0,,3
-Calcium,Population 1 an et +,715,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mg,0,0,,3
+Calcium,Population 1 an et +,16725,des,Confiserie - sucres et grignotines salées,,,,,34.8,1,32.8,36.9,mg,4.3,0.1,,1
+Calcium,Population 1 an et +,6211,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,7.6,0.6,6.6,8.7,mg,0.9,0.1,,2
+Calcium,Population 1 an et +,2912,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,17.8,0.8,16.2,19.5,mg,2.2,0.1,,2
+Calcium,Population 1 an et +,4652,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,5.1,0.3,4.4,5.7,mg,0.6,0,,2
+Calcium,Population 1 an et +,14214,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,4.3,0.3,3.8,4.8,mg,0.5,0,,2
+Calcium,Population 1 an et +,3815,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,5.5,0.4,4.7,6.2,mg,0.7,0,,3
+Calcium,Population 1 an et +,2559,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,1.2,0.4,0.4,2,mg,0.1,0.1,E,3
+Calcium,Population 1 an et +,703,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,1,0.1,0.8,1.2,mg,0.1,0,,3
+Calcium,Population 1 an et +,2447,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,17.6,0.8,16,19.2,mg,2.2,0.1,,3
+Calcium,Population 1 an et +,560,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0.3,0,0.2,0.3,mg,0,0,,3
+Calcium,Population 1 an et +,4750,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,3.2,0.3,2.7,3.7,mg,0.4,0,,3
+Calcium,Population 1 an et +,12217,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0.7,0,0.6,0.8,mg,0.1,0,,3
+Calcium,Population 1 an et +,2044,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.4,0,0.3,0.5,mg,0,0,,3
+Calcium,Population 1 an et +,715,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mg,0,0,,3
 Calcium,Hommes adultes 19 ans +,22,des,Aliments pour bébés,,,,,0.3,0.1,0,0.6,mg,0,0,E,1
 Calcium,Hommes adultes 19 ans +,21,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0.3,0.1,0,0.6,mg,0,0,E,2
-Calcium,Hommes adultes 19 ans +,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,mg,X,X,<10,2
+Calcium,Hommes adultes 19 ans +,,des,Aliments pour bébés,des,Préparation pour nourrissons,,,X,X,,,mg,X,X,<10,2
 Calcium,Hommes adultes 19 ans +,6187,des,Boissons (excluant laits),,,,,67.8,2.1,63.7,71.8,mg,7.9,0.2,,1
 Calcium,Hommes adultes 19 ans +,1946,des,Boissons (excluant laits),de l',Alcool,,,9.5,0.5,8.5,10.6,mg,1.1,0.1,,2
 Calcium,Hommes adultes 19 ans +,5104,des,Boissons (excluant laits),du,Café et thé,,,8.9,0.4,8,9.8,mg,1,0.1,,2
@@ -138,7 +138,7 @@ Calcium,Hommes adultes 19 ans +,3759,des,Produits laitiers et Boissons à base d
 Calcium,Hommes adultes 19 ans +,1819,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,52.6,3.3,46.2,59,mg,6.1,0.4,,3
 Calcium,Hommes adultes 19 ans +,1648,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,29.3,4.1,21.3,37.4,mg,3.4,0.5,,3
 Calcium,Hommes adultes 19 ans +,1812,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,19.1,1.9,15.5,22.8,mg,2.2,0.2,,3
-Calcium,Hommes adultes 19 ans +,1727,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,12.8,1.3,10.3,15.3,mg,1.5,0.1,,3
+Calcium,Hommes adultes 19 ans +,1727,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,12.8,1.3,10.3,15.3,mg,1.5,0.1,,3
 Calcium,Hommes adultes 19 ans +,208,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,11.6,1.9,7.9,15.3,mg,1.4,0.2,,3
 Calcium,Hommes adultes 19 ans +,5767,des,Graisses et huiles,,,,,2.9,0.1,2.7,3.1,mg,0.3,0,,1
 Calcium,Hommes adultes 19 ans +,333,des,Graisses et huiles,des,Graisses animales,,,0,0,0,0,mg,0,0,,2
@@ -154,9 +154,9 @@ Calcium,Hommes adultes 19 ans +,5918,des,Fruits et légumes,,,,,69.7,1.8,66.2,73
 Calcium,Hommes adultes 19 ans +,3876,des,Fruits et légumes,des,Fruits,,,17.9,0.7,16.5,19.2,mg,2.1,0.1,,2
 Calcium,Hommes adultes 19 ans +,5694,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,51.9,1.5,48.8,54.9,mg,6,0.2,,2
 Calcium,Hommes adultes 19 ans +,1019,des,Fruits et légumes,des,Fruits,des,Agrumes,6.5,0.5,5.5,7.4,mg,0.8,0.1,,3
-Calcium,Hommes adultes 19 ans +,1350,des,Fruits et légumes,des,Fruits,des,Pommes,2.4,0.1,2.1,2.7,mg,0.3,0,,3
+Calcium,Hommes adultes 19 ans +,1350,des,Fruits et légumes,des,Fruits,des,Pomme,2.4,0.1,2.1,2.7,mg,0.3,0,,3
 Calcium,Hommes adultes 19 ans +,603,des,Fruits et légumes,des,Fruits,des,Autres fruits,2.3,0.4,1.5,3,mg,0.3,0,E,3
-Calcium,Hommes adultes 19 ans +,1590,des,Fruits et légumes,des,Fruits,des,Bananes,1.7,0.1,1.5,1.8,mg,0.2,0,,3
+Calcium,Hommes adultes 19 ans +,1590,des,Fruits et légumes,des,Fruits,des,Banane,1.7,0.1,1.5,1.8,mg,0.2,0,,3
 Calcium,Hommes adultes 19 ans +,1066,des,Fruits et légumes,des,Fruits,des,Baies,1.6,0.1,1.3,1.9,mg,0.2,0,,3
 Calcium,Hommes adultes 19 ans +,782,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,1,0.1,0.8,1.2,mg,0.1,0,,3
 Calcium,Hommes adultes 19 ans +,247,des,Fruits et légumes,des,Fruits,des,Melons,0.9,0.1,0.6,1.2,mg,0.1,0,,3
@@ -172,7 +172,7 @@ Calcium,Hommes adultes 19 ans +,1991,des,Fruits et légumes,des,Légumes incluan
 Calcium,Hommes adultes 19 ans +,6068,des,Produits céréaliers,,,,,113.2,2,109.3,117.1,mg,13.2,0.3,,1
 Calcium,Hommes adultes 19 ans +,5104,des,Produits céréaliers,des,Pains,,,80.3,1.9,76.6,84.1,mg,9.4,0.2,,2
 Calcium,Hommes adultes 19 ans +,1921,des,Produits céréaliers,des,Céréales pour déjeuner,,,14.5,1,12.6,16.4,mg,1.7,0.1,,2
-Calcium,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,5.2,0.4,4.4,6,mg,0.6,0,,2
+Calcium,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,5.2,0.4,4.4,6,mg,0.6,0,,2
 Calcium,Hommes adultes 19 ans +,4551,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,13.2,0.5,12.3,14.1,mg,1.5,0.1,,2
 Calcium,Hommes adultes 19 ans +,2752,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,39.5,1.5,36.6,42.3,mg,4.6,0.2,,3
 Calcium,Hommes adultes 19 ans +,1980,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,21.9,1,19.9,23.9,mg,2.6,0.1,,3
@@ -180,9 +180,9 @@ Calcium,Hommes adultes 19 ans +,1885,des,Produits céréaliers,des,Pains,des,Aut
 Calcium,Hommes adultes 19 ans +,593,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,1.2,0.1,0.9,1.5,mg,0.1,0,,3
 Calcium,Hommes adultes 19 ans +,1481,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,11.5,0.9,9.7,13.3,mg,1.3,0.1,,3
 Calcium,Hommes adultes 19 ans +,523,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),3,0.4,2.3,3.7,mg,0.3,0,,3
-Calcium,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,2.8,0.3,2.2,3.4,mg,0.3,0,,3
-Calcium,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0,0.2,mg,0,0,,3
-Calcium,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.1,mg,0,0,,3
+Calcium,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,2.8,0.3,2.2,3.4,mg,0.3,0,,3
+Calcium,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0,0.2,mg,0,0,,3
+Calcium,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.1,mg,0,0,,3
 Calcium,Hommes adultes 19 ans +,3442,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,4.5,0.2,4.1,4.9,mg,0.5,0,,3
 Calcium,Hommes adultes 19 ans +,1250,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,4.2,0.3,3.5,4.8,mg,0.5,0,,3
 Calcium,Hommes adultes 19 ans +,1449,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,4.5,0.3,3.9,5,mg,0.5,0,,3
@@ -212,23 +212,23 @@ Calcium,Hommes adultes 19 ans +,5856,des,Soupes - sauces - Épices et autres ing
 Calcium,Hommes adultes 19 ans +,2384,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,4.6,0.3,4,5.2,mg,0.5,0,,2
 Calcium,Hommes adultes 19 ans +,1511,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,4.1,0.3,3.5,4.8,mg,0.5,0,,2
 Calcium,Hommes adultes 19 ans +,5575,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,23.8,1.9,20.1,27.5,mg,2.8,0.2,,2
-Calcium,Hommes adultes 19 ans +,5232,des,Confiseries - sucres et grignotines salées,,,,,32.1,1.8,28.6,35.5,mg,3.7,0.2,,1
-Calcium,Hommes adultes 19 ans +,1527,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,6.8,1.1,4.7,8.9,mg,0.8,0.1,,2
-Calcium,Hommes adultes 19 ans +,771,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,15.7,1.4,13,18.4,mg,1.8,0.2,,2
-Calcium,Hommes adultes 19 ans +,1268,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,5.4,0.6,4.2,6.7,mg,0.6,0.1,,2
-Calcium,Hommes adultes 19 ans +,4671,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,4.1,0.3,3.5,4.7,mg,0.5,0,,2
-Calcium,Hommes adultes 19 ans +,1023,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,4.5,0.4,3.7,5.3,mg,0.5,0,,3
-Calcium,Hommes adultes 19 ans +,170,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0.7,0.1,0.5,1,mg,0.1,0,,3
-Calcium,Hommes adultes 19 ans +,497,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,F,F,,,mg,F,F,F,3
-Calcium,Hommes adultes 19 ans +,702,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,15.5,1.4,12.9,18.2,mg,1.8,0.2,,3
-Calcium,Hommes adultes 19 ans +,80,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,F,F,,,mg,F,F,F,3
-Calcium,Hommes adultes 19 ans +,1360,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,2.8,0.3,2.2,3.3,mg,0.3,0,,3
-Calcium,Hommes adultes 19 ans +,726,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.5,0.1,0.4,0.7,mg,0.1,0,E,3
-Calcium,Hommes adultes 19 ans +,4068,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0.8,0.1,0.6,1,mg,0.1,0,,3
-Calcium,Hommes adultes 19 ans +,322,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mg,0,0,,3
+Calcium,Hommes adultes 19 ans +,5232,des,Confiserie - sucres et grignotines salées,,,,,32.1,1.8,28.6,35.5,mg,3.7,0.2,,1
+Calcium,Hommes adultes 19 ans +,1527,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,6.8,1.1,4.7,8.9,mg,0.8,0.1,,2
+Calcium,Hommes adultes 19 ans +,771,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,15.7,1.4,13,18.4,mg,1.8,0.2,,2
+Calcium,Hommes adultes 19 ans +,1268,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,5.4,0.6,4.2,6.7,mg,0.6,0.1,,2
+Calcium,Hommes adultes 19 ans +,4671,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,4.1,0.3,3.5,4.7,mg,0.5,0,,2
+Calcium,Hommes adultes 19 ans +,1023,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,4.5,0.4,3.7,5.3,mg,0.5,0,,3
+Calcium,Hommes adultes 19 ans +,170,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0.7,0.1,0.5,1,mg,0.1,0,,3
+Calcium,Hommes adultes 19 ans +,497,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,F,F,,,mg,F,F,F,3
+Calcium,Hommes adultes 19 ans +,702,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,15.5,1.4,12.9,18.2,mg,1.8,0.2,,3
+Calcium,Hommes adultes 19 ans +,80,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,F,F,,,mg,F,F,F,3
+Calcium,Hommes adultes 19 ans +,1360,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,2.8,0.3,2.2,3.3,mg,0.3,0,,3
+Calcium,Hommes adultes 19 ans +,726,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.5,0.1,0.4,0.7,mg,0.1,0,E,3
+Calcium,Hommes adultes 19 ans +,4068,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0.8,0.1,0.6,1,mg,0.1,0,,3
+Calcium,Hommes adultes 19 ans +,322,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mg,0,0,,3
 Calcium,Femmes adultes* 19 ans +,21,des,Aliments pour bébés,,,,,F,F,,,mg,F,F,F,1
 Calcium,Femmes adultes* 19 ans +,19,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,F,F,,,mg,F,F,F,2
-Calcium,Femmes adultes* 19 ans +,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,mg,X,X,<10,2
+Calcium,Femmes adultes* 19 ans +,,des,Aliments pour bébés,des,Préparation pour nourrissons,,,X,X,,,mg,X,X,<10,2
 Calcium,Femmes adultes* 19 ans +,6828,des,Boissons (excluant laits),,,,,53.2,1.2,50.9,55.5,mg,7.6,0.2,,1
 Calcium,Femmes adultes* 19 ans +,1439,des,Boissons (excluant laits),de l',Alcool,,,4.5,0.3,3.9,5,mg,0.6,0,,2
 Calcium,Femmes adultes* 19 ans +,5777,des,Boissons (excluant laits),du,Café et thé,,,7.1,0.2,6.7,7.5,mg,1,0,,2
@@ -252,7 +252,7 @@ Calcium,Femmes adultes* 19 ans +,2244,des,Produits laitiers et Boissons à base 
 Calcium,Femmes adultes* 19 ans +,2211,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,20.3,1.5,17.4,23.2,mg,2.9,0.2,,3
 Calcium,Femmes adultes* 19 ans +,1928,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,19.7,2.7,14.4,24.9,mg,2.8,0.4,,3
 Calcium,Femmes adultes* 19 ans +,358,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,12.9,1.4,10.1,15.7,mg,1.8,0.2,,3
-Calcium,Femmes adultes* 19 ans +,1769,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,9.6,0.6,8.4,10.7,mg,1.4,0.1,,3
+Calcium,Femmes adultes* 19 ans +,1769,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,9.6,0.6,8.4,10.7,mg,1.4,0.1,,3
 Calcium,Femmes adultes* 19 ans +,6356,des,Graisses et huiles,,,,,2.6,0.1,2.4,2.8,mg,0.4,0,,1
 Calcium,Femmes adultes* 19 ans +,369,des,Graisses et huiles,des,Graisses animales,,,0,0,0,0,mg,0,0,,2
 Calcium,Femmes adultes* 19 ans +,1972,des,Graisses et huiles,du,Beurre,,,0.8,0.1,0.6,0.9,mg,0.1,0,,2
@@ -268,9 +268,9 @@ Calcium,Femmes adultes* 19 ans +,4951,des,Fruits et légumes,des,Fruits,,,19.5,0
 Calcium,Femmes adultes* 19 ans +,6291,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,51,1.5,48.2,53.9,mg,7.3,0.2,,2
 Calcium,Femmes adultes* 19 ans +,1356,des,Fruits et légumes,des,Fruits,des,Agrumes,7.5,0.5,6.6,8.5,mg,1.1,0.1,,3
 Calcium,Femmes adultes* 19 ans +,854,des,Fruits et légumes,des,Fruits,des,Autres fruits,2.7,0.5,1.8,3.6,mg,0.4,0.1,E,3
-Calcium,Femmes adultes* 19 ans +,1574,des,Fruits et légumes,des,Fruits,des,Pommes,2.1,0.1,1.8,2.3,mg,0.3,0,,3
+Calcium,Femmes adultes* 19 ans +,1574,des,Fruits et légumes,des,Fruits,des,Pomme,2.1,0.1,1.8,2.3,mg,0.3,0,,3
 Calcium,Femmes adultes* 19 ans +,1597,des,Fruits et légumes,des,Fruits,des,Baies,2.1,0.1,1.8,2.3,mg,0.3,0,,3
-Calcium,Femmes adultes* 19 ans +,1919,des,Fruits et légumes,des,Fruits,des,Bananes,1.3,0.1,1.2,1.4,mg,0.2,0,,3
+Calcium,Femmes adultes* 19 ans +,1919,des,Fruits et légumes,des,Fruits,des,Banane,1.3,0.1,1.2,1.4,mg,0.2,0,,3
 Calcium,Femmes adultes* 19 ans +,1006,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,1.2,0.1,0.9,1.5,mg,0.2,0,,3
 Calcium,Femmes adultes* 19 ans +,306,des,Fruits et légumes,des,Fruits,des,Melons,0.8,0.1,0.6,1.1,mg,0.1,0,,3
 Calcium,Femmes adultes* 19 ans +,265,des,Fruits et légumes,des,Fruits,des,Poires,0.6,0.1,0.4,0.7,mg,0.1,0,E,3
@@ -285,7 +285,7 @@ Calcium,Femmes adultes* 19 ans +,2348,des,Fruits et légumes,des,Légumes inclua
 Calcium,Femmes adultes* 19 ans +,6669,des,Produits céréaliers,,,,,85.3,1.6,82.3,88.4,mg,12.2,0.2,,1
 Calcium,Femmes adultes* 19 ans +,5520,des,Produits céréaliers,des,Pains,,,58.8,1.4,56.1,61.5,mg,8.4,0.2,,2
 Calcium,Femmes adultes* 19 ans +,2230,des,Produits céréaliers,des,Céréales pour déjeuner,,,11.8,0.6,10.5,13.1,mg,1.7,0.1,,2
-Calcium,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,3.9,0.3,3.3,4.5,mg,0.6,0,,2
+Calcium,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,3.9,0.3,3.3,4.5,mg,0.6,0,,2
 Calcium,Femmes adultes* 19 ans +,4893,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,10.8,0.5,9.7,11.9,mg,1.5,0.1,,2
 Calcium,Femmes adultes* 19 ans +,2551,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,24.1,1,22.3,26,mg,3.4,0.1,,3
 Calcium,Femmes adultes* 19 ans +,2239,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,19.1,0.8,17.6,20.6,mg,2.7,0.1,,3
@@ -293,10 +293,10 @@ Calcium,Femmes adultes* 19 ans +,1994,des,Produits céréaliers,des,Pains,des,Au
 Calcium,Femmes adultes* 19 ans +,914,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,1.7,0.2,1.2,2.1,mg,0.2,0,,3
 Calcium,Femmes adultes* 19 ans +,1756,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,9.3,0.6,8.2,10.5,mg,1.3,0.1,,3
 Calcium,Femmes adultes* 19 ans +,555,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),2.5,0.3,1.8,3.2,mg,0.4,0,,3
-Calcium,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,1.6,0.2,1.2,2.1,mg,0.2,0,,3
-Calcium,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0,0.1,mg,0,0,,3
-Calcium,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.1,mg,0,0,,3
-Calcium,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
+Calcium,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,1.6,0.2,1.2,2.1,mg,0.2,0,,3
+Calcium,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0,0.1,mg,0,0,,3
+Calcium,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.1,mg,0,0,,3
+Calcium,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
 Calcium,Femmes adultes* 19 ans +,3664,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,3.2,0.2,2.9,3.5,mg,0.5,0,,3
 Calcium,Femmes adultes* 19 ans +,1358,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,3.8,0.5,2.9,4.7,mg,0.5,0.1,,3
 Calcium,Femmes adultes* 19 ans +,1522,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,3.8,0.3,3.3,4.3,mg,0.5,0,,3
@@ -326,23 +326,23 @@ Calcium,Femmes adultes* 19 ans +,6382,des,Soupes - sauces - Épices et autres in
 Calcium,Femmes adultes* 19 ans +,2243,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,3.6,0.3,3.1,4.2,mg,0.5,0,,2
 Calcium,Femmes adultes* 19 ans +,1853,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,3.9,0.3,3.2,4.6,mg,0.6,0,,2
 Calcium,Femmes adultes* 19 ans +,6077,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,19.9,1.2,17.5,22.3,mg,2.8,0.2,,2
-Calcium,Femmes adultes* 19 ans +,5713,des,Confiseries - sucres et grignotines salées,,,,,32.5,1.8,28.9,36.1,mg,4.6,0.3,,1
-Calcium,Femmes adultes* 19 ans +,1936,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,8.3,1,6.4,10.2,mg,1.2,0.1,,2
-Calcium,Femmes adultes* 19 ans +,844,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,16.6,1.4,13.9,19.4,mg,2.4,0.2,,2
-Calcium,Femmes adultes* 19 ans +,1411,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,4,0.5,3.1,5,mg,0.6,0.1,,2
-Calcium,Femmes adultes* 19 ans +,4937,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,3.6,0.3,3,4.2,mg,0.5,0,,2
-Calcium,Femmes adultes* 19 ans +,1238,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,6.1,0.9,4.4,7.9,mg,0.9,0.1,,3
-Calcium,Femmes adultes* 19 ans +,685,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,1.1,0.3,0.5,1.7,mg,0.2,0,E,3
-Calcium,Femmes adultes* 19 ans +,229,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,1,0.2,0.7,1.4,mg,0.1,0,E,3
-Calcium,Femmes adultes* 19 ans +,762,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,16.5,1.4,13.7,19.2,mg,2.3,0.2,,3
-Calcium,Femmes adultes* 19 ans +,87,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,F,F,,,mg,F,F,F,3
-Calcium,Femmes adultes* 19 ans +,1529,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,2.6,0.3,2,3.1,mg,0.4,0,,3
-Calcium,Femmes adultes* 19 ans +,4229,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0.7,0.1,0.6,0.8,mg,0.1,0,,3
-Calcium,Femmes adultes* 19 ans +,773,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.3,0,0.3,0.4,mg,0,0,,3
-Calcium,Femmes adultes* 19 ans +,360,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mg,0,0,,3
+Calcium,Femmes adultes* 19 ans +,5713,des,Confiserie - sucres et grignotines salées,,,,,32.5,1.8,28.9,36.1,mg,4.6,0.3,,1
+Calcium,Femmes adultes* 19 ans +,1936,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,8.3,1,6.4,10.2,mg,1.2,0.1,,2
+Calcium,Femmes adultes* 19 ans +,844,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,16.6,1.4,13.9,19.4,mg,2.4,0.2,,2
+Calcium,Femmes adultes* 19 ans +,1411,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,4,0.5,3.1,5,mg,0.6,0.1,,2
+Calcium,Femmes adultes* 19 ans +,4937,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,3.6,0.3,3,4.2,mg,0.5,0,,2
+Calcium,Femmes adultes* 19 ans +,1238,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,6.1,0.9,4.4,7.9,mg,0.9,0.1,,3
+Calcium,Femmes adultes* 19 ans +,685,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,1.1,0.3,0.5,1.7,mg,0.2,0,E,3
+Calcium,Femmes adultes* 19 ans +,229,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,1,0.2,0.7,1.4,mg,0.1,0,E,3
+Calcium,Femmes adultes* 19 ans +,762,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,16.5,1.4,13.7,19.2,mg,2.3,0.2,,3
+Calcium,Femmes adultes* 19 ans +,87,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,F,F,,,mg,F,F,F,3
+Calcium,Femmes adultes* 19 ans +,1529,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,2.6,0.3,2,3.1,mg,0.4,0,,3
+Calcium,Femmes adultes* 19 ans +,4229,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0.7,0.1,0.6,0.8,mg,0.1,0,,3
+Calcium,Femmes adultes* 19 ans +,773,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.3,0,0.3,0.4,mg,0,0,,3
+Calcium,Femmes adultes* 19 ans +,360,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mg,0,0,,3
 Calcium,Enfants 1 à 8 ans,122,des,Aliments pour bébés,,,,,11.7,3.2,5.4,17.9,mg,1.3,0.3,E,1
 Calcium,Enfants 1 à 8 ans,95,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,F,F,,,mg,F,F,F,2
-Calcium,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparations pour nourrissons,,,4.5,1.3,1.8,7.1,mg,0.5,0.1,E,2
+Calcium,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparation pour nourrissons,,,4.5,1.3,1.8,7.1,mg,0.5,0.1,E,2
 Calcium,Enfants 1 à 8 ans,2443,des,Boissons (excluant laits),,,,,38.2,1.9,34.5,41.9,mg,4.1,0.2,,1
 Calcium,Enfants 1 à 8 ans,20,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0,mg,0,0,,2
 Calcium,Enfants 1 à 8 ans,141,des,Boissons (excluant laits),du,Café et thé,,,0.3,0.1,0.1,0.4,mg,0,0,E,2
@@ -366,7 +366,7 @@ Calcium,Enfants 1 à 8 ans,1078,des,Produits laitiers et Boissons à base de pla
 Calcium,Enfants 1 à 8 ans,854,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,71,8.1,55.1,86.9,mg,7.7,0.8,,3
 Calcium,Enfants 1 à 8 ans,739,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,11.2,1.9,7.6,14.9,mg,1.2,0.2,E,3
 Calcium,Enfants 1 à 8 ans,128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,10.5,1.8,7,13.9,mg,1.1,0.2,E,3
-Calcium,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,4.3,1,2.3,6.3,mg,0.5,0.1,E,3
+Calcium,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,4.3,1,2.3,6.3,mg,0.5,0.1,E,3
 Calcium,Enfants 1 à 8 ans,2270,des,Graisses et huiles,,,,,1.2,0.1,1.1,1.4,mg,0.1,0,,1
 Calcium,Enfants 1 à 8 ans,83,des,Graisses et huiles,des,Graisses animales,,,0,0,0,0,mg,0,0,,2
 Calcium,Enfants 1 à 8 ans,657,des,Graisses et huiles,du,Beurre,,,0.4,0,0.3,0.5,mg,0,0,,2
@@ -381,9 +381,9 @@ Calcium,Enfants 1 à 8 ans,2428,des,Fruits et légumes,,,,,48.3,1.5,45.3,51.3,mg
 Calcium,Enfants 1 à 8 ans,2117,des,Fruits et légumes,des,Fruits,,,20.1,0.8,18.5,21.7,mg,2.2,0.1,,2
 Calcium,Enfants 1 à 8 ans,2235,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,28.2,1.2,25.9,30.5,mg,3,0.1,,2
 Calcium,Enfants 1 à 8 ans,421,des,Fruits et légumes,des,Fruits,des,Agrumes,6.4,0.6,5.3,7.5,mg,0.7,0.1,,3
-Calcium,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pommes,3.2,0.2,2.8,3.6,mg,0.3,0,,3
+Calcium,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pomme,3.2,0.2,2.8,3.6,mg,0.3,0,,3
 Calcium,Enfants 1 à 8 ans,830,des,Fruits et légumes,des,Fruits,des,Baies,3.1,0.3,2.5,3.6,mg,0.3,0,,3
-Calcium,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Bananes,1.5,0.1,1.3,1.6,mg,0.2,0,,3
+Calcium,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Banane,1.5,0.1,1.3,1.6,mg,0.2,0,,3
 Calcium,Enfants 1 à 8 ans,572,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,1.8,0.3,1.2,2.3,mg,0.2,0,E,3
 Calcium,Enfants 1 à 8 ans,260,des,Fruits et légumes,des,Fruits,des,Autres fruits,1.4,0.2,1,1.8,mg,0.2,0,,3
 Calcium,Enfants 1 à 8 ans,219,des,Fruits et légumes,des,Fruits,des,Melons,1.2,0.2,0.9,1.5,mg,0.1,0,E,3
@@ -399,7 +399,7 @@ Calcium,Enfants 1 à 8 ans,1032,des,Fruits et légumes,des,Légumes incluant pom
 Calcium,Enfants 1 à 8 ans,2475,des,Produits céréaliers,,,,,101.6,2.2,97.2,105.9,mg,11,0.3,,1
 Calcium,Enfants 1 à 8 ans,2114,des,Produits céréaliers,des,Pains,,,57.6,1.9,53.9,61.4,mg,6.2,0.2,,2
 Calcium,Enfants 1 à 8 ans,1282,des,Produits céréaliers,des,Céréales pour déjeuner,,,23.9,1.3,21.4,26.4,mg,2.6,0.1,,2
-Calcium,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,6.4,0.4,5.6,7.2,mg,0.7,0,,2
+Calcium,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,6.4,0.4,5.6,7.2,mg,0.7,0,,2
 Calcium,Enfants 1 à 8 ans,2037,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,13.6,0.8,12,15.3,mg,1.5,0.1,,2
 Calcium,Enfants 1 à 8 ans,951,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,22.2,1.3,19.6,24.8,mg,2.4,0.1,,3
 Calcium,Enfants 1 à 8 ans,805,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,14.8,1.3,12.1,17.4,mg,1.6,0.1,,3
@@ -407,9 +407,9 @@ Calcium,Enfants 1 à 8 ans,813,des,Produits céréaliers,des,Pains,des,Pains et 
 Calcium,Enfants 1 à 8 ans,745,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,6.5,0.6,5.3,7.8,mg,0.7,0.1,,3
 Calcium,Enfants 1 à 8 ans,670,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),12.6,1,10.6,14.5,mg,1.4,0.1,,3
 Calcium,Enfants 1 à 8 ans,728,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,11.4,1,9.4,13.3,mg,1.2,0.1,,3
-Calcium,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,3.1,0.3,2.5,3.7,mg,0.3,0,,3
-Calcium,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0,0.2,mg,0,0,,3
-Calcium,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.1,mg,0,0,,3
+Calcium,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,3.1,0.3,2.5,3.7,mg,0.3,0,,3
+Calcium,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0,0.2,mg,0,0,,3
+Calcium,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.1,mg,0,0,,3
 Calcium,Enfants 1 à 8 ans,834,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,7.4,0.8,5.8,9,mg,0.8,0.1,,3
 Calcium,Enfants 1 à 8 ans,654,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,3.4,0.3,2.9,3.8,mg,0.4,0,,3
 Calcium,Enfants 1 à 8 ans,1461,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,2.9,0.2,2.5,3.2,mg,0.3,0,,3
@@ -439,23 +439,23 @@ Calcium,Enfants 1 à 8 ans,2295,des,Soupes - sauces - Épices et autres ingrédi
 Calcium,Enfants 1 à 8 ans,761,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,2.9,0.5,1.8,3.9,mg,0.3,0.1,E,2
 Calcium,Enfants 1 à 8 ans,532,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,2,0.3,1.3,2.6,mg,0.2,0,,2
 Calcium,Enfants 1 à 8 ans,2205,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,15.6,1.2,13.3,17.8,mg,1.7,0.1,,2
-Calcium,Enfants 1 à 8 ans,2106,des,Confiseries - sucres et grignotines salées,,,,,33.9,2.7,28.6,39.2,mg,3.7,0.3,,1
-Calcium,Enfants 1 à 8 ans,1048,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,6.9,0.6,5.6,8.1,mg,0.7,0.1,,2
-Calcium,Enfants 1 à 8 ans,497,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,17.2,1.7,13.9,20.5,mg,1.9,0.2,,2
-Calcium,Enfants 1 à 8 ans,615,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,3.2,0.4,2.4,4.1,mg,0.4,0,,2
-Calcium,Enfants 1 à 8 ans,1642,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,6.6,2.2,2.3,10.9,mg,0.7,0.2,E,2
-Calcium,Enfants 1 à 8 ans,548,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,4.7,0.5,3.7,5.7,mg,0.5,0.1,,3
-Calcium,Enfants 1 à 8 ans,131,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,1.7,0.3,1.1,2.4,mg,0.2,0,E,3
-Calcium,Enfants 1 à 8 ans,557,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0.5,0.1,0.3,0.6,mg,0.1,0,E,3
-Calcium,Enfants 1 à 8 ans,346,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,16.6,1.7,13.3,20,mg,1.8,0.2,,3
-Calcium,Enfants 1 à 8 ans,184,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,F,F,,,mg,F,F,F,3
-Calcium,Enfants 1 à 8 ans,257,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.3,0,0.2,0.4,mg,0,0,,3
-Calcium,Enfants 1 à 8 ans,1341,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0.4,0,0.3,0.4,mg,0,0,,3
-Calcium,Enfants 1 à 8 ans,720,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,F,F,,,mg,F,F,F,3
-Calcium,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,mg,X,X,<10,3
+Calcium,Enfants 1 à 8 ans,2106,des,Confiserie - sucres et grignotines salées,,,,,33.9,2.7,28.6,39.2,mg,3.7,0.3,,1
+Calcium,Enfants 1 à 8 ans,1048,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,6.9,0.6,5.6,8.1,mg,0.7,0.1,,2
+Calcium,Enfants 1 à 8 ans,497,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,17.2,1.7,13.9,20.5,mg,1.9,0.2,,2
+Calcium,Enfants 1 à 8 ans,615,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,3.2,0.4,2.4,4.1,mg,0.4,0,,2
+Calcium,Enfants 1 à 8 ans,1642,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,6.6,2.2,2.3,10.9,mg,0.7,0.2,E,2
+Calcium,Enfants 1 à 8 ans,548,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,4.7,0.5,3.7,5.7,mg,0.5,0.1,,3
+Calcium,Enfants 1 à 8 ans,131,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,1.7,0.3,1.1,2.4,mg,0.2,0,E,3
+Calcium,Enfants 1 à 8 ans,557,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,0.5,0.1,0.3,0.6,mg,0.1,0,E,3
+Calcium,Enfants 1 à 8 ans,346,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,16.6,1.7,13.3,20,mg,1.8,0.2,,3
+Calcium,Enfants 1 à 8 ans,184,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,F,F,,,mg,F,F,F,3
+Calcium,Enfants 1 à 8 ans,257,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.3,0,0.2,0.4,mg,0,0,,3
+Calcium,Enfants 1 à 8 ans,1341,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0.4,0,0.3,0.4,mg,0,0,,3
+Calcium,Enfants 1 à 8 ans,720,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,F,F,,,mg,F,F,F,3
+Calcium,Enfants 1 à 8 ans,,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,mg,X,X,<10,3
 Glucides,Population 1 an et +,186,des,Aliments pour bébés,,,,,0.2,0,0.1,0.3,g,0.1,0,,1
 Glucides,Population 1 an et +,154,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0.1,0,0.1,0.2,g,0.1,0,,2
-Glucides,Population 1 an et +,51,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0,0,0,0.1,g,0,0,,2
+Glucides,Population 1 an et +,51,des,Aliments pour bébés,des,Préparation pour nourrissons,,,0,0,0,0.1,g,0,0,,2
 Glucides,Population 1 an et +,19574,des,Boissons (excluant laits),,,,,26.5,0.6,25.4,27.6,g,11.7,0.2,,1
 Glucides,Population 1 an et +,3540,des,Boissons (excluant laits),de l',Alcool,,,3.5,0.2,3.2,3.9,g,1.6,0.1,,2
 Glucides,Population 1 an et +,12127,des,Boissons (excluant laits),du,Café et thé,,,2,0.2,1.6,2.4,g,0.9,0.1,,2
@@ -477,7 +477,7 @@ Glucides,Population 1 an et +,4392,des,Produits laitiers et Boissons à base de 
 Glucides,Population 1 an et +,15629,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait nature,8.6,0.2,8.3,8.9,g,3.8,0.1,,3
 Glucides,Population 1 an et +,932,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait aromatisé,1.4,0.1,1.1,1.6,g,0.6,0.1,,3
 Glucides,Population 1 an et +,814,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0.6,0,0.5,0.7,g,0.3,0,,3
-Glucides,Population 1 an et +,4411,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0.5,0,0.4,0.6,g,0.2,0,,3
+Glucides,Population 1 an et +,4411,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,0.5,0,0.4,0.6,g,0.2,0,,3
 Glucides,Population 1 an et +,3676,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,du,Yogourt aromatisé,2.5,0.1,2.3,2.7,g,1.1,0,,3
 Glucides,Population 1 an et +,818,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,du,Yogourt nature,0.3,0,0.2,0.3,g,0.1,0,,3
 Glucides,Population 1 an et +,18258,des,Graisses et huiles,,,,,0.7,0,0.6,0.7,g,0.3,0,,1
@@ -493,8 +493,8 @@ Glucides,Population 1 an et +,924,des,Poissons et fruits de mer,des,Mollusques e
 Glucides,Population 1 an et +,18914,des,Fruits et légumes,,,,,44.6,0.6,43.5,45.8,g,19.7,0.2,,1
 Glucides,Population 1 an et +,13689,des,Fruits et légumes,des,Fruits,,,23.9,0.4,23.1,24.8,g,10.6,0.2,,2
 Glucides,Population 1 an et +,17977,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,20.7,0.4,20,21.4,g,9.2,0.1,,2
-Glucides,Population 1 an et +,5308,des,Fruits et légumes,des,Fruits,des,Bananes,6.7,0.2,6.3,7,g,2.9,0.1,,3
-Glucides,Population 1 an et +,5026,des,Fruits et légumes,des,Fruits,des,Pommes,5.7,0.2,5.3,6,g,2.5,0.1,,3
+Glucides,Population 1 an et +,5308,des,Fruits et légumes,des,Fruits,des,Banane,6.7,0.2,6.3,7,g,2.9,0.1,,3
+Glucides,Population 1 an et +,5026,des,Fruits et légumes,des,Fruits,des,Pomme,5.7,0.2,5.3,6,g,2.5,0.1,,3
 Glucides,Population 1 an et +,3372,des,Fruits et légumes,des,Fruits,des,Agrumes,2.3,0.1,2.1,2.5,g,1,0,,3
 Glucides,Population 1 an et +,2881,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,2,0.1,1.8,2.3,g,0.9,0.1,,3
 Glucides,Population 1 an et +,2103,des,Fruits et légumes,des,Fruits,des,Autres fruits,2,0.1,1.7,2.2,g,0.9,0.1,,3
@@ -512,7 +512,7 @@ Glucides,Population 1 an et +,6318,des,Fruits et légumes,des,Légumes incluant 
 Glucides,Population 1 an et +,19327,des,Produits céréaliers,,,,,95.3,0.9,93.6,96.9,g,42.1,0.3,,1
 Glucides,Population 1 an et +,16168,des,Produits céréaliers,des,Pains,,,41.5,0.6,40.3,42.6,g,18.3,0.2,,2
 Glucides,Population 1 an et +,6966,des,Produits céréaliers,des,Céréales pour déjeuner,,,10.1,0.3,9.5,10.6,g,4.4,0.1,,2
-Glucides,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,6.4,0.2,6,6.8,g,2.8,0.1,,2
+Glucides,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,6.4,0.2,6,6.8,g,2.8,0.1,,2
 Glucides,Population 1 an et +,14820,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,37.3,0.6,36.1,38.6,g,16.5,0.3,,2
 Glucides,Population 1 an et +,8159,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,17.1,0.4,16.3,18,g,7.6,0.2,,3
 Glucides,Population 1 an et +,6257,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,12.3,0.4,11.5,13.2,g,5.5,0.2,,3
@@ -520,10 +520,10 @@ Glucides,Population 1 an et +,5962,des,Produits céréaliers,des,Pains,des,Pains
 Glucides,Population 1 an et +,2918,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,2,0.1,1.8,2.2,g,0.9,0,,3
 Glucides,Population 1 an et +,4760,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,7.4,0.3,6.9,7.9,g,3.3,0.1,,3
 Glucides,Population 1 an et +,2573,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),2.7,0.1,2.4,2.9,g,1.2,0.1,,3
-Glucides,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,2.1,0.1,1.9,2.3,g,0.9,0.1,,3
-Glucides,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.2,0,0.2,0.3,g,0.1,0,,3
-Glucides,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.2,0,0.1,0.2,g,0.1,0,,3
-Glucides,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
+Glucides,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,2.1,0.1,1.9,2.3,g,0.9,0.1,,3
+Glucides,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0.2,0,0.2,0.3,g,0.1,0,,3
+Glucides,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.2,0,0.1,0.2,g,0.1,0,,3
+Glucides,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
 Glucides,Population 1 an et +,11102,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,16.4,0.4,15.6,17.2,g,7.2,0.2,,3
 Glucides,Population 1 an et +,4598,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,10.9,0.4,10.1,11.7,g,4.8,0.2,,3
 Glucides,Population 1 an et +,4543,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,10.1,0.3,9.4,10.7,g,4.4,0.2,,3
@@ -553,23 +553,23 @@ Glucides,Population 1 an et +,18438,des,Soupes - sauces - Épices et autres ingr
 Glucides,Population 1 an et +,7054,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,1.9,0.1,1.8,2.1,g,0.8,0,,2
 Glucides,Population 1 an et +,4710,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,1.8,0.1,1.6,2.1,g,0.8,0.1,,2
 Glucides,Population 1 an et +,17547,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.9,0,0.8,1,g,0.4,0,,2
-Glucides,Population 1 an et +,16725,des,Confiseries - sucres et grignotines salées,,,,,31.5,0.6,30.4,32.6,g,13.9,0.2,,1
-Glucides,Population 1 an et +,6211,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,6.2,0.3,5.5,6.8,g,2.7,0.1,,2
-Glucides,Population 1 an et +,2912,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,4.3,0.2,4,4.7,g,1.9,0.1,,2
-Glucides,Population 1 an et +,4652,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,5.7,0.3,5.2,6.2,g,2.5,0.1,,2
-Glucides,Population 1 an et +,14214,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,15.2,0.3,14.6,15.9,g,6.7,0.1,,2
-Glucides,Population 1 an et +,2559,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,3,0.3,2.5,3.6,g,1.3,0.1,,3
-Glucides,Population 1 an et +,3815,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,2.7,0.2,2.4,3,g,1.2,0.1,,3
-Glucides,Population 1 an et +,703,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0.5,0,0.4,0.6,g,0.2,0,,3
-Glucides,Population 1 an et +,2447,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,3.4,0.2,3.1,3.7,g,1.5,0.1,,3
-Glucides,Population 1 an et +,560,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,1,0.1,0.8,1.2,g,0.4,0,,3
-Glucides,Population 1 an et +,12217,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,8.9,0.2,8.5,9.3,g,3.9,0.1,,3
-Glucides,Population 1 an et +,4750,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,4.9,0.2,4.5,5.2,g,2.1,0.1,,3
-Glucides,Population 1 an et +,2044,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,1.4,0.1,1.2,1.7,g,0.6,0,,3
-Glucides,Population 1 an et +,715,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0.1,0,0.1,0.1,g,0,0,,3
+Glucides,Population 1 an et +,16725,des,Confiserie - sucres et grignotines salées,,,,,31.5,0.6,30.4,32.6,g,13.9,0.2,,1
+Glucides,Population 1 an et +,6211,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,6.2,0.3,5.5,6.8,g,2.7,0.1,,2
+Glucides,Population 1 an et +,2912,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,4.3,0.2,4,4.7,g,1.9,0.1,,2
+Glucides,Population 1 an et +,4652,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,5.7,0.3,5.2,6.2,g,2.5,0.1,,2
+Glucides,Population 1 an et +,14214,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,15.2,0.3,14.6,15.9,g,6.7,0.1,,2
+Glucides,Population 1 an et +,2559,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,3,0.3,2.5,3.6,g,1.3,0.1,,3
+Glucides,Population 1 an et +,3815,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,2.7,0.2,2.4,3,g,1.2,0.1,,3
+Glucides,Population 1 an et +,703,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0.5,0,0.4,0.6,g,0.2,0,,3
+Glucides,Population 1 an et +,2447,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,3.4,0.2,3.1,3.7,g,1.5,0.1,,3
+Glucides,Population 1 an et +,560,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,1,0.1,0.8,1.2,g,0.4,0,,3
+Glucides,Population 1 an et +,12217,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,8.9,0.2,8.5,9.3,g,3.9,0.1,,3
+Glucides,Population 1 an et +,4750,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,4.9,0.2,4.5,5.2,g,2.1,0.1,,3
+Glucides,Population 1 an et +,2044,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,1.4,0.1,1.2,1.7,g,0.6,0,,3
+Glucides,Population 1 an et +,715,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0.1,0,0.1,0.1,g,0,0,,3
 Glucides,Hommes adultes 19 ans +,22,des,Aliments pour bébés,,,,,0.1,0,0,0.2,g,0,0,,1
 Glucides,Hommes adultes 19 ans +,21,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0.1,0,0,0.2,g,0,0,,2
-Glucides,Hommes adultes 19 ans +,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,g,X,X,<10,2
+Glucides,Hommes adultes 19 ans +,,des,Aliments pour bébés,des,Préparation pour nourrissons,,,X,X,,,g,X,X,<10,2
 Glucides,Hommes adultes 19 ans +,6187,des,Boissons (excluant laits),,,,,33.2,1.1,31,35.5,g,13.2,0.4,,1
 Glucides,Hommes adultes 19 ans +,1946,des,Boissons (excluant laits),de l',Alcool,,,6.7,0.4,5.8,7.5,g,2.7,0.2,,2
 Glucides,Hommes adultes 19 ans +,5104,des,Boissons (excluant laits),du,Café et thé,,,2.6,0.5,1.6,3.5,g,1,0.2,E,2
@@ -590,7 +590,7 @@ Glucides,Hommes adultes 19 ans +,5221,des,Produits laitiers et Boissons à base 
 Glucides,Hommes adultes 19 ans +,926,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,,,2.1,0.2,1.8,2.5,g,0.8,0.1,,2
 Glucides,Hommes adultes 19 ans +,4710,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait nature,7.7,0.3,7.2,8.3,g,3.1,0.1,,3
 Glucides,Hommes adultes 19 ans +,188,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait aromatisé,1.4,0.2,1,1.9,g,0.6,0.1,,3
-Glucides,Hommes adultes 19 ans +,1727,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0.7,0.1,0.5,0.8,g,0.3,0,,3
+Glucides,Hommes adultes 19 ans +,1727,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,0.7,0.1,0.5,0.8,g,0.3,0,,3
 Glucides,Hommes adultes 19 ans +,208,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0.6,0.1,0.4,0.8,g,0.2,0,E,3
 Glucides,Hommes adultes 19 ans +,730,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,du,Yogourt aromatisé,1.9,0.2,1.6,2.2,g,0.8,0.1,,3
 Glucides,Hommes adultes 19 ans +,219,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,du,Yogourt nature,0.2,0,0.1,0.3,g,0.1,0,,3
@@ -607,8 +607,8 @@ Glucides,Hommes adultes 19 ans +,343,des,Poissons et fruits de mer,des,Mollusque
 Glucides,Hommes adultes 19 ans +,5918,des,Fruits et légumes,,,,,48,1.1,45.9,50.1,g,19.1,0.4,,1
 Glucides,Hommes adultes 19 ans +,3876,des,Fruits et légumes,des,Fruits,,,23.9,0.8,22.4,25.5,g,9.5,0.3,,2
 Glucides,Hommes adultes 19 ans +,5694,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,24.1,0.7,22.6,25.6,g,9.6,0.3,,2
-Glucides,Hommes adultes 19 ans +,1590,des,Fruits et légumes,des,Fruits,des,Bananes,7.7,0.4,7,8.4,g,3.1,0.1,,3
-Glucides,Hommes adultes 19 ans +,1350,des,Fruits et légumes,des,Fruits,des,Pommes,5.5,0.3,4.9,6.2,g,2.2,0.1,,3
+Glucides,Hommes adultes 19 ans +,1590,des,Fruits et légumes,des,Fruits,des,Banane,7.7,0.4,7,8.4,g,3.1,0.1,,3
+Glucides,Hommes adultes 19 ans +,1350,des,Fruits et légumes,des,Fruits,des,Pomme,5.5,0.3,4.9,6.2,g,2.2,0.1,,3
 Glucides,Hommes adultes 19 ans +,1019,des,Fruits et légumes,des,Fruits,des,Agrumes,2.2,0.2,1.9,2.5,g,0.9,0.1,,3
 Glucides,Hommes adultes 19 ans +,1066,des,Fruits et légumes,des,Fruits,des,Baies,1.8,0.2,1.4,2.2,g,0.7,0.1,,3
 Glucides,Hommes adultes 19 ans +,782,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,1.7,0.2,1.4,2,g,0.7,0.1,,3
@@ -626,7 +626,7 @@ Glucides,Hommes adultes 19 ans +,1991,des,Fruits et légumes,des,Légumes inclua
 Glucides,Hommes adultes 19 ans +,6068,des,Produits céréaliers,,,,,107.8,1.6,104.7,110.8,g,42.8,0.5,,1
 Glucides,Hommes adultes 19 ans +,5104,des,Produits céréaliers,des,Pains,,,48.4,1.1,46.2,50.7,g,19.2,0.4,,2
 Glucides,Hommes adultes 19 ans +,1921,des,Produits céréaliers,des,Céréales pour déjeuner,,,10.7,0.5,9.7,11.8,g,4.3,0.2,,2
-Glucides,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,6.3,0.4,5.5,7.1,g,2.5,0.2,,2
+Glucides,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,6.3,0.4,5.5,7.1,g,2.5,0.2,,2
 Glucides,Hommes adultes 19 ans +,4551,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,42.3,1.2,40,44.6,g,16.8,0.4,,2
 Glucides,Hommes adultes 19 ans +,2752,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,21.7,0.9,20,23.5,g,8.6,0.3,,3
 Glucides,Hommes adultes 19 ans +,1885,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,13.7,0.8,12.2,15.3,g,5.5,0.3,,3
@@ -634,9 +634,9 @@ Glucides,Hommes adultes 19 ans +,1980,des,Produits céréaliers,des,Pains,des,Pa
 Glucides,Hommes adultes 19 ans +,593,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,1.6,0.1,1.3,1.9,g,0.6,0.1,,3
 Glucides,Hommes adultes 19 ans +,1481,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,8.8,0.5,7.8,9.8,g,3.5,0.2,,3
 Glucides,Hommes adultes 19 ans +,523,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),1.9,0.2,1.5,2.3,g,0.8,0.1,,3
-Glucides,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,2.2,0.3,1.7,2.7,g,0.9,0.1,,3
-Glucides,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.3,0.1,0.1,0.5,g,0.1,0,E,3
-Glucides,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.2,g,0,0,,3
+Glucides,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,2.2,0.3,1.7,2.7,g,0.9,0.1,,3
+Glucides,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0.3,0.1,0.1,0.5,g,0.1,0,E,3
+Glucides,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.2,g,0,0,,3
 Glucides,Hommes adultes 19 ans +,3442,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,19.2,0.8,17.7,20.7,g,7.6,0.3,,3
 Glucides,Hommes adultes 19 ans +,1449,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,12.2,0.7,10.8,13.7,g,4.9,0.3,,3
 Glucides,Hommes adultes 19 ans +,1250,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,10.9,0.7,9.6,12.2,g,4.3,0.3,,3
@@ -666,23 +666,23 @@ Glucides,Hommes adultes 19 ans +,5856,des,Soupes - sauces - Épices et autres in
 Glucides,Hommes adultes 19 ans +,2384,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,2.4,0.2,2.1,2.7,g,1,0.1,,2
 Glucides,Hommes adultes 19 ans +,1511,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,2.2,0.3,1.7,2.7,g,0.9,0.1,,2
 Glucides,Hommes adultes 19 ans +,5575,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,1.1,0.1,1,1.3,g,0.5,0,,2
-Glucides,Hommes adultes 19 ans +,5232,des,Confiseries - sucres et grignotines salées,,,,,32.8,1.1,30.6,34.9,g,13,0.4,,1
-Glucides,Hommes adultes 19 ans +,1527,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,5.4,0.7,4,6.7,g,2.1,0.3,,2
-Glucides,Hommes adultes 19 ans +,771,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,3.8,0.3,3.1,4.5,g,1.5,0.1,,2
-Glucides,Hommes adultes 19 ans +,1268,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,6,0.5,5,7,g,2.4,0.2,,2
-Glucides,Hommes adultes 19 ans +,4671,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,17.6,0.6,16.4,18.8,g,7,0.2,,2
-Glucides,Hommes adultes 19 ans +,497,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,2.7,0.7,1.3,4.1,g,1.1,0.3,E,3
-Glucides,Hommes adultes 19 ans +,1023,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,2.4,0.2,2,2.7,g,0.9,0.1,,3
-Glucides,Hommes adultes 19 ans +,170,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0.3,0,0.2,0.4,g,0.1,0,,3
-Glucides,Hommes adultes 19 ans +,702,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,3,0.3,2.5,3.6,g,1.2,0.1,,3
-Glucides,Hommes adultes 19 ans +,80,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0.7,0.2,0.3,1.2,g,0.3,0.1,E,3
-Glucides,Hommes adultes 19 ans +,4068,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,10.6,0.4,9.9,11.3,g,4.2,0.1,,3
-Glucides,Hommes adultes 19 ans +,1360,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,5.1,0.3,4.5,5.8,g,2,0.1,,3
-Glucides,Hommes adultes 19 ans +,726,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,1.8,0.3,1.3,2.3,g,0.7,0.1,E,3
-Glucides,Hommes adultes 19 ans +,322,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0.1,0,0,0.1,g,0,0,,3
+Glucides,Hommes adultes 19 ans +,5232,des,Confiserie - sucres et grignotines salées,,,,,32.8,1.1,30.6,34.9,g,13,0.4,,1
+Glucides,Hommes adultes 19 ans +,1527,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,5.4,0.7,4,6.7,g,2.1,0.3,,2
+Glucides,Hommes adultes 19 ans +,771,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,3.8,0.3,3.1,4.5,g,1.5,0.1,,2
+Glucides,Hommes adultes 19 ans +,1268,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,6,0.5,5,7,g,2.4,0.2,,2
+Glucides,Hommes adultes 19 ans +,4671,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,17.6,0.6,16.4,18.8,g,7,0.2,,2
+Glucides,Hommes adultes 19 ans +,497,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,2.7,0.7,1.3,4.1,g,1.1,0.3,E,3
+Glucides,Hommes adultes 19 ans +,1023,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,2.4,0.2,2,2.7,g,0.9,0.1,,3
+Glucides,Hommes adultes 19 ans +,170,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0.3,0,0.2,0.4,g,0.1,0,,3
+Glucides,Hommes adultes 19 ans +,702,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,3,0.3,2.5,3.6,g,1.2,0.1,,3
+Glucides,Hommes adultes 19 ans +,80,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0.7,0.2,0.3,1.2,g,0.3,0.1,E,3
+Glucides,Hommes adultes 19 ans +,4068,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,10.6,0.4,9.9,11.3,g,4.2,0.1,,3
+Glucides,Hommes adultes 19 ans +,1360,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,5.1,0.3,4.5,5.8,g,2,0.1,,3
+Glucides,Hommes adultes 19 ans +,726,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,1.8,0.3,1.3,2.3,g,0.7,0.1,E,3
+Glucides,Hommes adultes 19 ans +,322,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0.1,0,0,0.1,g,0,0,,3
 Glucides,Femmes adultes* 19 ans +,21,des,Aliments pour bébés,,,,,F,F,,,g,F,F,F,1
 Glucides,Femmes adultes* 19 ans +,19,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,F,F,,,g,F,F,F,2
-Glucides,Femmes adultes* 19 ans +,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,g,X,X,<10,2
+Glucides,Femmes adultes* 19 ans +,,des,Aliments pour bébés,des,Préparation pour nourrissons,,,X,X,,,g,X,X,<10,2
 Glucides,Femmes adultes* 19 ans +,6828,des,Boissons (excluant laits),,,,,18.7,0.6,17.5,19.9,g,9.7,0.3,,1
 Glucides,Femmes adultes* 19 ans +,1439,des,Boissons (excluant laits),de l',Alcool,,,2.2,0.2,1.9,2.5,g,1.1,0.1,,2
 Glucides,Femmes adultes* 19 ans +,5777,des,Boissons (excluant laits),du,Café et thé,,,1.7,0.2,1.3,2,g,0.9,0.1,,2
@@ -702,7 +702,7 @@ Glucides,Femmes adultes* 19 ans +,3758,des,Produits laitiers et Boissons à base
 Glucides,Femmes adultes* 19 ans +,5851,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,8.2,0.2,7.7,8.7,g,4.2,0.1,,2
 Glucides,Femmes adultes* 19 ans +,1629,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,,,2.8,0.2,2.5,3.2,g,1.5,0.1,,2
 Glucides,Femmes adultes* 19 ans +,5294,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait nature,6.7,0.2,6.2,7.1,g,3.5,0.1,,3
-Glucides,Femmes adultes* 19 ans +,1769,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0.5,0,0.4,0.6,g,0.3,0,,3
+Glucides,Femmes adultes* 19 ans +,1769,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,0.5,0,0.4,0.6,g,0.3,0,,3
 Glucides,Femmes adultes* 19 ans +,358,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0.6,0.1,0.5,0.8,g,0.3,0,E,3
 Glucides,Femmes adultes* 19 ans +,105,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait aromatisé,0.4,0.1,0.2,0.5,g,0.2,0,E,3
 Glucides,Femmes adultes* 19 ans +,1295,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,du,Yogourt aromatisé,2.5,0.2,2.2,2.8,g,1.3,0.1,,3
@@ -720,8 +720,8 @@ Glucides,Femmes adultes* 19 ans +,370,des,Poissons et fruits de mer,des,Mollusqu
 Glucides,Femmes adultes* 19 ans +,6595,des,Fruits et légumes,,,,,43.3,0.8,41.7,45,g,22.5,0.4,,1
 Glucides,Femmes adultes* 19 ans +,4951,des,Fruits et légumes,des,Fruits,,,23.3,0.6,22.1,24.5,g,12.1,0.3,,2
 Glucides,Femmes adultes* 19 ans +,6291,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,20.1,0.5,19.1,21.1,g,10.4,0.3,,2
-Glucides,Femmes adultes* 19 ans +,1919,des,Fruits et légumes,des,Fruits,des,Bananes,6,0.3,5.5,6.6,g,3.1,0.1,,3
-Glucides,Femmes adultes* 19 ans +,1574,des,Fruits et légumes,des,Fruits,des,Pommes,4.9,0.3,4.3,5.4,g,2.5,0.1,,3
+Glucides,Femmes adultes* 19 ans +,1919,des,Fruits et légumes,des,Fruits,des,Banane,6,0.3,5.5,6.6,g,3.1,0.1,,3
+Glucides,Femmes adultes* 19 ans +,1574,des,Fruits et légumes,des,Fruits,des,Pomme,4.9,0.3,4.3,5.4,g,2.5,0.1,,3
 Glucides,Femmes adultes* 19 ans +,1356,des,Fruits et légumes,des,Fruits,des,Agrumes,2.6,0.2,2.3,2.9,g,1.3,0.1,,3
 Glucides,Femmes adultes* 19 ans +,1006,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,2.1,0.2,1.7,2.5,g,1.1,0.1,,3
 Glucides,Femmes adultes* 19 ans +,854,des,Fruits et légumes,des,Fruits,des,Autres fruits,2.2,0.2,1.8,2.6,g,1.1,0.1,,3
@@ -739,7 +739,7 @@ Glucides,Femmes adultes* 19 ans +,2348,des,Fruits et légumes,des,Légumes inclu
 Glucides,Femmes adultes* 19 ans +,6669,des,Produits céréaliers,,,,,79.1,1.2,76.6,81.5,g,41.1,0.5,,1
 Glucides,Femmes adultes* 19 ans +,5520,des,Produits céréaliers,des,Pains,,,35.2,0.7,33.7,36.6,g,18.3,0.3,,2
 Glucides,Femmes adultes* 19 ans +,2230,des,Produits céréaliers,des,Céréales pour déjeuner,,,8.2,0.4,7.4,8.9,g,4.2,0.2,,2
-Glucides,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,4.8,0.3,4.2,5.4,g,2.5,0.1,,2
+Glucides,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,4.8,0.3,4.2,5.4,g,2.5,0.1,,2
 Glucides,Femmes adultes* 19 ans +,4893,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,30.9,0.9,29.1,32.8,g,16.1,0.4,,2
 Glucides,Femmes adultes* 19 ans +,2551,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,13.4,0.5,12.4,14.4,g,7,0.3,,3
 Glucides,Femmes adultes* 19 ans +,1994,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,10.3,0.5,9.2,11.3,g,5.3,0.3,,3
@@ -747,10 +747,10 @@ Glucides,Femmes adultes* 19 ans +,2239,des,Produits céréaliers,des,Pains,des,P
 Glucides,Femmes adultes* 19 ans +,914,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,1.6,0.2,1.3,1.9,g,0.8,0.1,,3
 Glucides,Femmes adultes* 19 ans +,1756,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,6.6,0.3,6,7.3,g,3.4,0.2,,3
 Glucides,Femmes adultes* 19 ans +,555,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),1.5,0.1,1.3,1.8,g,0.8,0.1,,3
-Glucides,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,1.2,0.1,0.9,1.5,g,0.6,0.1,,3
-Glucides,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0.1,0.2,g,0.1,0,,3
-Glucides,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.2,g,0.1,0,,3
-Glucides,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
+Glucides,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,1.2,0.1,0.9,1.5,g,0.6,0.1,,3
+Glucides,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0.1,0.2,g,0.1,0,,3
+Glucides,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.2,g,0.1,0,,3
+Glucides,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
 Glucides,Femmes adultes* 19 ans +,3664,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,13.2,0.7,11.9,14.4,g,6.8,0.3,,3
 Glucides,Femmes adultes* 19 ans +,1522,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,9.5,0.5,8.5,10.5,g,5,0.3,,3
 Glucides,Femmes adultes* 19 ans +,1358,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,8.3,0.5,7.3,9.2,g,4.3,0.2,,3
@@ -780,23 +780,23 @@ Glucides,Femmes adultes* 19 ans +,6382,des,Soupes - sauces - Épices et autres i
 Glucides,Femmes adultes* 19 ans +,2243,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,1.5,0.1,1.3,1.7,g,0.8,0.1,,2
 Glucides,Femmes adultes* 19 ans +,1853,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,1.8,0.2,1.4,2.1,g,0.9,0.1,,2
 Glucides,Femmes adultes* 19 ans +,6077,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.9,0.1,0.7,1,g,0.4,0,,2
-Glucides,Femmes adultes* 19 ans +,5713,des,Confiseries - sucres et grignotines salées,,,,,27.2,0.8,25.6,28.8,g,14.1,0.4,,1
-Glucides,Femmes adultes* 19 ans +,1936,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,5.9,0.5,4.8,7,g,3.1,0.3,,2
-Glucides,Femmes adultes* 19 ans +,844,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,3.3,0.3,2.8,3.8,g,1.7,0.1,,2
-Glucides,Femmes adultes* 19 ans +,1411,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,4.7,0.4,3.9,5.4,g,2.4,0.2,,2
-Glucides,Femmes adultes* 19 ans +,4937,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,13.3,0.4,12.4,14.1,g,6.9,0.2,,2
-Glucides,Femmes adultes* 19 ans +,1238,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,2.9,0.3,2.2,3.6,g,1.5,0.2,,3
-Glucides,Femmes adultes* 19 ans +,685,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,2.5,0.3,1.9,3.2,g,1.3,0.2,,3
-Glucides,Femmes adultes* 19 ans +,229,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0.5,0.1,0.4,0.7,g,0.3,0,E,3
-Glucides,Femmes adultes* 19 ans +,762,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,3,0.2,2.5,3.5,g,1.6,0.1,,3
-Glucides,Femmes adultes* 19 ans +,87,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0.3,0.1,0.2,0.4,g,0.2,0,E,3
-Glucides,Femmes adultes* 19 ans +,4229,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,8.2,0.3,7.6,8.8,g,4.3,0.2,,3
-Glucides,Femmes adultes* 19 ans +,1529,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,3.8,0.3,3.3,4.4,g,2,0.1,,3
-Glucides,Femmes adultes* 19 ans +,773,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,1.1,0.1,0.9,1.3,g,0.6,0.1,,3
-Glucides,Femmes adultes* 19 ans +,360,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0.1,0,0.1,0.1,g,0.1,0,,3
+Glucides,Femmes adultes* 19 ans +,5713,des,Confiserie - sucres et grignotines salées,,,,,27.2,0.8,25.6,28.8,g,14.1,0.4,,1
+Glucides,Femmes adultes* 19 ans +,1936,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,5.9,0.5,4.8,7,g,3.1,0.3,,2
+Glucides,Femmes adultes* 19 ans +,844,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,3.3,0.3,2.8,3.8,g,1.7,0.1,,2
+Glucides,Femmes adultes* 19 ans +,1411,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,4.7,0.4,3.9,5.4,g,2.4,0.2,,2
+Glucides,Femmes adultes* 19 ans +,4937,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,13.3,0.4,12.4,14.1,g,6.9,0.2,,2
+Glucides,Femmes adultes* 19 ans +,1238,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,2.9,0.3,2.2,3.6,g,1.5,0.2,,3
+Glucides,Femmes adultes* 19 ans +,685,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,2.5,0.3,1.9,3.2,g,1.3,0.2,,3
+Glucides,Femmes adultes* 19 ans +,229,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0.5,0.1,0.4,0.7,g,0.3,0,E,3
+Glucides,Femmes adultes* 19 ans +,762,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,3,0.2,2.5,3.5,g,1.6,0.1,,3
+Glucides,Femmes adultes* 19 ans +,87,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0.3,0.1,0.2,0.4,g,0.2,0,E,3
+Glucides,Femmes adultes* 19 ans +,4229,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,8.2,0.3,7.6,8.8,g,4.3,0.2,,3
+Glucides,Femmes adultes* 19 ans +,1529,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,3.8,0.3,3.3,4.4,g,2,0.1,,3
+Glucides,Femmes adultes* 19 ans +,773,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,1.1,0.1,0.9,1.3,g,0.6,0.1,,3
+Glucides,Femmes adultes* 19 ans +,360,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0.1,0,0.1,0.1,g,0.1,0,,3
 Glucides,Enfants 1 à 8 ans,122,des,Aliments pour bébés,,,,,1.3,0.3,0.8,1.8,g,0.6,0.1,E,1
 Glucides,Enfants 1 à 8 ans,95,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0.8,0.2,0.4,1.1,g,0.4,0.1,E,2
-Glucides,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0.5,0.1,0.2,0.8,g,0.2,0.1,E,2
+Glucides,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparation pour nourrissons,,,0.5,0.1,0.2,0.8,g,0.2,0.1,E,2
 Glucides,Enfants 1 à 8 ans,2443,des,Boissons (excluant laits),,,,,21.2,0.8,19.6,22.8,g,10.1,0.4,,1
 Glucides,Enfants 1 à 8 ans,20,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0.1,g,0,0,,2
 Glucides,Enfants 1 à 8 ans,141,des,Boissons (excluant laits),du,Café et thé,,,0.6,0.1,0.3,0.8,g,0.3,0.1,E,2
@@ -818,7 +818,7 @@ Glucides,Enfants 1 à 8 ans,1032,des,Produits laitiers et Boissons à base de pl
 Glucides,Enfants 1 à 8 ans,2242,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait nature,15.3,0.5,14.4,16.2,g,7.3,0.2,,3
 Glucides,Enfants 1 à 8 ans,217,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait aromatisé,2.5,0.3,1.9,3.1,g,1.2,0.1,,3
 Glucides,Enfants 1 à 8 ans,128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0.5,0.1,0.3,0.7,g,0.2,0,E,3
-Glucides,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0.3,0.1,0,0.5,g,0.1,0.1,E,3
+Glucides,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,0.3,0.1,0,0.5,g,0.1,0.1,E,3
 Glucides,Enfants 1 à 8 ans,948,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,du,Yogourt aromatisé,5.6,0.3,5,6.2,g,2.7,0.1,,3
 Glucides,Enfants 1 à 8 ans,109,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,du,Yogourt nature,0.2,0,0.1,0.3,g,0.1,0,,3
 Glucides,Enfants 1 à 8 ans,2270,des,Graisses et huiles,,,,,0.2,0,0.2,0.3,g,0.1,0,,1
@@ -834,8 +834,8 @@ Glucides,Enfants 1 à 8 ans,50,des,Poissons et fruits de mer,des,Mollusques et c
 Glucides,Enfants 1 à 8 ans,2428,des,Fruits et légumes,,,,,39.9,1.1,37.7,42.1,g,19.1,0.5,,1
 Glucides,Enfants 1 à 8 ans,2117,des,Fruits et légumes,des,Fruits,,,27.3,0.9,25.5,29,g,13,0.4,,2
 Glucides,Enfants 1 à 8 ans,2235,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,12.6,0.5,11.6,13.6,g,6,0.2,,2
-Glucides,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pommes,7.9,0.5,6.9,8.9,g,3.8,0.2,,3
-Glucides,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Bananes,6.6,0.4,5.9,7.4,g,3.2,0.2,,3
+Glucides,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pomme,7.9,0.5,6.9,8.9,g,3.8,0.2,,3
+Glucides,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Banane,6.6,0.4,5.9,7.4,g,3.2,0.2,,3
 Glucides,Enfants 1 à 8 ans,572,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,3.1,0.5,2.2,4,g,1.5,0.2,,3
 Glucides,Enfants 1 à 8 ans,830,des,Fruits et légumes,des,Fruits,des,Baies,2.5,0.2,2.1,3,g,1.2,0.1,,3
 Glucides,Enfants 1 à 8 ans,421,des,Fruits et légumes,des,Fruits,des,Agrumes,2.1,0.2,1.7,2.4,g,1,0.1,,3
@@ -853,7 +853,7 @@ Glucides,Enfants 1 à 8 ans,875,des,Fruits et légumes,des,Légumes incluant pom
 Glucides,Enfants 1 à 8 ans,2475,des,Produits céréaliers,,,,,85.5,1.6,82.3,88.8,g,40.9,0.6,,1
 Glucides,Enfants 1 à 8 ans,2114,des,Produits céréaliers,des,Pains,,,33,1.1,30.8,35.3,g,15.8,0.5,,2
 Glucides,Enfants 1 à 8 ans,1282,des,Produits céréaliers,des,Céréales pour déjeuner,,,11.1,0.5,10.2,12,g,5.3,0.2,,2
-Glucides,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,8.9,0.5,7.9,9.8,g,4.2,0.2,,2
+Glucides,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,8.9,0.5,7.9,9.8,g,4.2,0.2,,2
 Glucides,Enfants 1 à 8 ans,2037,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,32.6,1.2,30.3,34.9,g,15.6,0.5,,2
 Glucides,Enfants 1 à 8 ans,951,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,12.4,0.9,10.6,14.2,g,5.9,0.4,,3
 Glucides,Enfants 1 à 8 ans,805,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,9,0.7,7.6,10.5,g,4.3,0.3,,3
@@ -861,9 +861,9 @@ Glucides,Enfants 1 à 8 ans,813,des,Produits céréaliers,des,Pains,des,Pains et
 Glucides,Enfants 1 à 8 ans,745,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,4.2,0.4,3.4,5,g,2,0.2,,3
 Glucides,Enfants 1 à 8 ans,670,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),5.6,0.4,4.9,6.3,g,2.7,0.2,,3
 Glucides,Enfants 1 à 8 ans,728,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,5.4,0.4,4.7,6.2,g,2.6,0.2,,3
-Glucides,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,2.4,0.2,2,2.8,g,1.1,0.1,,3
-Glucides,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.3,0.1,0.1,0.5,g,0.2,0.1,E,3
-Glucides,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.3,0.1,0,0.5,g,0.1,0.1,E,3
+Glucides,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,2.4,0.2,2,2.8,g,1.1,0.1,,3
+Glucides,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0.3,0.1,0.1,0.5,g,0.2,0.1,E,3
+Glucides,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.3,0.1,0,0.5,g,0.1,0.1,E,3
 Glucides,Enfants 1 à 8 ans,1461,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,12.6,0.8,11,14.2,g,6,0.4,,3
 Glucides,Enfants 1 à 8 ans,834,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,11.1,0.8,9.5,12.7,g,5.3,0.4,,3
 Glucides,Enfants 1 à 8 ans,654,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,8.9,0.6,7.6,10.1,g,4.2,0.3,,3
@@ -893,23 +893,23 @@ Glucides,Enfants 1 à 8 ans,2295,des,Soupes - sauces - Épices et autres ingréd
 Glucides,Enfants 1 à 8 ans,761,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,1.2,0.2,0.9,1.5,g,0.6,0.1,E,2
 Glucides,Enfants 1 à 8 ans,532,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,1,0.2,0.7,1.4,g,0.5,0.1,E,2
 Glucides,Enfants 1 à 8 ans,2205,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.4,0,0.3,0.5,g,0.2,0,,2
-Glucides,Enfants 1 à 8 ans,2106,des,Confiseries - sucres et grignotines salées,,,,,28.2,1.2,25.9,30.6,g,13.5,0.5,,1
-Glucides,Enfants 1 à 8 ans,1048,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,7.2,0.5,6.3,8.2,g,3.5,0.2,,2
-Glucides,Enfants 1 à 8 ans,497,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,5.9,0.6,4.7,7,g,2.8,0.3,,2
-Glucides,Enfants 1 à 8 ans,615,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,3.9,0.4,3.2,4.6,g,1.9,0.2,,2
-Glucides,Enfants 1 à 8 ans,1642,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,11.2,0.7,9.8,12.7,g,5.4,0.3,,2
-Glucides,Enfants 1 à 8 ans,557,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,4.1,0.4,3.4,4.9,g,2,0.2,,3
-Glucides,Enfants 1 à 8 ans,548,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,2.1,0.2,1.7,2.5,g,1,0.1,,3
-Glucides,Enfants 1 à 8 ans,131,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,1,0.2,0.6,1.3,g,0.5,0.1,E,3
-Glucides,Enfants 1 à 8 ans,346,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,3.3,0.3,2.6,4,g,1.6,0.2,,3
-Glucides,Enfants 1 à 8 ans,184,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,2.6,0.4,1.7,3.4,g,1.2,0.2,,3
-Glucides,Enfants 1 à 8 ans,720,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,5.7,0.5,4.6,6.7,g,2.7,0.2,,3
-Glucides,Enfants 1 à 8 ans,1341,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,4.5,0.3,3.8,5.2,g,2.1,0.2,,3
-Glucides,Enfants 1 à 8 ans,257,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,1.1,0.2,0.7,1.4,g,0.5,0.1,E,3
-Glucides,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,g,X,X,<10,3
+Glucides,Enfants 1 à 8 ans,2106,des,Confiserie - sucres et grignotines salées,,,,,28.2,1.2,25.9,30.6,g,13.5,0.5,,1
+Glucides,Enfants 1 à 8 ans,1048,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,7.2,0.5,6.3,8.2,g,3.5,0.2,,2
+Glucides,Enfants 1 à 8 ans,497,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,5.9,0.6,4.7,7,g,2.8,0.3,,2
+Glucides,Enfants 1 à 8 ans,615,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,3.9,0.4,3.2,4.6,g,1.9,0.2,,2
+Glucides,Enfants 1 à 8 ans,1642,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,11.2,0.7,9.8,12.7,g,5.4,0.3,,2
+Glucides,Enfants 1 à 8 ans,557,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,4.1,0.4,3.4,4.9,g,2,0.2,,3
+Glucides,Enfants 1 à 8 ans,548,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,2.1,0.2,1.7,2.5,g,1,0.1,,3
+Glucides,Enfants 1 à 8 ans,131,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,1,0.2,0.6,1.3,g,0.5,0.1,E,3
+Glucides,Enfants 1 à 8 ans,346,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,3.3,0.3,2.6,4,g,1.6,0.2,,3
+Glucides,Enfants 1 à 8 ans,184,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,2.6,0.4,1.7,3.4,g,1.2,0.2,,3
+Glucides,Enfants 1 à 8 ans,720,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,5.7,0.5,4.6,6.7,g,2.7,0.2,,3
+Glucides,Enfants 1 à 8 ans,1341,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,4.5,0.3,3.8,5.2,g,2.1,0.2,,3
+Glucides,Enfants 1 à 8 ans,257,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,1.1,0.2,0.7,1.4,g,0.5,0.1,E,3
+Glucides,Enfants 1 à 8 ans,,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,g,X,X,<10,3
 Fibres alimentaires,Population 1 an et +,186,des,Aliments pour bébés,,,,,0,0,0,0,g,0.1,0,,1
 Fibres alimentaires,Population 1 an et +,154,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0,g,0.1,0,,2
-Fibres alimentaires,Population 1 an et +,51,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0,0,0,0,g,0,0,,2
+Fibres alimentaires,Population 1 an et +,51,des,Aliments pour bébés,des,Préparation pour nourrissons,,,0,0,0,0,g,0,0,,2
 Fibres alimentaires,Population 1 an et +,19574,des,Boissons (excluant laits),,,,,0.3,0,0.3,0.3,g,1.7,0,,1
 Fibres alimentaires,Population 1 an et +,3540,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0,g,0,0,,2
 Fibres alimentaires,Population 1 an et +,12127,des,Boissons (excluant laits),du,Café et thé,,,0,0,0,0,g,0,0,,2
@@ -931,7 +931,7 @@ Fibres alimentaires,Population 1 an et +,4392,des,Produits laitiers et Boissons 
 Fibres alimentaires,Population 1 an et +,6481,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,0,0,0,0,g,0.2,0,,3
 Fibres alimentaires,Population 1 an et +,12441,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,0,0,0,0,g,0.2,0,,3
 Fibres alimentaires,Population 1 an et +,814,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0,0,0,0,g,0.2,0,,3
-Fibres alimentaires,Population 1 an et +,4411,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Population 1 an et +,4411,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,0,0,0,0,g,0,0,,3
 Fibres alimentaires,Population 1 an et +,6026,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0,0,0,0,g,0,0,,3
 Fibres alimentaires,Population 1 an et +,5835,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,0,0,0,0,g,0,0,,3
 Fibres alimentaires,Population 1 an et +,18258,des,Graisses et huiles,,,,,0,0,0,0,g,0.1,0,,1
@@ -947,8 +947,8 @@ Fibres alimentaires,Population 1 an et +,924,des,Poissons et fruits de mer,des,M
 Fibres alimentaires,Population 1 an et +,18914,des,Fruits et légumes,,,,,6.7,0.1,6.5,6.8,g,39.6,0.4,,1
 Fibres alimentaires,Population 1 an et +,13689,des,Fruits et légumes,des,Fruits,,,3,0.1,2.9,3.1,g,17.9,0.3,,2
 Fibres alimentaires,Population 1 an et +,17977,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,3.7,0.1,3.5,3.8,g,21.7,0.3,,2
-Fibres alimentaires,Population 1 an et +,5026,des,Fruits et légumes,des,Fruits,des,Pommes,0.8,0,0.7,0.8,g,4.5,0.1,,3
-Fibres alimentaires,Population 1 an et +,5308,des,Fruits et légumes,des,Fruits,des,Bananes,0.5,0,0.5,0.5,g,3,0.1,,3
+Fibres alimentaires,Population 1 an et +,5026,des,Fruits et légumes,des,Fruits,des,Pomme,0.8,0,0.7,0.8,g,4.5,0.1,,3
+Fibres alimentaires,Population 1 an et +,5308,des,Fruits et légumes,des,Fruits,des,Banane,0.5,0,0.5,0.5,g,3,0.1,,3
 Fibres alimentaires,Population 1 an et +,4326,des,Fruits et légumes,des,Fruits,des,Baies,0.4,0,0.4,0.5,g,2.5,0.1,,3
 Fibres alimentaires,Population 1 an et +,2103,des,Fruits et légumes,des,Fruits,des,Autres fruits,0.4,0,0.3,0.4,g,2.4,0.1,,3
 Fibres alimentaires,Population 1 an et +,3372,des,Fruits et légumes,des,Fruits,des,Agrumes,0.4,0,0.3,0.4,g,2.1,0.1,,3
@@ -966,7 +966,7 @@ Fibres alimentaires,Population 1 an et +,6318,des,Fruits et légumes,des,Légume
 Fibres alimentaires,Population 1 an et +,19327,des,Produits céréaliers,,,,,6.7,0.1,6.5,6.8,g,39.7,0.4,,1
 Fibres alimentaires,Population 1 an et +,16168,des,Produits céréaliers,des,Pains,,,3.5,0.1,3.4,3.6,g,20.8,0.3,,2
 Fibres alimentaires,Population 1 an et +,6966,des,Produits céréaliers,des,Céréales pour déjeuner,,,1.3,0,1.2,1.4,g,7.6,0.3,,2
-Fibres alimentaires,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.3,0,0.3,0.4,g,2,0.1,,2
+Fibres alimentaires,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,0.3,0,0.3,0.4,g,2,0.1,,2
 Fibres alimentaires,Population 1 an et +,14820,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,1.6,0,1.5,1.6,g,9.3,0.2,,2
 Fibres alimentaires,Population 1 an et +,5962,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,1.4,0,1.3,1.4,g,8.1,0.2,,3
 Fibres alimentaires,Population 1 an et +,6257,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,1,0,0.9,1.1,g,6,0.3,,3
@@ -974,10 +974,10 @@ Fibres alimentaires,Population 1 an et +,8159,des,Produits céréaliers,des,Pain
 Fibres alimentaires,Population 1 an et +,2918,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.1,0,0.1,0.1,g,0.7,0,,3
 Fibres alimentaires,Population 1 an et +,4760,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,1.1,0,1,1.2,g,6.7,0.3,,3
 Fibres alimentaires,Population 1 an et +,2573,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.2,0,0.1,0.2,g,1,0,,3
-Fibres alimentaires,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.2,0,0.2,0.2,g,1.1,0.1,,3
-Fibres alimentaires,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0.1,0,,3
-Fibres alimentaires,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
+Fibres alimentaires,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,0.2,0,0.2,0.2,g,1.1,0.1,,3
+Fibres alimentaires,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0.1,0,,3
+Fibres alimentaires,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
 Fibres alimentaires,Population 1 an et +,11102,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.8,0,0.8,0.9,g,4.8,0.1,,3
 Fibres alimentaires,Population 1 an et +,4543,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.5,0,0.5,0.5,g,3,0.1,,3
 Fibres alimentaires,Population 1 an et +,4598,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0.3,0,0.2,0.3,g,1.6,0.1,,3
@@ -1007,23 +1007,23 @@ Fibres alimentaires,Population 1 an et +,18438,des,Soupes - sauces - Épices et 
 Fibres alimentaires,Population 1 an et +,7054,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.1,0,0.1,0.2,g,0.9,0,,2
 Fibres alimentaires,Population 1 an et +,4710,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0.2,0,0.2,0.3,g,1.4,0.1,,2
 Fibres alimentaires,Population 1 an et +,17547,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.2,0,0.2,0.2,g,1.3,0,,2
-Fibres alimentaires,Population 1 an et +,16725,des,Confiseries - sucres et grignotines salées,,,,,0.8,0,0.8,0.9,g,5,0.2,,1
-Fibres alimentaires,Population 1 an et +,6211,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,0.2,0,0.2,0.2,g,1.2,0.1,,2
-Fibres alimentaires,Population 1 an et +,2912,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,0.1,0,0.1,0.1,g,0.6,0,,2
-Fibres alimentaires,Population 1 an et +,4652,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0.5,0,0.4,0.5,g,2.8,0.1,,2
-Fibres alimentaires,Population 1 an et +,14214,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.1,0,0.1,0.1,g,0.5,0,,2
-Fibres alimentaires,Population 1 an et +,3815,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0.2,0,0.1,0.2,g,1,0,,3
-Fibres alimentaires,Population 1 an et +,2559,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0,0,0,0,g,0.2,0,,3
-Fibres alimentaires,Population 1 an et +,703,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Population 1 an et +,2447,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.1,0,0.1,0.1,g,0.6,0,,3
-Fibres alimentaires,Population 1 an et +,560,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Population 1 an et +,4750,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.1,0,0,0.1,g,0.3,0,,3
-Fibres alimentaires,Population 1 an et +,2044,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0.1,0,,3
-Fibres alimentaires,Population 1 an et +,715,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Population 1 an et +,12217,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Population 1 an et +,16725,des,Confiserie - sucres et grignotines salées,,,,,0.8,0,0.8,0.9,g,5,0.2,,1
+Fibres alimentaires,Population 1 an et +,6211,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,0.2,0,0.2,0.2,g,1.2,0.1,,2
+Fibres alimentaires,Population 1 an et +,2912,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,0.1,0,0.1,0.1,g,0.6,0,,2
+Fibres alimentaires,Population 1 an et +,4652,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,0.5,0,0.4,0.5,g,2.8,0.1,,2
+Fibres alimentaires,Population 1 an et +,14214,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.1,0,0.1,0.1,g,0.5,0,,2
+Fibres alimentaires,Population 1 an et +,3815,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,0.2,0,0.1,0.2,g,1,0,,3
+Fibres alimentaires,Population 1 an et +,2559,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,0,0,0,0,g,0.2,0,,3
+Fibres alimentaires,Population 1 an et +,703,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Population 1 an et +,2447,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.1,0,0.1,0.1,g,0.6,0,,3
+Fibres alimentaires,Population 1 an et +,560,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Population 1 an et +,4750,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.1,0,0,0.1,g,0.3,0,,3
+Fibres alimentaires,Population 1 an et +,2044,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0.1,0,,3
+Fibres alimentaires,Population 1 an et +,715,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Population 1 an et +,12217,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
 Fibres alimentaires,Hommes adultes 19 ans +,22,des,Aliments pour bébés,,,,,0,0,0,0,g,0.1,0,,1
 Fibres alimentaires,Hommes adultes 19 ans +,21,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0,g,0.1,0,,2
-Fibres alimentaires,Hommes adultes 19 ans +,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,g,X,X,<10,2
+Fibres alimentaires,Hommes adultes 19 ans +,,des,Aliments pour bébés,des,Préparation pour nourrissons,,,X,X,,,g,X,X,<10,2
 Fibres alimentaires,Hommes adultes 19 ans +,6187,des,Boissons (excluant laits),,,,,0.3,0,0.3,0.3,g,1.5,0.1,,1
 Fibres alimentaires,Hommes adultes 19 ans +,1946,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0,g,0,0,,2
 Fibres alimentaires,Hommes adultes 19 ans +,5104,des,Boissons (excluant laits),du,Café et thé,,,0,0,0,0,g,0,0,,2
@@ -1046,7 +1046,7 @@ Fibres alimentaires,Hommes adultes 19 ans +,1819,des,Produits laitiers et Boisso
 Fibres alimentaires,Hommes adultes 19 ans +,208,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0,0,0,0,g,0.2,0,,3
 Fibres alimentaires,Hommes adultes 19 ans +,3759,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,0,0,0,0,g,0.1,0,,3
 Fibres alimentaires,Hommes adultes 19 ans +,1648,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,0,0,0,0,g,0.1,0,,3
-Fibres alimentaires,Hommes adultes 19 ans +,1727,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Hommes adultes 19 ans +,1727,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,0,0,0,0,g,0,0,,3
 Fibres alimentaires,Hommes adultes 19 ans +,1812,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0,0,0,0,g,0,0,,3
 Fibres alimentaires,Hommes adultes 19 ans +,5767,des,Graisses et huiles,,,,,0,0,0,0,g,0.1,0,,1
 Fibres alimentaires,Hommes adultes 19 ans +,333,des,Graisses et huiles,des,Graisses animales,,,0,0,0,0,g,0,0,,2
@@ -1061,8 +1061,8 @@ Fibres alimentaires,Hommes adultes 19 ans +,343,des,Poissons et fruits de mer,de
 Fibres alimentaires,Hommes adultes 19 ans +,5918,des,Fruits et légumes,,,,,6.9,0.1,6.7,7.2,g,37.8,0.6,,1
 Fibres alimentaires,Hommes adultes 19 ans +,3876,des,Fruits et légumes,des,Fruits,,,2.9,0.1,2.7,3.1,g,15.7,0.4,,2
 Fibres alimentaires,Hommes adultes 19 ans +,5694,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,4.1,0.1,3.9,4.3,g,22.1,0.5,,2
-Fibres alimentaires,Hommes adultes 19 ans +,1350,des,Fruits et légumes,des,Fruits,des,Pommes,0.7,0,0.7,0.8,g,4.1,0.2,,3
-Fibres alimentaires,Hommes adultes 19 ans +,1590,des,Fruits et légumes,des,Fruits,des,Bananes,0.6,0,0.5,0.6,g,3.2,0.1,,3
+Fibres alimentaires,Hommes adultes 19 ans +,1350,des,Fruits et légumes,des,Fruits,des,Pomme,0.7,0,0.7,0.8,g,4.1,0.2,,3
+Fibres alimentaires,Hommes adultes 19 ans +,1590,des,Fruits et légumes,des,Fruits,des,Banane,0.6,0,0.5,0.6,g,3.2,0.1,,3
 Fibres alimentaires,Hommes adultes 19 ans +,1066,des,Fruits et légumes,des,Fruits,des,Baies,0.3,0,0.3,0.4,g,1.9,0.2,,3
 Fibres alimentaires,Hommes adultes 19 ans +,603,des,Fruits et légumes,des,Fruits,des,Autres fruits,0.3,0,0.3,0.4,g,1.9,0.2,,3
 Fibres alimentaires,Hommes adultes 19 ans +,1019,des,Fruits et légumes,des,Fruits,des,Agrumes,0.3,0,0.3,0.4,g,1.8,0.1,,3
@@ -1080,7 +1080,7 @@ Fibres alimentaires,Hommes adultes 19 ans +,1991,des,Fruits et légumes,des,Lég
 Fibres alimentaires,Hommes adultes 19 ans +,6068,des,Produits céréaliers,,,,,7.6,0.1,7.3,7.8,g,41.1,0.6,,1
 Fibres alimentaires,Hommes adultes 19 ans +,5104,des,Produits céréaliers,des,Pains,,,4,0.1,3.8,4.2,g,21.9,0.6,,2
 Fibres alimentaires,Hommes adultes 19 ans +,1921,des,Produits céréaliers,des,Céréales pour déjeuner,,,1.4,0.1,1.2,1.5,g,7.6,0.4,,2
-Fibres alimentaires,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.3,0,0.3,0.4,g,1.9,0.2,,2
+Fibres alimentaires,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,0.3,0,0.3,0.4,g,1.9,0.2,,2
 Fibres alimentaires,Hommes adultes 19 ans +,4551,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,1.8,0.1,1.7,1.9,g,9.7,0.3,,2
 Fibres alimentaires,Hommes adultes 19 ans +,1980,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,1.5,0.1,1.4,1.7,g,8.4,0.4,,3
 Fibres alimentaires,Hommes adultes 19 ans +,2752,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,1.2,0,1.2,1.3,g,6.8,0.3,,3
@@ -1088,9 +1088,9 @@ Fibres alimentaires,Hommes adultes 19 ans +,1885,des,Produits céréaliers,des,P
 Fibres alimentaires,Hommes adultes 19 ans +,593,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.1,0,0.1,0.1,g,0.5,0.1,,3
 Fibres alimentaires,Hommes adultes 19 ans +,1481,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,1.3,0.1,1.1,1.4,g,7,0.4,,3
 Fibres alimentaires,Hommes adultes 19 ans +,523,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.1,0,0.1,0.1,g,0.6,0.1,,3
-Fibres alimentaires,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.2,0,0.1,0.3,g,1.1,0.1,,3
-Fibres alimentaires,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,0.2,0,0.1,0.3,g,1.1,0.1,,3
+Fibres alimentaires,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
 Fibres alimentaires,Hommes adultes 19 ans +,3442,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.9,0,0.9,1,g,5.1,0.2,,3
 Fibres alimentaires,Hommes adultes 19 ans +,1250,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.5,0,0.5,0.6,g,3,0.2,,3
 Fibres alimentaires,Hommes adultes 19 ans +,1449,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0.3,0,0.3,0.3,g,1.6,0.1,,3
@@ -1120,23 +1120,23 @@ Fibres alimentaires,Hommes adultes 19 ans +,5856,des,Soupes - sauces - Épices e
 Fibres alimentaires,Hommes adultes 19 ans +,2384,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.2,0,0.2,0.2,g,1,0.1,,2
 Fibres alimentaires,Hommes adultes 19 ans +,1511,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0.3,0,0.2,0.4,g,1.6,0.2,,2
 Fibres alimentaires,Hommes adultes 19 ans +,5575,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.2,0,0.2,0.3,g,1.3,0.1,,2
-Fibres alimentaires,Hommes adultes 19 ans +,5232,des,Confiseries - sucres et grignotines salées,,,,,0.8,0,0.7,0.9,g,4.4,0.2,,1
-Fibres alimentaires,Hommes adultes 19 ans +,1527,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,0.2,0,0.2,0.2,g,1,0.1,,2
-Fibres alimentaires,Hommes adultes 19 ans +,771,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,0.1,0,0.1,0.1,g,0.5,0,,2
-Fibres alimentaires,Hommes adultes 19 ans +,1268,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0.5,0,0.4,0.6,g,2.6,0.2,,2
-Fibres alimentaires,Hommes adultes 19 ans +,4671,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.1,0,0.1,0.1,g,0.3,0,,2
-Fibres alimentaires,Hommes adultes 19 ans +,1023,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0.2,0,0.1,0.2,g,0.8,0.1,,3
-Fibres alimentaires,Hommes adultes 19 ans +,497,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0,0,0,0,g,0.1,0.1,,3
-Fibres alimentaires,Hommes adultes 19 ans +,170,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Hommes adultes 19 ans +,702,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.1,0,0.1,0.1,g,0.5,0,,3
-Fibres alimentaires,Hommes adultes 19 ans +,80,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Hommes adultes 19 ans +,726,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0.2,0,,3
-Fibres alimentaires,Hommes adultes 19 ans +,1360,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0,0,0,0,g,0.2,0,,3
-Fibres alimentaires,Hommes adultes 19 ans +,322,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Hommes adultes 19 ans +,4068,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Hommes adultes 19 ans +,5232,des,Confiserie - sucres et grignotines salées,,,,,0.8,0,0.7,0.9,g,4.4,0.2,,1
+Fibres alimentaires,Hommes adultes 19 ans +,1527,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,0.2,0,0.2,0.2,g,1,0.1,,2
+Fibres alimentaires,Hommes adultes 19 ans +,771,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,0.1,0,0.1,0.1,g,0.5,0,,2
+Fibres alimentaires,Hommes adultes 19 ans +,1268,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,0.5,0,0.4,0.6,g,2.6,0.2,,2
+Fibres alimentaires,Hommes adultes 19 ans +,4671,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.1,0,0.1,0.1,g,0.3,0,,2
+Fibres alimentaires,Hommes adultes 19 ans +,1023,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,0.2,0,0.1,0.2,g,0.8,0.1,,3
+Fibres alimentaires,Hommes adultes 19 ans +,497,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,0,0,0,0,g,0.1,0.1,,3
+Fibres alimentaires,Hommes adultes 19 ans +,170,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Hommes adultes 19 ans +,702,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.1,0,0.1,0.1,g,0.5,0,,3
+Fibres alimentaires,Hommes adultes 19 ans +,80,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Hommes adultes 19 ans +,726,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0.2,0,,3
+Fibres alimentaires,Hommes adultes 19 ans +,1360,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0,0,0,0,g,0.2,0,,3
+Fibres alimentaires,Hommes adultes 19 ans +,322,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Hommes adultes 19 ans +,4068,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
 Fibres alimentaires,Femmes adultes* 19 ans +,21,des,Aliments pour bébés,,,,,0,0,0,0,g,0.1,0,,1
 Fibres alimentaires,Femmes adultes* 19 ans +,19,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0,g,0.1,0,,2
-Fibres alimentaires,Femmes adultes* 19 ans +,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,g,X,X,<10,2
+Fibres alimentaires,Femmes adultes* 19 ans +,,des,Aliments pour bébés,des,Préparation pour nourrissons,,,X,X,,,g,X,X,<10,2
 Fibres alimentaires,Femmes adultes* 19 ans +,6828,des,Boissons (excluant laits),,,,,0.2,0,0.2,0.2,g,1.4,0.1,,1
 Fibres alimentaires,Femmes adultes* 19 ans +,1439,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0,g,0,0,,2
 Fibres alimentaires,Femmes adultes* 19 ans +,5777,des,Boissons (excluant laits),du,Café et thé,,,0,0,0,0,g,0,0,,2
@@ -1158,7 +1158,7 @@ Fibres alimentaires,Femmes adultes* 19 ans +,1629,des,Produits laitiers et Boiss
 Fibres alimentaires,Femmes adultes* 19 ans +,358,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0,0,0,0,g,0.2,0,,3
 Fibres alimentaires,Femmes adultes* 19 ans +,4136,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,0,0,0,0,g,0.1,0,,3
 Fibres alimentaires,Femmes adultes* 19 ans +,2244,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Femmes adultes* 19 ans +,1769,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Femmes adultes* 19 ans +,1769,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,0,0,0,0,g,0,0,,3
 Fibres alimentaires,Femmes adultes* 19 ans +,2211,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0,0,0,0,g,0,0,,3
 Fibres alimentaires,Femmes adultes* 19 ans +,1928,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,0,0,0,0,g,0,0,,3
 Fibres alimentaires,Femmes adultes* 19 ans +,6356,des,Graisses et huiles,,,,,0,0,0,0,g,0.1,0,,1
@@ -1174,9 +1174,9 @@ Fibres alimentaires,Femmes adultes* 19 ans +,370,des,Poissons et fruits de mer,d
 Fibres alimentaires,Femmes adultes* 19 ans +,6595,des,Fruits et légumes,,,,,6.8,0.1,6.5,7.1,g,42.6,0.6,,1
 Fibres alimentaires,Femmes adultes* 19 ans +,4951,des,Fruits et légumes,des,Fruits,,,3,0.1,2.9,3.2,g,19.1,0.4,,2
 Fibres alimentaires,Femmes adultes* 19 ans +,6291,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,3.7,0.1,3.6,3.9,g,23.5,0.5,,2
-Fibres alimentaires,Femmes adultes* 19 ans +,1574,des,Fruits et légumes,des,Fruits,des,Pommes,0.7,0,0.6,0.7,g,4.1,0.2,,3
+Fibres alimentaires,Femmes adultes* 19 ans +,1574,des,Fruits et légumes,des,Fruits,des,Pomme,0.7,0,0.6,0.7,g,4.1,0.2,,3
 Fibres alimentaires,Femmes adultes* 19 ans +,854,des,Fruits et légumes,des,Fruits,des,Autres fruits,0.5,0,0.4,0.6,g,3,0.3,,3
-Fibres alimentaires,Femmes adultes* 19 ans +,1919,des,Fruits et légumes,des,Fruits,des,Bananes,0.5,0,0.4,0.5,g,2.9,0.1,,3
+Fibres alimentaires,Femmes adultes* 19 ans +,1919,des,Fruits et légumes,des,Fruits,des,Banane,0.5,0,0.4,0.5,g,2.9,0.1,,3
 Fibres alimentaires,Femmes adultes* 19 ans +,1597,des,Fruits et légumes,des,Fruits,des,Baies,0.4,0,0.4,0.5,g,2.8,0.2,,3
 Fibres alimentaires,Femmes adultes* 19 ans +,1356,des,Fruits et légumes,des,Fruits,des,Agrumes,0.4,0,0.4,0.4,g,2.5,0.1,,3
 Fibres alimentaires,Femmes adultes* 19 ans +,265,des,Fruits et légumes,des,Fruits,des,Poires,0.2,0,0.2,0.3,g,1.3,0.2,,3
@@ -1193,7 +1193,7 @@ Fibres alimentaires,Femmes adultes* 19 ans +,2348,des,Fruits et légumes,des,Lé
 Fibres alimentaires,Femmes adultes* 19 ans +,6669,des,Produits céréaliers,,,,,5.9,0.1,5.7,6.2,g,37.1,0.6,,1
 Fibres alimentaires,Femmes adultes* 19 ans +,5520,des,Produits céréaliers,des,Pains,,,3.1,0.1,3,3.3,g,19.6,0.5,,2
 Fibres alimentaires,Femmes adultes* 19 ans +,2230,des,Produits céréaliers,des,Céréales pour déjeuner,,,1.2,0.1,1,1.4,g,7.5,0.5,,2
-Fibres alimentaires,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.2,0,0.2,0.3,g,1.5,0.1,,2
+Fibres alimentaires,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,0.2,0,0.2,0.3,g,1.5,0.1,,2
 Fibres alimentaires,Femmes adultes* 19 ans +,4893,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,1.4,0,1.3,1.4,g,8.5,0.3,,2
 Fibres alimentaires,Femmes adultes* 19 ans +,2239,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,1.3,0.1,1.2,1.5,g,8.4,0.3,,3
 Fibres alimentaires,Femmes adultes* 19 ans +,1994,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,0.9,0.1,0.7,1,g,5.4,0.4,,3
@@ -1201,10 +1201,10 @@ Fibres alimentaires,Femmes adultes* 19 ans +,2551,des,Produits céréaliers,des,
 Fibres alimentaires,Femmes adultes* 19 ans +,914,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.1,0,0.1,0.1,g,0.7,0.1,,3
 Fibres alimentaires,Femmes adultes* 19 ans +,1756,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,1.1,0.1,1,1.3,g,7,0.5,,3
 Fibres alimentaires,Femmes adultes* 19 ans +,555,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.1,0,0.1,0.1,g,0.6,0.1,,3
-Fibres alimentaires,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.1,g,0.7,0.1,,3
-Fibres alimentaires,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
+Fibres alimentaires,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.1,g,0.7,0.1,,3
+Fibres alimentaires,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
 Fibres alimentaires,Femmes adultes* 19 ans +,3664,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.7,0,0.6,0.8,g,4.4,0.2,,3
 Fibres alimentaires,Femmes adultes* 19 ans +,1358,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.4,0,0.4,0.5,g,2.6,0.2,,3
 Fibres alimentaires,Femmes adultes* 19 ans +,1522,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0.2,0,0.2,0.3,g,1.6,0.1,,3
@@ -1234,23 +1234,23 @@ Fibres alimentaires,Femmes adultes* 19 ans +,6382,des,Soupes - sauces - Épices 
 Fibres alimentaires,Femmes adultes* 19 ans +,2243,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.1,0,0.1,0.1,g,0.7,0,,2
 Fibres alimentaires,Femmes adultes* 19 ans +,1853,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0.2,0,0.2,0.3,g,1.4,0.1,,2
 Fibres alimentaires,Femmes adultes* 19 ans +,6077,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.2,0,0.2,0.2,g,1.2,0.1,,2
-Fibres alimentaires,Femmes adultes* 19 ans +,5713,des,Confiseries - sucres et grignotines salées,,,,,0.7,0,0.6,0.8,g,4.6,0.3,,1
-Fibres alimentaires,Femmes adultes* 19 ans +,1936,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,0.2,0,0.2,0.2,g,1.2,0.1,,2
-Fibres alimentaires,Femmes adultes* 19 ans +,844,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,0.1,0,0.1,0.1,g,0.6,0.1,,2
-Fibres alimentaires,Femmes adultes* 19 ans +,1411,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0.4,0,0.3,0.5,g,2.5,0.2,,2
-Fibres alimentaires,Femmes adultes* 19 ans +,4937,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.1,0,0,0.1,g,0.3,0,,2
-Fibres alimentaires,Femmes adultes* 19 ans +,1238,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0.2,0,0.1,0.2,g,1,0.1,,3
-Fibres alimentaires,Femmes adultes* 19 ans +,685,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0,0,0,0,g,0.1,0,,3
-Fibres alimentaires,Femmes adultes* 19 ans +,229,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Femmes adultes* 19 ans +,762,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.1,0,0.1,0.1,g,0.6,0.1,,3
-Fibres alimentaires,Femmes adultes* 19 ans +,87,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Femmes adultes* 19 ans +,1529,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0,0,0,0,g,0.2,0,,3
-Fibres alimentaires,Femmes adultes* 19 ans +,773,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0.1,0,,3
-Fibres alimentaires,Femmes adultes* 19 ans +,360,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Femmes adultes* 19 ans +,4229,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Femmes adultes* 19 ans +,5713,des,Confiserie - sucres et grignotines salées,,,,,0.7,0,0.6,0.8,g,4.6,0.3,,1
+Fibres alimentaires,Femmes adultes* 19 ans +,1936,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,0.2,0,0.2,0.2,g,1.2,0.1,,2
+Fibres alimentaires,Femmes adultes* 19 ans +,844,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,0.1,0,0.1,0.1,g,0.6,0.1,,2
+Fibres alimentaires,Femmes adultes* 19 ans +,1411,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,0.4,0,0.3,0.5,g,2.5,0.2,,2
+Fibres alimentaires,Femmes adultes* 19 ans +,4937,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.1,0,0,0.1,g,0.3,0,,2
+Fibres alimentaires,Femmes adultes* 19 ans +,1238,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,0.2,0,0.1,0.2,g,1,0.1,,3
+Fibres alimentaires,Femmes adultes* 19 ans +,685,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,0,0,0,0,g,0.1,0,,3
+Fibres alimentaires,Femmes adultes* 19 ans +,229,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Femmes adultes* 19 ans +,762,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.1,0,0.1,0.1,g,0.6,0.1,,3
+Fibres alimentaires,Femmes adultes* 19 ans +,87,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Femmes adultes* 19 ans +,1529,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0,0,0,0,g,0.2,0,,3
+Fibres alimentaires,Femmes adultes* 19 ans +,773,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0.1,0,,3
+Fibres alimentaires,Femmes adultes* 19 ans +,360,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Femmes adultes* 19 ans +,4229,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
 Fibres alimentaires,Enfants 1 à 8 ans,122,des,Aliments pour bébés,,,,,0.1,0,0,0.1,g,0.6,0.2,,1
 Fibres alimentaires,Enfants 1 à 8 ans,95,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0.1,0,0,0.1,g,0.6,0.2,,2
-Fibres alimentaires,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0,0,0,0,g,0,0,,2
+Fibres alimentaires,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparation pour nourrissons,,,0,0,0,0,g,0,0,,2
 Fibres alimentaires,Enfants 1 à 8 ans,2443,des,Boissons (excluant laits),,,,,0.4,0,0.3,0.4,g,2.7,0.1,,1
 Fibres alimentaires,Enfants 1 à 8 ans,20,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0,g,0,0,,2
 Fibres alimentaires,Enfants 1 à 8 ans,141,des,Boissons (excluant laits),du,Café et thé,,,0,0,0,0,g,0,0,,2
@@ -1273,7 +1273,7 @@ Fibres alimentaires,Enfants 1 à 8 ans,1810,des,Produits laitiers et Boissons à
 Fibres alimentaires,Enfants 1 à 8 ans,854,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,0,0,0,0.1,g,0.3,0.1,,3
 Fibres alimentaires,Enfants 1 à 8 ans,128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0,0,0,0,g,0.2,0,,3
 Fibres alimentaires,Enfants 1 à 8 ans,1078,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,0,0,0,0,g,0.1,0,,3
-Fibres alimentaires,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,0,0,0,0,g,0,0,,3
 Fibres alimentaires,Enfants 1 à 8 ans,739,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0,0,0,0,g,0,0,,3
 Fibres alimentaires,Enfants 1 à 8 ans,2270,des,Graisses et huiles,,,,,0,0,0,0,g,0,0,,1
 Fibres alimentaires,Enfants 1 à 8 ans,83,des,Graisses et huiles,des,Graisses animales,,,0,0,0,0,g,0,0,,2
@@ -1288,9 +1288,9 @@ Fibres alimentaires,Enfants 1 à 8 ans,50,des,Poissons et fruits de mer,des,Moll
 Fibres alimentaires,Enfants 1 à 8 ans,2428,des,Fruits et légumes,,,,,5.7,0.2,5.3,6,g,41.8,0.8,,1
 Fibres alimentaires,Enfants 1 à 8 ans,2117,des,Fruits et légumes,des,Fruits,,,3.4,0.1,3.2,3.6,g,25,0.7,,2
 Fibres alimentaires,Enfants 1 à 8 ans,2235,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,2.3,0.1,2.1,2.4,g,16.7,0.5,,2
-Fibres alimentaires,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pommes,1,0.1,0.9,1.1,g,7.4,0.4,,3
+Fibres alimentaires,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pomme,1,0.1,0.9,1.1,g,7.4,0.4,,3
 Fibres alimentaires,Enfants 1 à 8 ans,830,des,Fruits et légumes,des,Fruits,des,Baies,0.6,0.1,0.5,0.8,g,4.7,0.4,E,3
-Fibres alimentaires,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Bananes,0.5,0,0.4,0.6,g,3.7,0.2,,3
+Fibres alimentaires,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Banane,0.5,0,0.4,0.6,g,3.7,0.2,,3
 Fibres alimentaires,Enfants 1 à 8 ans,421,des,Fruits et légumes,des,Fruits,des,Agrumes,0.3,0,0.3,0.4,g,2.3,0.2,,3
 Fibres alimentaires,Enfants 1 à 8 ans,260,des,Fruits et légumes,des,Fruits,des,Autres fruits,0.3,0,0.2,0.3,g,1.9,0.3,,3
 Fibres alimentaires,Enfants 1 à 8 ans,133,des,Fruits et légumes,des,Fruits,des,Poires,0.2,0,0.1,0.3,g,1.5,0.3,,3
@@ -1307,7 +1307,7 @@ Fibres alimentaires,Enfants 1 à 8 ans,875,des,Fruits et légumes,des,Légumes i
 Fibres alimentaires,Enfants 1 à 8 ans,2475,des,Produits céréaliers,,,,,5.4,0.1,5.2,5.6,g,40,0.7,,1
 Fibres alimentaires,Enfants 1 à 8 ans,2114,des,Produits céréaliers,des,Pains,,,2.6,0.1,2.4,2.8,g,19,0.6,,2
 Fibres alimentaires,Enfants 1 à 8 ans,1282,des,Produits céréaliers,des,Céréales pour déjeuner,,,1.1,0.1,1,1.2,g,8.3,0.4,,2
-Fibres alimentaires,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.4,0,0.4,0.4,g,2.9,0.2,,2
+Fibres alimentaires,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,0.4,0,0.4,0.4,g,2.9,0.2,,2
 Fibres alimentaires,Enfants 1 à 8 ans,2037,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,1.3,0.1,1.2,1.4,g,9.8,0.4,,2
 Fibres alimentaires,Enfants 1 à 8 ans,813,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,1,0.1,0.9,1.1,g,7.4,0.4,,3
 Fibres alimentaires,Enfants 1 à 8 ans,951,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,0.8,0.1,0.6,0.9,g,5.6,0.4,,3
@@ -1315,9 +1315,9 @@ Fibres alimentaires,Enfants 1 à 8 ans,805,des,Produits céréaliers,des,Pains,d
 Fibres alimentaires,Enfants 1 à 8 ans,745,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.2,0,0.2,0.3,g,1.5,0.2,,3
 Fibres alimentaires,Enfants 1 à 8 ans,728,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.8,0.1,0.6,0.9,g,5.6,0.4,,3
 Fibres alimentaires,Enfants 1 à 8 ans,670,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.4,0,0.3,0.4,g,2.6,0.2,,3
-Fibres alimentaires,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.2,0,0.1,0.2,g,1.3,0.1,,3
-Fibres alimentaires,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0.1,0,,3
-Fibres alimentaires,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,0.2,0,0.1,0.2,g,1.3,0.1,,3
+Fibres alimentaires,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0.1,0,,3
+Fibres alimentaires,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
 Fibres alimentaires,Enfants 1 à 8 ans,1461,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.6,0,0.5,0.7,g,4.4,0.3,,3
 Fibres alimentaires,Enfants 1 à 8 ans,834,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.6,0,0.5,0.6,g,4.1,0.3,,3
 Fibres alimentaires,Enfants 1 à 8 ans,654,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0.2,0,0.2,0.2,g,1.3,0.1,,3
@@ -1347,23 +1347,23 @@ Fibres alimentaires,Enfants 1 à 8 ans,2295,des,Soupes - sauces - Épices et aut
 Fibres alimentaires,Enfants 1 à 8 ans,761,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.1,0,0.1,0.1,g,0.6,0.1,,2
 Fibres alimentaires,Enfants 1 à 8 ans,532,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0.1,0,0.1,0.2,g,0.9,0.1,,2
 Fibres alimentaires,Enfants 1 à 8 ans,2205,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.1,0,0.1,0.2,g,1.1,0.1,,2
-Fibres alimentaires,Enfants 1 à 8 ans,2106,des,Confiseries - sucres et grignotines salées,,,,,0.7,0,0.7,0.8,g,5.4,0.3,,1
-Fibres alimentaires,Enfants 1 à 8 ans,1048,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,0.2,0,0.2,0.2,g,1.4,0.1,,2
-Fibres alimentaires,Enfants 1 à 8 ans,497,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,0.1,0,0.1,0.1,g,0.7,0.1,,2
-Fibres alimentaires,Enfants 1 à 8 ans,615,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0.3,0,0.3,0.4,g,2.5,0.2,,2
-Fibres alimentaires,Enfants 1 à 8 ans,1642,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.1,0,0.1,0.1,g,0.8,0.1,,2
-Fibres alimentaires,Enfants 1 à 8 ans,548,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0.1,0,0.1,0.2,g,1,0.1,,3
-Fibres alimentaires,Enfants 1 à 8 ans,557,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0.1,0,0,0.1,g,0.4,0.1,,3
-Fibres alimentaires,Enfants 1 à 8 ans,131,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Enfants 1 à 8 ans,346,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.1,0,0.1,0.1,g,0.6,0.1,,3
-Fibres alimentaires,Enfants 1 à 8 ans,184,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0.1,0,,3
-Fibres alimentaires,Enfants 1 à 8 ans,720,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.1,0,0.1,0.1,g,0.7,0.1,,3
-Fibres alimentaires,Enfants 1 à 8 ans,257,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0.1,0,,3
-Fibres alimentaires,Enfants 1 à 8 ans,1341,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,g,X,X,<10,3
+Fibres alimentaires,Enfants 1 à 8 ans,2106,des,Confiserie - sucres et grignotines salées,,,,,0.7,0,0.7,0.8,g,5.4,0.3,,1
+Fibres alimentaires,Enfants 1 à 8 ans,1048,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,0.2,0,0.2,0.2,g,1.4,0.1,,2
+Fibres alimentaires,Enfants 1 à 8 ans,497,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,0.1,0,0.1,0.1,g,0.7,0.1,,2
+Fibres alimentaires,Enfants 1 à 8 ans,615,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,0.3,0,0.3,0.4,g,2.5,0.2,,2
+Fibres alimentaires,Enfants 1 à 8 ans,1642,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.1,0,0.1,0.1,g,0.8,0.1,,2
+Fibres alimentaires,Enfants 1 à 8 ans,548,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,0.1,0,0.1,0.2,g,1,0.1,,3
+Fibres alimentaires,Enfants 1 à 8 ans,557,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,0.1,0,0,0.1,g,0.4,0.1,,3
+Fibres alimentaires,Enfants 1 à 8 ans,131,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Enfants 1 à 8 ans,346,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.1,0,0.1,0.1,g,0.6,0.1,,3
+Fibres alimentaires,Enfants 1 à 8 ans,184,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0.1,0,,3
+Fibres alimentaires,Enfants 1 à 8 ans,720,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.1,0,0.1,0.1,g,0.7,0.1,,3
+Fibres alimentaires,Enfants 1 à 8 ans,257,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0.1,0,,3
+Fibres alimentaires,Enfants 1 à 8 ans,1341,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Enfants 1 à 8 ans,,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,g,X,X,<10,3
 Énergie,Population 1 an et +,186,des,Aliments pour bébés,,,,,1.2,0.2,0.7,1.6,kcal,0.1,0,E,1
 Énergie,Population 1 an et +,154,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0.8,0.2,0.4,1.1,kcal,0,0,E,2
-Énergie,Population 1 an et +,51,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0.4,0.1,0.2,0.7,kcal,0,0,E,2
+Énergie,Population 1 an et +,51,des,Aliments pour bébés,des,Préparation pour nourrissons,,,0.4,0.1,0.2,0.7,kcal,0,0,E,2
 Énergie,Population 1 an et +,19574,des,Boissons (excluant laits),,,,,161.5,3.7,154.3,168.7,kcal,8.7,0.2,,1
 Énergie,Population 1 an et +,3540,des,Boissons (excluant laits),de l',Alcool,,,67.8,3.1,61.8,73.8,kcal,3.6,0.2,,2
 Énergie,Population 1 an et +,12127,des,Boissons (excluant laits),du,Café et thé,,,8.4,0.8,6.8,10.1,kcal,0.5,0,,2
@@ -1385,7 +1385,7 @@ Fibres alimentaires,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines 
 Énergie,Population 1 an et +,12441,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,49.5,1.1,47.3,51.7,kcal,2.7,0.1,,3
 Énergie,Population 1 an et +,6481,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,20.5,0.8,18.8,22.1,kcal,1.1,0,,3
 Énergie,Population 1 an et +,5835,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,18.6,1.1,16.4,20.8,kcal,1,0.1,,3
-Énergie,Population 1 an et +,4411,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,14.3,0.6,13,15.5,kcal,0.8,0,,3
+Énergie,Population 1 an et +,4411,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,14.3,0.6,13,15.5,kcal,0.8,0,,3
 Énergie,Population 1 an et +,6026,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,5.6,0.3,5,6.2,kcal,0.3,0,,3
 Énergie,Population 1 an et +,814,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,3.9,0.3,3.2,4.5,kcal,0.2,0,,3
 Énergie,Population 1 an et +,18258,des,Graisses et huiles,,,,,172.4,2.4,167.7,177.1,kcal,9.3,0.1,,1
@@ -1401,8 +1401,8 @@ Fibres alimentaires,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines 
 Énergie,Population 1 an et +,18914,des,Fruits et légumes,,,,,197.6,2.5,192.7,202.5,kcal,10.6,0.1,,1
 Énergie,Population 1 an et +,13689,des,Fruits et légumes,des,Fruits,,,96.7,1.7,93.3,100.1,kcal,5.2,0.1,,2
 Énergie,Population 1 an et +,17977,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,100.9,1.7,97.6,104.3,kcal,5.4,0.1,,2
-Énergie,Population 1 an et +,5308,des,Fruits et légumes,des,Fruits,des,Bananes,26,0.7,24.6,27.3,kcal,1.4,0,,3
-Énergie,Population 1 an et +,5026,des,Fruits et légumes,des,Fruits,des,Pommes,21.4,0.7,20,22.7,kcal,1.1,0,,3
+Énergie,Population 1 an et +,5308,des,Fruits et légumes,des,Fruits,des,Banane,26,0.7,24.6,27.3,kcal,1.4,0,,3
+Énergie,Population 1 an et +,5026,des,Fruits et légumes,des,Fruits,des,Pomme,21.4,0.7,20,22.7,kcal,1.1,0,,3
 Énergie,Population 1 an et +,2103,des,Fruits et légumes,des,Fruits,des,Autres fruits,11.5,0.7,10.1,12.9,kcal,0.6,0,,3
 Énergie,Population 1 an et +,3372,des,Fruits et légumes,des,Fruits,des,Agrumes,9,0.4,8.3,9.8,kcal,0.5,0,,3
 Énergie,Population 1 an et +,4326,des,Fruits et légumes,des,Fruits,des,Baies,7.6,0.3,7,8.3,kcal,0.4,0,,3
@@ -1420,7 +1420,7 @@ Fibres alimentaires,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines 
 Énergie,Population 1 an et +,19327,des,Produits céréaliers,,,,,512.8,4.6,503.7,521.9,kcal,27.6,0.2,,1
 Énergie,Population 1 an et +,16168,des,Produits céréaliers,des,Pains,,,233.6,3.4,226.9,240.3,kcal,12.6,0.2,,2
 Énergie,Population 1 an et +,6966,des,Produits céréaliers,des,Céréales pour déjeuner,,,50.8,1.4,48,53.6,kcal,2.7,0.1,,2
-Énergie,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,41.5,1.4,38.8,44.3,kcal,2.2,0.1,,2
+Énergie,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,41.5,1.4,38.8,44.3,kcal,2.2,0.1,,2
 Énergie,Population 1 an et +,14820,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,186.9,3.2,180.7,193.1,kcal,10,0.2,,2
 Énergie,Population 1 an et +,8159,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,93.8,2.4,89.1,98.4,kcal,5,0.1,,3
 Énergie,Population 1 an et +,6257,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,70.8,2.5,65.9,75.7,kcal,3.8,0.1,,3
@@ -1428,10 +1428,10 @@ Fibres alimentaires,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines 
 Énergie,Population 1 an et +,2918,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,13.2,0.7,11.9,14.5,kcal,0.7,0,,3
 Énergie,Population 1 an et +,4760,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,38.3,1.4,35.7,41,kcal,2.1,0.1,,3
 Énergie,Population 1 an et +,2573,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),12.5,0.6,11.3,13.6,kcal,0.7,0,,3
-Énergie,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,12.6,0.7,11.2,14,kcal,0.7,0,,3
-Énergie,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,1.6,0.3,1,2.2,kcal,0.1,0,E,3
-Énergie,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,1.1,0.2,0.7,1.5,kcal,0.1,0,E,3
-Énergie,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,kcal,X,X,<10,3
+Énergie,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,12.6,0.7,11.2,14,kcal,0.7,0,,3
+Énergie,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,1.6,0.3,1,2.2,kcal,0.1,0,E,3
+Énergie,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,1.1,0.2,0.7,1.5,kcal,0.1,0,E,3
+Énergie,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,kcal,X,X,<10,3
 Énergie,Population 1 an et +,11102,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,83.2,2.1,79,87.4,kcal,4.5,0.1,,3
 Énergie,Population 1 an et +,4543,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,53.1,1.8,49.5,56.7,kcal,2.9,0.1,,3
 Énergie,Population 1 an et +,4598,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,50.6,1.8,47.1,54.2,kcal,2.7,0.1,,3
@@ -1461,23 +1461,23 @@ Fibres alimentaires,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines 
 Énergie,Population 1 an et +,7054,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,12.2,0.5,11.2,13.1,kcal,0.7,0,,2
 Énergie,Population 1 an et +,4710,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,13.3,0.8,11.7,14.8,kcal,0.7,0,,2
 Énergie,Population 1 an et +,17547,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,5.8,0.2,5.3,6.3,kcal,0.3,0,,2
-Énergie,Population 1 an et +,16725,des,Confiseries - sucres et grignotines salées,,,,,178.8,3.4,172.1,185.5,kcal,9.6,0.2,,1
-Énergie,Population 1 an et +,6211,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,39,2,35.1,42.9,kcal,2.1,0.1,,2
-Énergie,Population 1 an et +,2912,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,31.6,1.4,28.9,34.3,kcal,1.7,0.1,,2
-Énergie,Population 1 an et +,4652,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,47.4,2.1,43.2,51.6,kcal,2.5,0.1,,2
-Énergie,Population 1 an et +,14214,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,60.8,1.3,58.2,63.3,kcal,3.3,0.1,,2
-Énergie,Population 1 an et +,3815,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,22.2,1.3,19.7,24.7,kcal,1.2,0.1,,3
-Énergie,Population 1 an et +,2559,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,14.2,1.6,11.1,17.2,kcal,0.8,0.1,,3
-Énergie,Population 1 an et +,703,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,2.6,0.2,2.2,3.1,kcal,0.1,0,,3
-Énergie,Population 1 an et +,2447,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,27.7,1.3,25.2,30.2,kcal,1.5,0.1,,3
-Énergie,Population 1 an et +,560,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,3.9,0.4,3.1,4.8,kcal,0.2,0,,3
-Énergie,Population 1 an et +,12217,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,34.4,0.8,32.8,36,kcal,1.8,0,,3
-Énergie,Population 1 an et +,4750,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,20.6,0.8,19.1,22.2,kcal,1.1,0,,3
-Énergie,Population 1 an et +,2044,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,5.6,0.4,4.7,6.5,kcal,0.3,0,,3
-Énergie,Population 1 an et +,715,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0.2,0,0.1,0.2,kcal,0,0,,3
+Énergie,Population 1 an et +,16725,des,Confiserie - sucres et grignotines salées,,,,,178.8,3.4,172.1,185.5,kcal,9.6,0.2,,1
+Énergie,Population 1 an et +,6211,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,39,2,35.1,42.9,kcal,2.1,0.1,,2
+Énergie,Population 1 an et +,2912,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,31.6,1.4,28.9,34.3,kcal,1.7,0.1,,2
+Énergie,Population 1 an et +,4652,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,47.4,2.1,43.2,51.6,kcal,2.5,0.1,,2
+Énergie,Population 1 an et +,14214,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,60.8,1.3,58.2,63.3,kcal,3.3,0.1,,2
+Énergie,Population 1 an et +,3815,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,22.2,1.3,19.7,24.7,kcal,1.2,0.1,,3
+Énergie,Population 1 an et +,2559,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,14.2,1.6,11.1,17.2,kcal,0.8,0.1,,3
+Énergie,Population 1 an et +,703,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,2.6,0.2,2.2,3.1,kcal,0.1,0,,3
+Énergie,Population 1 an et +,2447,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,27.7,1.3,25.2,30.2,kcal,1.5,0.1,,3
+Énergie,Population 1 an et +,560,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,3.9,0.4,3.1,4.8,kcal,0.2,0,,3
+Énergie,Population 1 an et +,12217,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,34.4,0.8,32.8,36,kcal,1.8,0,,3
+Énergie,Population 1 an et +,4750,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,20.6,0.8,19.1,22.2,kcal,1.1,0,,3
+Énergie,Population 1 an et +,2044,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,5.6,0.4,4.7,6.5,kcal,0.3,0,,3
+Énergie,Population 1 an et +,715,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0.2,0,0.1,0.2,kcal,0,0,,3
 Énergie,Hommes adultes 19 ans +,22,des,Aliments pour bébés,,,,,F,F,,,kcal,F,F,F,1
 Énergie,Hommes adultes 19 ans +,21,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,F,F,,,kcal,F,F,F,2
-Énergie,Hommes adultes 19 ans +,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,kcal,X,X,<10,2
+Énergie,Hommes adultes 19 ans +,,des,Aliments pour bébés,des,Préparation pour nourrissons,,,X,X,,,kcal,X,X,<10,2
 Énergie,Hommes adultes 19 ans +,6187,des,Boissons (excluant laits),,,,,222.2,8,206.5,238,kcal,10.3,0.3,,1
 Énergie,Hommes adultes 19 ans +,1946,des,Boissons (excluant laits),de l',Alcool,,,114.5,6.8,101.1,127.9,kcal,5.3,0.3,,2
 Énergie,Hommes adultes 19 ans +,5104,des,Boissons (excluant laits),du,Café et thé,,,10.8,1.9,7.1,14.6,kcal,0.5,0.1,E,2
@@ -1498,7 +1498,7 @@ Fibres alimentaires,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines 
 Énergie,Hommes adultes 19 ans +,926,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,,,15.9,1.2,13.5,18.4,kcal,0.7,0.1,,2
 Énergie,Hommes adultes 19 ans +,3759,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,44.1,1.9,40.3,47.9,kcal,2,0.1,,3
 Énergie,Hommes adultes 19 ans +,1819,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,20,1.4,17.3,22.7,kcal,0.9,0.1,,3
-Énergie,Hommes adultes 19 ans +,1727,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,17.7,1.4,14.9,20.4,kcal,0.8,0.1,,3
+Énergie,Hommes adultes 19 ans +,1727,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,17.7,1.4,14.9,20.4,kcal,0.8,0.1,,3
 Énergie,Hommes adultes 19 ans +,1648,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,16.1,2.2,11.7,20.5,kcal,0.7,0.1,,3
 Énergie,Hommes adultes 19 ans +,1812,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,5.6,0.6,4.5,6.7,kcal,0.3,0,,3
 Énergie,Hommes adultes 19 ans +,208,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,3.8,0.6,2.6,4.9,kcal,0.2,0,,3
@@ -1515,8 +1515,8 @@ Fibres alimentaires,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines 
 Énergie,Hommes adultes 19 ans +,5918,des,Fruits et légumes,,,,,214.3,4.6,205.2,223.4,kcal,9.9,0.2,,1
 Énergie,Hommes adultes 19 ans +,3876,des,Fruits et légumes,des,Fruits,,,96.5,3.1,90.5,102.5,kcal,4.5,0.2,,2
 Énergie,Hommes adultes 19 ans +,5694,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,117.8,3.6,110.7,124.9,kcal,5.5,0.2,,2
-Énergie,Hommes adultes 19 ans +,1590,des,Fruits et légumes,des,Fruits,des,Bananes,30,1.4,27.2,32.8,kcal,1.4,0.1,,3
-Énergie,Hommes adultes 19 ans +,1350,des,Fruits et légumes,des,Fruits,des,Pommes,20.9,1.3,18.4,23.4,kcal,1,0.1,,3
+Énergie,Hommes adultes 19 ans +,1590,des,Fruits et légumes,des,Fruits,des,Banane,30,1.4,27.2,32.8,kcal,1.4,0.1,,3
+Énergie,Hommes adultes 19 ans +,1350,des,Fruits et légumes,des,Fruits,des,Pomme,20.9,1.3,18.4,23.4,kcal,1,0.1,,3
 Énergie,Hommes adultes 19 ans +,603,des,Fruits et légumes,des,Fruits,des,Autres fruits,10.7,1.2,8.2,13.1,kcal,0.5,0.1,,3
 Énergie,Hommes adultes 19 ans +,1019,des,Fruits et légumes,des,Fruits,des,Agrumes,8.6,0.6,7.3,9.8,kcal,0.4,0,,3
 Énergie,Hommes adultes 19 ans +,1066,des,Fruits et légumes,des,Fruits,des,Baies,7.2,0.7,5.8,8.6,kcal,0.3,0,,3
@@ -1534,7 +1534,7 @@ Fibres alimentaires,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines 
 Énergie,Hommes adultes 19 ans +,6068,des,Produits céréaliers,,,,,577.3,8.6,560.4,594.1,kcal,26.7,0.4,,1
 Énergie,Hommes adultes 19 ans +,5104,des,Produits céréaliers,des,Pains,,,270.9,6.6,257.9,283.8,kcal,12.5,0.3,,2
 Énergie,Hommes adultes 19 ans +,1921,des,Produits céréaliers,des,Céréales pour déjeuner,,,54.5,2.8,49,60.1,kcal,2.5,0.1,,2
-Énergie,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,41,2.6,35.9,46,kcal,1.9,0.1,,2
+Énergie,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,41,2.6,35.9,46,kcal,1.9,0.1,,2
 Énergie,Hommes adultes 19 ans +,4551,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,210.9,5.8,199.5,222.3,kcal,9.8,0.3,,2
 Énergie,Hommes adultes 19 ans +,2752,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,119.2,4.9,109.7,128.8,kcal,5.5,0.2,,3
 Énergie,Hommes adultes 19 ans +,1885,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,78.3,4.6,69.2,87.3,kcal,3.6,0.2,,3
@@ -1542,9 +1542,9 @@ Fibres alimentaires,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines 
 Énergie,Hommes adultes 19 ans +,593,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,9.9,0.9,8.2,11.7,kcal,0.5,0,,3
 Énergie,Hommes adultes 19 ans +,1481,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,45.7,2.7,40.4,50.9,kcal,2.1,0.1,,3
 Énergie,Hommes adultes 19 ans +,523,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),8.9,0.9,7.1,10.6,kcal,0.4,0,,3
-Énergie,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,13.6,1.6,10.5,16.6,kcal,0.6,0.1,,3
-Énergie,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.9,0.3,0.3,1.5,kcal,0,0,E,3
-Énergie,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,F,F,,,kcal,F,F,F,3
+Énergie,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,13.6,1.6,10.5,16.6,kcal,0.6,0.1,,3
+Énergie,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.9,0.3,0.3,1.5,kcal,0,0,E,3
+Énergie,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,F,F,,,kcal,F,F,F,3
 Énergie,Hommes adultes 19 ans +,3442,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,97.3,4,89.4,105.2,kcal,4.5,0.2,,3
 Énergie,Hommes adultes 19 ans +,1250,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,56.7,3.4,50,63.5,kcal,2.6,0.2,,3
 Énergie,Hommes adultes 19 ans +,1449,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,56.9,3.4,50.2,63.6,kcal,2.6,0.2,,3
@@ -1574,23 +1574,23 @@ Fibres alimentaires,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines 
 Énergie,Hommes adultes 19 ans +,2384,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,14.4,0.9,12.6,16.3,kcal,0.7,0,,2
 Énergie,Hommes adultes 19 ans +,1511,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,15.9,1.5,12.9,18.9,kcal,0.7,0.1,,2
 Énergie,Hommes adultes 19 ans +,5575,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,7.3,0.5,6.3,8.3,kcal,0.3,0,,2
-Énergie,Hommes adultes 19 ans +,5232,des,Confiseries - sucres et grignotines salées,,,,,183.2,6.4,170.7,195.6,kcal,8.5,0.3,,1
-Énergie,Hommes adultes 19 ans +,1527,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,34.8,3.9,27.2,42.4,kcal,1.6,0.2,,2
-Énergie,Hommes adultes 19 ans +,771,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,28.2,2.4,23.5,32.9,kcal,1.3,0.1,,2
-Énergie,Hommes adultes 19 ans +,1268,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,51.2,4.1,43.1,59.2,kcal,2.4,0.2,,2
-Énergie,Hommes adultes 19 ans +,4671,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,69,2.4,64.3,73.7,kcal,3.2,0.1,,2
-Énergie,Hommes adultes 19 ans +,1023,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,19.8,1.6,16.7,22.8,kcal,0.9,0.1,,3
-Énergie,Hommes adultes 19 ans +,497,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,13.4,3.7,6,20.7,kcal,0.6,0.2,E,3
-Énergie,Hommes adultes 19 ans +,170,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,1.7,0.2,1.2,2.1,kcal,0.1,0,,3
-Énergie,Hommes adultes 19 ans +,702,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,25.2,2.2,20.9,29.5,kcal,1.2,0.1,,3
-Énergie,Hommes adultes 19 ans +,80,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,3,0.9,1.3,4.7,kcal,0.1,0,E,3
-Énergie,Hommes adultes 19 ans +,4068,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,41,1.4,38.2,43.7,kcal,1.9,0.1,,3
-Énergie,Hommes adultes 19 ans +,1360,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,20.7,1.3,18.1,23.3,kcal,1,0.1,,3
-Énergie,Hommes adultes 19 ans +,726,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,7.1,1.1,5.1,9.2,kcal,0.3,0,,3
-Énergie,Hommes adultes 19 ans +,322,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0.2,0,0.1,0.2,kcal,0,0,,3
+Énergie,Hommes adultes 19 ans +,5232,des,Confiserie - sucres et grignotines salées,,,,,183.2,6.4,170.7,195.6,kcal,8.5,0.3,,1
+Énergie,Hommes adultes 19 ans +,1527,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,34.8,3.9,27.2,42.4,kcal,1.6,0.2,,2
+Énergie,Hommes adultes 19 ans +,771,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,28.2,2.4,23.5,32.9,kcal,1.3,0.1,,2
+Énergie,Hommes adultes 19 ans +,1268,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,51.2,4.1,43.1,59.2,kcal,2.4,0.2,,2
+Énergie,Hommes adultes 19 ans +,4671,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,69,2.4,64.3,73.7,kcal,3.2,0.1,,2
+Énergie,Hommes adultes 19 ans +,1023,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,19.8,1.6,16.7,22.8,kcal,0.9,0.1,,3
+Énergie,Hommes adultes 19 ans +,497,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,13.4,3.7,6,20.7,kcal,0.6,0.2,E,3
+Énergie,Hommes adultes 19 ans +,170,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,1.7,0.2,1.2,2.1,kcal,0.1,0,,3
+Énergie,Hommes adultes 19 ans +,702,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,25.2,2.2,20.9,29.5,kcal,1.2,0.1,,3
+Énergie,Hommes adultes 19 ans +,80,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,3,0.9,1.3,4.7,kcal,0.1,0,E,3
+Énergie,Hommes adultes 19 ans +,4068,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,41,1.4,38.2,43.7,kcal,1.9,0.1,,3
+Énergie,Hommes adultes 19 ans +,1360,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,20.7,1.3,18.1,23.3,kcal,1,0.1,,3
+Énergie,Hommes adultes 19 ans +,726,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,7.1,1.1,5.1,9.2,kcal,0.3,0,,3
+Énergie,Hommes adultes 19 ans +,322,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0.2,0,0.1,0.2,kcal,0,0,,3
 Énergie,Femmes adultes* 19 ans +,21,des,Aliments pour bébés,,,,,F,F,,,kcal,F,F,F,1
 Énergie,Femmes adultes* 19 ans +,19,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,F,F,,,kcal,F,F,F,2
-Énergie,Femmes adultes* 19 ans +,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,kcal,X,X,<10,2
+Énergie,Femmes adultes* 19 ans +,,des,Aliments pour bébés,des,Préparation pour nourrissons,,,X,X,,,kcal,X,X,<10,2
 Énergie,Femmes adultes* 19 ans +,6828,des,Boissons (excluant laits),,,,,123.2,4.5,114.5,132,kcal,7.8,0.3,,1
 Énergie,Femmes adultes* 19 ans +,1439,des,Boissons (excluant laits),de l',Alcool,,,55.4,3.5,48.5,62.3,kcal,3.5,0.2,,2
 Énergie,Femmes adultes* 19 ans +,5777,des,Boissons (excluant laits),du,Café et thé,,,7.4,0.9,5.7,9.1,kcal,0.5,0.1,,2
@@ -1611,7 +1611,7 @@ Fibres alimentaires,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines 
 Énergie,Femmes adultes* 19 ans +,1629,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,,,22.3,1.4,19.6,25,kcal,1.4,0.1,,2
 Énergie,Femmes adultes* 19 ans +,4136,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,37.6,1.6,34.5,40.8,kcal,2.4,0.1,,3
 Énergie,Femmes adultes* 19 ans +,2244,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,13.6,0.9,11.9,15.4,kcal,0.9,0.1,,3
-Énergie,Femmes adultes* 19 ans +,1769,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,13.9,0.8,12.3,15.5,kcal,0.9,0,,3
+Énergie,Femmes adultes* 19 ans +,1769,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,13.9,0.8,12.3,15.5,kcal,0.9,0,,3
 Énergie,Femmes adultes* 19 ans +,1928,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,10.6,1.4,7.8,13.5,kcal,0.7,0.1,,3
 Énergie,Femmes adultes* 19 ans +,2211,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,5.8,0.4,4.9,6.6,kcal,0.4,0,,3
 Énergie,Femmes adultes* 19 ans +,358,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,4.2,0.5,3.3,5.2,kcal,0.3,0,,3
@@ -1628,8 +1628,8 @@ Fibres alimentaires,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines 
 Énergie,Femmes adultes* 19 ans +,6595,des,Fruits et légumes,,,,,191.5,3.6,184.4,198.6,kcal,12.1,0.2,,1
 Énergie,Femmes adultes* 19 ans +,4951,des,Fruits et légumes,des,Fruits,,,95.2,2.6,90.1,100.4,kcal,6,0.2,,2
 Énergie,Femmes adultes* 19 ans +,6291,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,96.2,2.4,91.5,101,kcal,6.1,0.1,,2
-Énergie,Femmes adultes* 19 ans +,1919,des,Fruits et légumes,des,Fruits,des,Bananes,23.5,1.1,21.4,25.7,kcal,1.5,0.1,,3
-Énergie,Femmes adultes* 19 ans +,1574,des,Fruits et légumes,des,Fruits,des,Pommes,18.3,1,16.3,20.4,kcal,1.2,0.1,,3
+Énergie,Femmes adultes* 19 ans +,1919,des,Fruits et légumes,des,Fruits,des,Banane,23.5,1.1,21.4,25.7,kcal,1.5,0.1,,3
+Énergie,Femmes adultes* 19 ans +,1574,des,Fruits et légumes,des,Fruits,des,Pomme,18.3,1,16.3,20.4,kcal,1.2,0.1,,3
 Énergie,Femmes adultes* 19 ans +,854,des,Fruits et légumes,des,Fruits,des,Autres fruits,13.5,1.2,11.2,15.8,kcal,0.9,0.1,,3
 Énergie,Femmes adultes* 19 ans +,1356,des,Fruits et légumes,des,Fruits,des,Agrumes,10.2,0.6,8.9,11.5,kcal,0.6,0,,3
 Énergie,Femmes adultes* 19 ans +,1597,des,Fruits et légumes,des,Fruits,des,Baies,7.6,0.4,6.8,8.4,kcal,0.5,0,,3
@@ -1647,7 +1647,7 @@ Fibres alimentaires,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines 
 Énergie,Femmes adultes* 19 ans +,6669,des,Produits céréaliers,,,,,424.7,6.7,411.6,437.8,kcal,26.8,0.3,,1
 Énergie,Femmes adultes* 19 ans +,5520,des,Produits céréaliers,des,Pains,,,197.3,4.2,189.1,205.4,kcal,12.5,0.2,,2
 Énergie,Femmes adultes* 19 ans +,2230,des,Produits céréaliers,des,Céréales pour déjeuner,,,41.2,1.8,37.6,44.7,kcal,2.6,0.1,,2
-Énergie,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,31.6,2,27.7,35.5,kcal,2,0.1,,2
+Énergie,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,31.6,2,27.7,35.5,kcal,2,0.1,,2
 Énergie,Femmes adultes* 19 ans +,4893,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,154.6,4.7,145.3,163.9,kcal,9.8,0.3,,2
 Énergie,Femmes adultes* 19 ans +,2551,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,73.1,2.8,67.5,78.6,kcal,4.6,0.2,,3
 Énergie,Femmes adultes* 19 ans +,1994,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,59,3.1,52.8,65.1,kcal,3.7,0.2,,3
@@ -1655,10 +1655,10 @@ Fibres alimentaires,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines 
 Énergie,Femmes adultes* 19 ans +,914,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,10.2,1,8.2,12.3,kcal,0.6,0.1,,3
 Énergie,Femmes adultes* 19 ans +,1756,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,34.2,1.7,30.7,37.6,kcal,2.2,0.1,,3
 Énergie,Femmes adultes* 19 ans +,555,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),7,0.6,5.8,8.3,kcal,0.4,0,,3
-Énergie,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,7.2,0.8,5.7,8.8,kcal,0.5,0,,3
-Énergie,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.9,0.2,0.4,1.3,kcal,0.1,0,E,3
-Énergie,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.9,0.3,0.3,1.6,kcal,0.1,0,E,3
-Énergie,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,kcal,X,X,<10,3
+Énergie,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,7.2,0.8,5.7,8.8,kcal,0.5,0,,3
+Énergie,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0.9,0.2,0.4,1.3,kcal,0.1,0,E,3
+Énergie,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.9,0.3,0.3,1.6,kcal,0.1,0,E,3
+Énergie,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,kcal,X,X,<10,3
 Énergie,Femmes adultes* 19 ans +,3664,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,66.7,3.3,60.2,73.3,kcal,4.2,0.2,,3
 Énergie,Femmes adultes* 19 ans +,1358,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,43.6,2.5,38.7,48.5,kcal,2.8,0.2,,3
 Énergie,Femmes adultes* 19 ans +,1522,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,44.3,2.4,39.6,49.1,kcal,2.8,0.2,,3
@@ -1688,23 +1688,23 @@ Fibres alimentaires,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines 
 Énergie,Femmes adultes* 19 ans +,2243,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,10.2,0.6,9,11.5,kcal,0.6,0,,2
 Énergie,Femmes adultes* 19 ans +,1853,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,13,1.2,10.8,15.3,kcal,0.8,0.1,,2
 Énergie,Femmes adultes* 19 ans +,6077,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,5.6,0.3,5,6.3,kcal,0.4,0,,2
-Énergie,Femmes adultes* 19 ans +,5713,des,Confiseries - sucres et grignotines salées,,,,,153.5,5.1,143.6,163.5,kcal,9.7,0.3,,1
-Énergie,Femmes adultes* 19 ans +,1936,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,38.3,3.5,31.5,45.2,kcal,2.4,0.2,,2
-Énergie,Femmes adultes* 19 ans +,844,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,26.1,2,22.1,30.1,kcal,1.7,0.1,,2
-Énergie,Femmes adultes* 19 ans +,1411,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,36.9,2.7,31.5,42.3,kcal,2.3,0.2,,2
-Énergie,Femmes adultes* 19 ans +,4937,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,52.2,1.7,48.8,55.6,kcal,3.3,0.1,,2
-Énergie,Femmes adultes* 19 ans +,1238,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,23.8,2.8,18.3,29.3,kcal,1.5,0.2,,3
-Énergie,Femmes adultes* 19 ans +,685,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,11.8,1.6,8.6,15,kcal,0.7,0.1,,3
-Énergie,Femmes adultes* 19 ans +,229,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,2.8,0.4,1.9,3.6,kcal,0.2,0,,3
-Énergie,Femmes adultes* 19 ans +,762,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,24.8,2,20.8,28.8,kcal,1.6,0.1,,3
-Énergie,Femmes adultes* 19 ans +,87,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,1.3,0.3,0.8,1.9,kcal,0.1,0,E,3
-Énergie,Femmes adultes* 19 ans +,4229,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,31.9,1.2,29.6,34.2,kcal,2,0.1,,3
-Énergie,Femmes adultes* 19 ans +,1529,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,15.7,1.2,13.4,18.1,kcal,1,0.1,,3
-Énergie,Femmes adultes* 19 ans +,773,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,4.3,0.4,3.6,5.1,kcal,0.3,0,,3
-Énergie,Femmes adultes* 19 ans +,360,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0.2,0,0.2,0.3,kcal,0,0,,3
+Énergie,Femmes adultes* 19 ans +,5713,des,Confiserie - sucres et grignotines salées,,,,,153.5,5.1,143.6,163.5,kcal,9.7,0.3,,1
+Énergie,Femmes adultes* 19 ans +,1936,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,38.3,3.5,31.5,45.2,kcal,2.4,0.2,,2
+Énergie,Femmes adultes* 19 ans +,844,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,26.1,2,22.1,30.1,kcal,1.7,0.1,,2
+Énergie,Femmes adultes* 19 ans +,1411,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,36.9,2.7,31.5,42.3,kcal,2.3,0.2,,2
+Énergie,Femmes adultes* 19 ans +,4937,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,52.2,1.7,48.8,55.6,kcal,3.3,0.1,,2
+Énergie,Femmes adultes* 19 ans +,1238,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,23.8,2.8,18.3,29.3,kcal,1.5,0.2,,3
+Énergie,Femmes adultes* 19 ans +,685,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,11.8,1.6,8.6,15,kcal,0.7,0.1,,3
+Énergie,Femmes adultes* 19 ans +,229,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,2.8,0.4,1.9,3.6,kcal,0.2,0,,3
+Énergie,Femmes adultes* 19 ans +,762,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,24.8,2,20.8,28.8,kcal,1.6,0.1,,3
+Énergie,Femmes adultes* 19 ans +,87,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,1.3,0.3,0.8,1.9,kcal,0.1,0,E,3
+Énergie,Femmes adultes* 19 ans +,4229,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,31.9,1.2,29.6,34.2,kcal,2,0.1,,3
+Énergie,Femmes adultes* 19 ans +,1529,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,15.7,1.2,13.4,18.1,kcal,1,0.1,,3
+Énergie,Femmes adultes* 19 ans +,773,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,4.3,0.4,3.6,5.1,kcal,0.3,0,,3
+Énergie,Femmes adultes* 19 ans +,360,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0.2,0,0.2,0.3,kcal,0,0,,3
 Énergie,Enfants 1 à 8 ans,122,des,Aliments pour bébés,,,,,8.5,1.8,5,12.1,kcal,0.6,0.1,E,1
 Énergie,Enfants 1 à 8 ans,95,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,3.8,0.8,2.2,5.4,kcal,0.2,0.1,E,2
-Énergie,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparations pour nourrissons,,,4.7,1.3,2.2,7.3,kcal,0.3,0.1,E,2
+Énergie,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparation pour nourrissons,,,4.7,1.3,2.2,7.3,kcal,0.3,0.1,E,2
 Énergie,Enfants 1 à 8 ans,2443,des,Boissons (excluant laits),,,,,87.3,3.4,80.6,94,kcal,5.7,0.2,,1
 Énergie,Enfants 1 à 8 ans,20,des,Boissons (excluant laits),de l',Alcool,,,F,F,,,kcal,F,F,F,2
 Énergie,Enfants 1 à 8 ans,141,des,Boissons (excluant laits),du,Café et thé,,,2.3,0.6,1.1,3.4,kcal,0.1,0,E,2
@@ -1726,7 +1726,7 @@ Fibres alimentaires,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines 
 Énergie,Enfants 1 à 8 ans,1810,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,84.4,3.7,77.1,91.6,kcal,5.5,0.2,,3
 Énergie,Enfants 1 à 8 ans,1078,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,65.2,4.1,57.2,73.2,kcal,4.3,0.3,,3
 Énergie,Enfants 1 à 8 ans,854,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,26.8,2.9,21,32.5,kcal,1.7,0.2,,3
-Énergie,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,5.1,1,3.1,7.1,kcal,0.3,0.1,E,3
+Énergie,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,5.1,1,3.1,7.1,kcal,0.3,0.1,E,3
 Énergie,Enfants 1 à 8 ans,128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,3.4,0.6,2.3,4.6,kcal,0.2,0,E,3
 Énergie,Enfants 1 à 8 ans,739,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,3.2,0.5,2.2,4.2,kcal,0.2,0,,3
 Énergie,Enfants 1 à 8 ans,2270,des,Graisses et huiles,,,,,102.9,3.3,96.5,109.3,kcal,6.7,0.2,,1
@@ -1742,8 +1742,8 @@ Fibres alimentaires,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines 
 Énergie,Enfants 1 à 8 ans,2428,des,Fruits et légumes,,,,,170.6,4.7,161.3,179.9,kcal,11.1,0.3,,1
 Énergie,Enfants 1 à 8 ans,2117,des,Fruits et légumes,des,Fruits,,,108,3.6,100.8,115.1,kcal,7.1,0.2,,2
 Énergie,Enfants 1 à 8 ans,2235,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,62.6,2.5,57.6,67.6,kcal,4.1,0.2,,2
-Énergie,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pommes,29.8,1.9,26,33.6,kcal,1.9,0.1,,3
-Énergie,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Bananes,25.9,1.5,22.9,28.8,kcal,1.7,0.1,,3
+Énergie,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pomme,29.8,1.9,26,33.6,kcal,1.9,0.1,,3
+Énergie,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Banane,25.9,1.5,22.9,28.8,kcal,1.7,0.1,,3
 Énergie,Enfants 1 à 8 ans,572,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,11.8,1.8,8.3,15.2,kcal,0.8,0.1,,3
 Énergie,Enfants 1 à 8 ans,830,des,Fruits et légumes,des,Fruits,des,Baies,10.4,0.9,8.6,12.3,kcal,0.7,0.1,,3
 Énergie,Enfants 1 à 8 ans,421,des,Fruits et légumes,des,Fruits,des,Agrumes,8.3,0.7,6.9,9.7,kcal,0.5,0,,3
@@ -1761,7 +1761,7 @@ Fibres alimentaires,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines 
 Énergie,Enfants 1 à 8 ans,2475,des,Produits céréaliers,,,,,468.6,9.1,450.7,486.4,kcal,30.6,0.5,,1
 Énergie,Enfants 1 à 8 ans,2114,des,Produits céréaliers,des,Pains,,,191.5,6.5,178.7,204.3,kcal,12.5,0.4,,2
 Énergie,Enfants 1 à 8 ans,1282,des,Produits céréaliers,des,Céréales pour déjeuner,,,55,2.2,50.6,59.4,kcal,3.6,0.1,,2
-Énergie,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,56.6,3.1,50.5,62.8,kcal,3.7,0.2,,2
+Énergie,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,56.6,3.1,50.5,62.8,kcal,3.7,0.2,,2
 Énergie,Enfants 1 à 8 ans,2037,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,165.5,6,153.6,177.3,kcal,10.8,0.4,,2
 Énergie,Enfants 1 à 8 ans,951,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,67.6,4.8,58.1,77.1,kcal,4.4,0.3,,3
 Énergie,Enfants 1 à 8 ans,805,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,51.7,4,43.8,59.6,kcal,3.4,0.3,,3
@@ -1769,9 +1769,9 @@ Fibres alimentaires,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines 
 Énergie,Enfants 1 à 8 ans,745,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,31,2.8,25.5,36.6,kcal,2,0.2,,3
 Énergie,Enfants 1 à 8 ans,728,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,28.4,2,24.5,32.2,kcal,1.9,0.1,,3
 Énergie,Enfants 1 à 8 ans,670,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),26.6,1.7,23.3,29.9,kcal,1.7,0.1,,3
-Énergie,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,14.2,1.2,11.8,16.7,kcal,0.9,0.1,,3
-Énergie,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,2.1,0.7,0.7,3.4,kcal,0.1,0,E,3
-Énergie,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,F,F,,,kcal,F,F,F,3
+Énergie,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,14.2,1.2,11.8,16.7,kcal,0.9,0.1,,3
+Énergie,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,2.1,0.7,0.7,3.4,kcal,0.1,0,E,3
+Énergie,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,F,F,,,kcal,F,F,F,3
 Énergie,Enfants 1 à 8 ans,1461,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,64.2,4.2,56,72.5,kcal,4.2,0.3,,3
 Énergie,Enfants 1 à 8 ans,834,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,60.1,4.3,51.6,68.6,kcal,3.9,0.3,,3
 Énergie,Enfants 1 à 8 ans,654,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,41.1,2.9,35.4,46.9,kcal,2.7,0.2,,3
@@ -1801,23 +1801,23 @@ Fibres alimentaires,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines 
 Énergie,Enfants 1 à 8 ans,761,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,8.5,1.2,6.1,10.8,kcal,0.6,0.1,,2
 Énergie,Enfants 1 à 8 ans,532,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,6.9,1,4.9,8.8,kcal,0.4,0.1,,2
 Énergie,Enfants 1 à 8 ans,2205,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,2.4,0.2,2,2.7,kcal,0.2,0,,2
-Énergie,Enfants 1 à 8 ans,2106,des,Confiseries - sucres et grignotines salées,,,,,157.8,6.6,144.8,170.8,kcal,10.3,0.4,,1
-Énergie,Enfants 1 à 8 ans,1048,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,40.6,2.6,35.5,45.7,kcal,2.7,0.2,,2
-Énergie,Enfants 1 à 8 ans,497,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,37.3,3.4,30.5,44,kcal,2.4,0.2,,2
-Énergie,Enfants 1 à 8 ans,615,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,32.3,2.9,26.5,38,kcal,2.1,0.2,,2
-Énergie,Enfants 1 à 8 ans,1642,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,47.7,3.2,41.4,53.9,kcal,3.1,0.2,,2
-Énergie,Enfants 1 à 8 ans,557,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,17.7,1.7,14.5,21,kcal,1.2,0.1,,3
-Énergie,Enfants 1 à 8 ans,548,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,17.6,1.6,14.4,20.8,kcal,1.1,0.1,,3
-Énergie,Enfants 1 à 8 ans,131,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,5.3,0.9,3.5,7,kcal,0.3,0.1,E,3
-Énergie,Enfants 1 à 8 ans,346,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,26.9,2.8,21.4,32.4,kcal,1.8,0.2,,3
-Énergie,Enfants 1 à 8 ans,184,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,10.4,1.7,7.1,13.7,kcal,0.7,0.1,,3
-Énergie,Enfants 1 à 8 ans,720,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,26.1,2.4,21.4,30.8,kcal,1.7,0.2,,3
-Énergie,Enfants 1 à 8 ans,1341,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,17.4,1.3,14.7,20,kcal,1.1,0.1,,3
-Énergie,Enfants 1 à 8 ans,257,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,4.2,0.6,2.9,5.4,kcal,0.3,0,,3
-Énergie,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,kcal,X,X,<10,3
+Énergie,Enfants 1 à 8 ans,2106,des,Confiserie - sucres et grignotines salées,,,,,157.8,6.6,144.8,170.8,kcal,10.3,0.4,,1
+Énergie,Enfants 1 à 8 ans,1048,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,40.6,2.6,35.5,45.7,kcal,2.7,0.2,,2
+Énergie,Enfants 1 à 8 ans,497,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,37.3,3.4,30.5,44,kcal,2.4,0.2,,2
+Énergie,Enfants 1 à 8 ans,615,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,32.3,2.9,26.5,38,kcal,2.1,0.2,,2
+Énergie,Enfants 1 à 8 ans,1642,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,47.7,3.2,41.4,53.9,kcal,3.1,0.2,,2
+Énergie,Enfants 1 à 8 ans,557,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,17.7,1.7,14.5,21,kcal,1.2,0.1,,3
+Énergie,Enfants 1 à 8 ans,548,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,17.6,1.6,14.4,20.8,kcal,1.1,0.1,,3
+Énergie,Enfants 1 à 8 ans,131,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,5.3,0.9,3.5,7,kcal,0.3,0.1,E,3
+Énergie,Enfants 1 à 8 ans,346,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,26.9,2.8,21.4,32.4,kcal,1.8,0.2,,3
+Énergie,Enfants 1 à 8 ans,184,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,10.4,1.7,7.1,13.7,kcal,0.7,0.1,,3
+Énergie,Enfants 1 à 8 ans,720,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,26.1,2.4,21.4,30.8,kcal,1.7,0.2,,3
+Énergie,Enfants 1 à 8 ans,1341,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,17.4,1.3,14.7,20,kcal,1.1,0.1,,3
+Énergie,Enfants 1 à 8 ans,257,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,4.2,0.6,2.9,5.4,kcal,0.3,0,,3
+Énergie,Enfants 1 à 8 ans,,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,kcal,X,X,<10,3
 Folate,Population 1 an et +,186,des,Aliments pour bébés,,,,,0.1,0,0,0.1,mcg (ÉFA),0,0,,1
 Folate,Population 1 an et +,154,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0.1,0,0,0.1,mcg (ÉFA),0,0,,2
-Folate,Population 1 an et +,51,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0,0,0,0,mcg (ÉFA),0,0,,2
+Folate,Population 1 an et +,51,des,Aliments pour bébés,des,Préparation pour nourrissons,,,0,0,0,0,mcg (ÉFA),0,0,,2
 Folate,Population 1 an et +,19574,des,Boissons (excluant laits),,,,,25.5,0.5,24.5,26.4,mcg (ÉFA),6.4,0.1,,1
 Folate,Population 1 an et +,3540,des,Boissons (excluant laits),de l',Alcool,,,5,0.3,4.4,5.6,mcg (ÉFA),1.3,0.1,,2
 Folate,Population 1 an et +,12127,des,Boissons (excluant laits),du,Café et thé,,,9,0.2,8.6,9.4,mcg (ÉFA),2.2,0,,2
@@ -1841,7 +1841,7 @@ Folate,Population 1 an et +,6481,des,Produits laitiers et Boissons à base de pl
 Folate,Population 1 an et +,814,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,1.1,0.1,0.9,1.3,mcg (ÉFA),0.3,0,,3
 Folate,Population 1 an et +,5835,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,1.5,0.1,1.3,1.6,mcg (ÉFA),0.4,0,,3
 Folate,Population 1 an et +,6026,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0.8,0,0.7,0.9,mcg (ÉFA),0.2,0,,3
-Folate,Population 1 an et +,4411,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0.4,0,0.4,0.4,mcg (ÉFA),0.1,0,,3
+Folate,Population 1 an et +,4411,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,0.4,0,0.4,0.4,mcg (ÉFA),0.1,0,,3
 Folate,Population 1 an et +,18258,des,Graisses et huiles,,,,,0.4,0,0.4,0.4,mcg (ÉFA),0.1,0,,1
 Folate,Population 1 an et +,944,des,Graisses et huiles,des,Graisses animales,,,0,0,0,0,mcg (ÉFA),0,0,,2
 Folate,Population 1 an et +,5492,des,Graisses et huiles,du,Beurre,,,0.1,0,0.1,0.1,mcg (ÉFA),0,0,,2
@@ -1855,11 +1855,11 @@ Folate,Population 1 an et +,924,des,Poissons et fruits de mer,des,Mollusques et 
 Folate,Population 1 an et +,18914,des,Fruits et légumes,,,,,76.5,1.3,74,79,mcg (ÉFA),19.1,0.3,,1
 Folate,Population 1 an et +,13689,des,Fruits et légumes,des,Fruits,,,20.9,0.5,20,21.9,mcg (ÉFA),5.2,0.1,,2
 Folate,Population 1 an et +,17977,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,55.6,1.1,53.4,57.7,mcg (ÉFA),13.9,0.3,,2
-Folate,Population 1 an et +,5308,des,Fruits et légumes,des,Fruits,des,Bananes,5.8,0.2,5.5,6.1,mcg (ÉFA),1.5,0,,3
+Folate,Population 1 an et +,5308,des,Fruits et légumes,des,Fruits,des,Banane,5.8,0.2,5.5,6.1,mcg (ÉFA),1.5,0,,3
 Folate,Population 1 an et +,3372,des,Fruits et légumes,des,Fruits,des,Agrumes,4.7,0.2,4.3,5.1,mcg (ÉFA),1.2,0,,3
 Folate,Population 1 an et +,2103,des,Fruits et légumes,des,Fruits,des,Autres fruits,4.5,0.3,3.9,5.2,mcg (ÉFA),1.1,0.1,,3
 Folate,Population 1 an et +,4326,des,Fruits et légumes,des,Fruits,des,Baies,2.3,0.1,2.1,2.5,mcg (ÉFA),0.6,0,,3
-Folate,Population 1 an et +,5026,des,Fruits et légumes,des,Fruits,des,Pommes,1.2,0,1.1,1.3,mcg (ÉFA),0.3,0,,3
+Folate,Population 1 an et +,5026,des,Fruits et légumes,des,Fruits,des,Pomme,1.2,0,1.1,1.3,mcg (ÉFA),0.3,0,,3
 Folate,Population 1 an et +,982,des,Fruits et légumes,des,Fruits,des,Melons,1,0.1,0.9,1.2,mcg (ÉFA),0.3,0,,3
 Folate,Population 1 an et +,722,des,Fruits et légumes,des,Fruits,des,Poires,0.4,0,0.3,0.5,mcg (ÉFA),0.1,0,,3
 Folate,Population 1 an et +,847,des,Fruits et légumes,des,Fruits,des,Ananas,0.5,0,0.4,0.6,mcg (ÉFA),0.1,0,,3
@@ -1874,7 +1874,7 @@ Folate,Population 1 an et +,6318,des,Fruits et légumes,des,Légumes incluant po
 Folate,Population 1 an et +,19327,des,Produits céréaliers,,,,,220.1,2.5,215.1,225.1,mcg (ÉFA),54.9,0.4,,1
 Folate,Population 1 an et +,16168,des,Produits céréaliers,des,Pains,,,103.9,1.8,100.4,107.4,mcg (ÉFA),25.9,0.4,,2
 Folate,Population 1 an et +,6966,des,Produits céréaliers,des,Céréales pour déjeuner,,,15.8,0.5,14.9,16.8,mcg (ÉFA),3.9,0.1,,2
-Folate,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,6.5,0.2,6,6.9,mcg (ÉFA),1.6,0.1,,2
+Folate,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,6.5,0.2,6,6.9,mcg (ÉFA),1.6,0.1,,2
 Folate,Population 1 an et +,14820,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,93.9,1.9,90.1,97.7,mcg (ÉFA),23.4,0.4,,2
 Folate,Population 1 an et +,8159,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,57.4,1.5,54.5,60.3,mcg (ÉFA),14.3,0.4,,3
 Folate,Population 1 an et +,6257,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,29.6,1.1,27.3,31.8,mcg (ÉFA),7.4,0.3,,3
@@ -1882,10 +1882,10 @@ Folate,Population 1 an et +,5962,des,Produits céréaliers,des,Pains,des,Pains e
 Folate,Population 1 an et +,2918,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,4.6,0.2,4.2,5.1,mcg (ÉFA),1.2,0.1,,3
 Folate,Population 1 an et +,4760,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,10.6,0.4,9.7,11.5,mcg (ÉFA),2.6,0.1,,3
 Folate,Population 1 an et +,2573,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),5.2,0.2,4.7,5.7,mcg (ÉFA),1.3,0.1,,3
-Folate,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.3,0.1,0.2,0.4,mcg (ÉFA),0.1,0,E,3
-Folate,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.4,0,0.4,0.5,mcg (ÉFA),0.1,0,,3
-Folate,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.2,0,0.1,0.3,mcg (ÉFA),0.1,0,,3
-Folate,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mcg (ÉFA),X,X,<10,3
+Folate,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0.3,0.1,0.2,0.4,mcg (ÉFA),0.1,0,E,3
+Folate,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,0.4,0,0.4,0.5,mcg (ÉFA),0.1,0,,3
+Folate,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.2,0,0.1,0.3,mcg (ÉFA),0.1,0,,3
+Folate,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mcg (ÉFA),X,X,<10,3
 Folate,Population 1 an et +,11102,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,49.3,1.3,46.6,51.9,mcg (ÉFA),12.3,0.3,,3
 Folate,Population 1 an et +,4543,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,41.3,1.5,38.4,44.2,mcg (ÉFA),10.3,0.3,,3
 Folate,Population 1 an et +,4598,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,3.3,0.3,2.8,3.9,mcg (ÉFA),0.8,0.1,,3
@@ -1915,23 +1915,23 @@ Folate,Population 1 an et +,18438,des,Soupes - sauces - Épices et autres ingré
 Folate,Population 1 an et +,7054,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.9,0,0.8,1,mcg (ÉFA),0.2,0,,2
 Folate,Population 1 an et +,4710,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,2.9,0.2,2.5,3.2,mcg (ÉFA),0.7,0,,2
 Folate,Population 1 an et +,17547,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,4.1,0.2,3.8,4.5,mcg (ÉFA),1,0,,2
-Folate,Population 1 an et +,16725,des,Confiseries - sucres et grignotines salées,,,,,5.2,0.2,4.8,5.7,mcg (ÉFA),1.3,0.1,,1
-Folate,Population 1 an et +,6211,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,0.9,0.1,0.7,1.1,mcg (ÉFA),0.2,0,,2
-Folate,Population 1 an et +,2912,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,1,0,0.9,1.1,mcg (ÉFA),0.3,0,,2
-Folate,Population 1 an et +,4652,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,2.7,0.1,2.4,3,mcg (ÉFA),0.7,0,,2
-Folate,Population 1 an et +,14214,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.6,0.1,0.3,0.8,mcg (ÉFA),0.1,0,E,2
-Folate,Population 1 an et +,3815,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0.6,0,0.6,0.7,mcg (ÉFA),0.2,0,,3
-Folate,Population 1 an et +,703,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0.1,0,0,0.1,mcg (ÉFA),0,0,,3
-Folate,Population 1 an et +,2559,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,F,F,,,mcg (ÉFA),F,F,F,3
-Folate,Population 1 an et +,2447,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,1,0,0.9,1.1,mcg (ÉFA),0.2,0,,3
-Folate,Population 1 an et +,560,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,mcg (ÉFA),0,0,,3
-Folate,Population 1 an et +,4750,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.4,0.1,0.1,0.6,mcg (ÉFA),0.1,0,E,3
-Folate,Population 1 an et +,2044,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.2,0,0.2,0.2,mcg (ÉFA),0.1,0,,3
-Folate,Population 1 an et +,715,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mcg (ÉFA),0,0,,3
-Folate,Population 1 an et +,12217,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,mcg (ÉFA),0,0,,3
+Folate,Population 1 an et +,16725,des,Confiserie - sucres et grignotines salées,,,,,5.2,0.2,4.8,5.7,mcg (ÉFA),1.3,0.1,,1
+Folate,Population 1 an et +,6211,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,0.9,0.1,0.7,1.1,mcg (ÉFA),0.2,0,,2
+Folate,Population 1 an et +,2912,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,1,0,0.9,1.1,mcg (ÉFA),0.3,0,,2
+Folate,Population 1 an et +,4652,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,2.7,0.1,2.4,3,mcg (ÉFA),0.7,0,,2
+Folate,Population 1 an et +,14214,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.6,0.1,0.3,0.8,mcg (ÉFA),0.1,0,E,2
+Folate,Population 1 an et +,3815,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,0.6,0,0.6,0.7,mcg (ÉFA),0.2,0,,3
+Folate,Population 1 an et +,703,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0.1,0,0,0.1,mcg (ÉFA),0,0,,3
+Folate,Population 1 an et +,2559,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,F,F,,,mcg (ÉFA),F,F,F,3
+Folate,Population 1 an et +,2447,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,1,0,0.9,1.1,mcg (ÉFA),0.2,0,,3
+Folate,Population 1 an et +,560,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,mcg (ÉFA),0,0,,3
+Folate,Population 1 an et +,4750,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.4,0.1,0.1,0.6,mcg (ÉFA),0.1,0,E,3
+Folate,Population 1 an et +,2044,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.2,0,0.2,0.2,mcg (ÉFA),0.1,0,,3
+Folate,Population 1 an et +,715,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mcg (ÉFA),0,0,,3
+Folate,Population 1 an et +,12217,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,mcg (ÉFA),0,0,,3
 Folate,Hommes adultes 19 ans +,22,des,Aliments pour bébés,,,,,F,F,,,mcg (ÉFA),F,F,F,1
 Folate,Hommes adultes 19 ans +,21,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,F,F,,,mcg (ÉFA),F,F,F,2
-Folate,Hommes adultes 19 ans +,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,mcg (ÉFA),X,X,<10,2
+Folate,Hommes adultes 19 ans +,,des,Aliments pour bébés,des,Préparation pour nourrissons,,,X,X,,,mcg (ÉFA),X,X,<10,2
 Folate,Hommes adultes 19 ans +,6187,des,Boissons (excluant laits),,,,,33.4,1,31.4,35.4,mcg (ÉFA),7.3,0.2,,1
 Folate,Hommes adultes 19 ans +,1946,des,Boissons (excluant laits),de l',Alcool,,,10.4,0.7,9,11.8,mcg (ÉFA),2.3,0.2,,2
 Folate,Hommes adultes 19 ans +,5104,des,Boissons (excluant laits),du,Café et thé,,,11.2,0.4,10.5,11.9,mcg (ÉFA),2.5,0.1,,2
@@ -1955,7 +1955,7 @@ Folate,Hommes adultes 19 ans +,1819,des,Produits laitiers et Boissons à base de
 Folate,Hommes adultes 19 ans +,1648,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,1.2,0.2,0.9,1.6,mcg (ÉFA),0.3,0,E,3
 Folate,Hommes adultes 19 ans +,208,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,1.1,0.2,0.7,1.5,mcg (ÉFA),0.2,0,E,3
 Folate,Hommes adultes 19 ans +,1812,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0.7,0.1,0.6,0.9,mcg (ÉFA),0.2,0,,3
-Folate,Hommes adultes 19 ans +,1727,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0.5,0,0.4,0.6,mcg (ÉFA),0.1,0,,3
+Folate,Hommes adultes 19 ans +,1727,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,0.5,0,0.4,0.6,mcg (ÉFA),0.1,0,,3
 Folate,Hommes adultes 19 ans +,5767,des,Graisses et huiles,,,,,0.5,0,0.4,0.5,mcg (ÉFA),0.1,0,,1
 Folate,Hommes adultes 19 ans +,333,des,Graisses et huiles,des,Graisses animales,,,0,0,0,0,mcg (ÉFA),0,0,,2
 Folate,Hommes adultes 19 ans +,1787,des,Graisses et huiles,du,Beurre,,,0.1,0,0.1,0.1,mcg (ÉFA),0,0,,2
@@ -1969,11 +1969,11 @@ Folate,Hommes adultes 19 ans +,343,des,Poissons et fruits de mer,des,Mollusques 
 Folate,Hommes adultes 19 ans +,5918,des,Fruits et légumes,,,,,80,2,76.1,83.8,mcg (ÉFA),17.6,0.4,,1
 Folate,Hommes adultes 19 ans +,3876,des,Fruits et légumes,des,Fruits,,,20.5,0.8,19,22.1,mcg (ÉFA),4.5,0.2,,2
 Folate,Hommes adultes 19 ans +,5694,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,59.5,1.7,56.1,62.8,mcg (ÉFA),13.1,0.4,,2
-Folate,Hommes adultes 19 ans +,1590,des,Fruits et légumes,des,Fruits,des,Bananes,6.7,0.3,6.1,7.3,mcg (ÉFA),1.5,0.1,,3
+Folate,Hommes adultes 19 ans +,1590,des,Fruits et légumes,des,Fruits,des,Banane,6.7,0.3,6.1,7.3,mcg (ÉFA),1.5,0.1,,3
 Folate,Hommes adultes 19 ans +,1019,des,Fruits et légumes,des,Fruits,des,Agrumes,4.6,0.4,3.9,5.3,mcg (ÉFA),1,0.1,,3
 Folate,Hommes adultes 19 ans +,603,des,Fruits et légumes,des,Fruits,des,Autres fruits,4,0.5,3,5.1,mcg (ÉFA),0.9,0.1,,3
 Folate,Hommes adultes 19 ans +,1066,des,Fruits et légumes,des,Fruits,des,Baies,1.8,0.2,1.4,2.1,mcg (ÉFA),0.4,0,,3
-Folate,Hommes adultes 19 ans +,1350,des,Fruits et légumes,des,Fruits,des,Pommes,1.1,0.1,1,1.3,mcg (ÉFA),0.3,0,,3
+Folate,Hommes adultes 19 ans +,1350,des,Fruits et légumes,des,Fruits,des,Pomme,1.1,0.1,1,1.3,mcg (ÉFA),0.3,0,,3
 Folate,Hommes adultes 19 ans +,247,des,Fruits et légumes,des,Fruits,des,Melons,1,0.1,0.7,1.2,mcg (ÉFA),0.2,0,,3
 Folate,Hommes adultes 19 ans +,188,des,Fruits et légumes,des,Fruits,des,Poires,0.4,0.1,0.2,0.5,mcg (ÉFA),0.1,0,E,3
 Folate,Hommes adultes 19 ans +,252,des,Fruits et légumes,des,Fruits,des,Ananas,0.4,0.1,0.3,0.6,mcg (ÉFA),0.1,0,E,3
@@ -1988,7 +1988,7 @@ Folate,Hommes adultes 19 ans +,1991,des,Fruits et légumes,des,Légumes incluant
 Folate,Hommes adultes 19 ans +,6068,des,Produits céréaliers,,,,,251.7,4.7,242.4,261,mcg (ÉFA),55.2,0.6,,1
 Folate,Hommes adultes 19 ans +,5104,des,Produits céréaliers,des,Pains,,,123.5,3.6,116.5,130.5,mcg (ÉFA),27.1,0.7,,2
 Folate,Hommes adultes 19 ans +,1921,des,Produits céréaliers,des,Céréales pour déjeuner,,,16.2,0.9,14.5,18,mcg (ÉFA),3.6,0.2,,2
-Folate,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,6,0.4,5.2,6.7,mcg (ÉFA),1.3,0.1,,2
+Folate,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,6,0.4,5.2,6.7,mcg (ÉFA),1.3,0.1,,2
 Folate,Hommes adultes 19 ans +,4551,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,106,3.4,99.3,112.8,mcg (ÉFA),23.3,0.6,,2
 Folate,Hommes adultes 19 ans +,2752,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,72.9,3,67.1,78.8,mcg (ÉFA),16,0.6,,3
 Folate,Hommes adultes 19 ans +,1885,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,33.1,2.1,29,37.2,mcg (ÉFA),7.3,0.4,,3
@@ -1996,9 +1996,9 @@ Folate,Hommes adultes 19 ans +,1980,des,Produits céréaliers,des,Pains,des,Pain
 Folate,Hommes adultes 19 ans +,593,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,3.7,0.4,2.9,4.4,mcg (ÉFA),0.8,0.1,,3
 Folate,Hommes adultes 19 ans +,1481,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,12.6,0.8,11,14.3,mcg (ÉFA),2.8,0.2,,3
 Folate,Hommes adultes 19 ans +,523,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),3.6,0.4,2.9,4.3,mcg (ÉFA),0.8,0.1,,3
-Folate,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.3,0.1,0.1,0.5,mcg (ÉFA),0.1,0,E,3
-Folate,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.5,0.1,0.4,0.7,mcg (ÉFA),0.1,0,E,3
-Folate,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,F,F,,,mcg (ÉFA),F,F,F,3
+Folate,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0.3,0.1,0.1,0.5,mcg (ÉFA),0.1,0,E,3
+Folate,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,0.5,0.1,0.4,0.7,mcg (ÉFA),0.1,0,E,3
+Folate,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,F,F,,,mcg (ÉFA),F,F,F,3
 Folate,Hommes adultes 19 ans +,3442,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,57.7,2.5,52.7,62.7,mcg (ÉFA),12.7,0.5,,3
 Folate,Hommes adultes 19 ans +,1250,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,44.3,2.8,38.8,49.8,mcg (ÉFA),9.7,0.6,,3
 Folate,Hommes adultes 19 ans +,1449,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,4,0.6,2.8,5.3,mcg (ÉFA),0.9,0.1,,3
@@ -2028,23 +2028,23 @@ Folate,Hommes adultes 19 ans +,5856,des,Soupes - sauces - Épices et autres ingr
 Folate,Hommes adultes 19 ans +,2384,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,1.1,0.1,0.9,1.2,mcg (ÉFA),0.2,0,,2
 Folate,Hommes adultes 19 ans +,1511,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,3.2,0.3,2.6,3.9,mcg (ÉFA),0.7,0.1,,2
 Folate,Hommes adultes 19 ans +,5575,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,4.8,0.3,4.2,5.5,mcg (ÉFA),1.1,0.1,,2
-Folate,Hommes adultes 19 ans +,5232,des,Confiseries - sucres et grignotines salées,,,,,5,0.3,4.4,5.7,mcg (ÉFA),1.1,0.1,,1
-Folate,Hommes adultes 19 ans +,1527,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,1,0.2,0.6,1.5,mcg (ÉFA),0.2,0,E,2
-Folate,Hommes adultes 19 ans +,771,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,0.9,0.1,0.7,1.1,mcg (ÉFA),0.2,0,,2
-Folate,Hommes adultes 19 ans +,1268,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,2.7,0.3,2.2,3.2,mcg (ÉFA),0.6,0.1,,2
-Folate,Hommes adultes 19 ans +,4671,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.4,0,0.3,0.5,mcg (ÉFA),0.1,0,,2
-Folate,Hommes adultes 19 ans +,1023,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0.6,0.1,0.5,0.8,mcg (ÉFA),0.1,0,E,3
-Folate,Hommes adultes 19 ans +,170,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0,0,0,0,mcg (ÉFA),0,0,,3
-Folate,Hommes adultes 19 ans +,497,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,F,F,,,mcg (ÉFA),F,F,F,3
-Folate,Hommes adultes 19 ans +,702,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.9,0.1,0.7,1.1,mcg (ÉFA),0.2,0,,3
-Folate,Hommes adultes 19 ans +,80,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,mcg (ÉFA),0,0,,3
-Folate,Hommes adultes 19 ans +,726,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.3,0,0.2,0.4,mcg (ÉFA),0.1,0,,3
-Folate,Hommes adultes 19 ans +,1360,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.1,0,0.1,0.1,mcg (ÉFA),0,0,,3
-Folate,Hommes adultes 19 ans +,322,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mcg (ÉFA),0,0,,3
-Folate,Hommes adultes 19 ans +,4068,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,mcg (ÉFA),0,0,,3
+Folate,Hommes adultes 19 ans +,5232,des,Confiserie - sucres et grignotines salées,,,,,5,0.3,4.4,5.7,mcg (ÉFA),1.1,0.1,,1
+Folate,Hommes adultes 19 ans +,1527,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,1,0.2,0.6,1.5,mcg (ÉFA),0.2,0,E,2
+Folate,Hommes adultes 19 ans +,771,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,0.9,0.1,0.7,1.1,mcg (ÉFA),0.2,0,,2
+Folate,Hommes adultes 19 ans +,1268,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,2.7,0.3,2.2,3.2,mcg (ÉFA),0.6,0.1,,2
+Folate,Hommes adultes 19 ans +,4671,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.4,0,0.3,0.5,mcg (ÉFA),0.1,0,,2
+Folate,Hommes adultes 19 ans +,1023,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,0.6,0.1,0.5,0.8,mcg (ÉFA),0.1,0,E,3
+Folate,Hommes adultes 19 ans +,170,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0,0,0,0,mcg (ÉFA),0,0,,3
+Folate,Hommes adultes 19 ans +,497,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,F,F,,,mcg (ÉFA),F,F,F,3
+Folate,Hommes adultes 19 ans +,702,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.9,0.1,0.7,1.1,mcg (ÉFA),0.2,0,,3
+Folate,Hommes adultes 19 ans +,80,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,mcg (ÉFA),0,0,,3
+Folate,Hommes adultes 19 ans +,726,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.3,0,0.2,0.4,mcg (ÉFA),0.1,0,,3
+Folate,Hommes adultes 19 ans +,1360,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.1,0,0.1,0.1,mcg (ÉFA),0,0,,3
+Folate,Hommes adultes 19 ans +,322,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mcg (ÉFA),0,0,,3
+Folate,Hommes adultes 19 ans +,4068,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,mcg (ÉFA),0,0,,3
 Folate,Femmes adultes* 19 ans +,21,des,Aliments pour bébés,,,,,0,0,0,0,mcg (ÉFA),0,0,,1
 Folate,Femmes adultes* 19 ans +,19,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0,mcg (ÉFA),0,0,,2
-Folate,Femmes adultes* 19 ans +,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,mcg (ÉFA),X,X,<10,2
+Folate,Femmes adultes* 19 ans +,,des,Aliments pour bébés,des,Préparation pour nourrissons,,,X,X,,,mcg (ÉFA),X,X,<10,2
 Folate,Femmes adultes* 19 ans +,6828,des,Boissons (excluant laits),,,,,22.5,0.6,21.3,23.8,mcg (ÉFA),6.4,0.2,,1
 Folate,Femmes adultes* 19 ans +,1439,des,Boissons (excluant laits),de l',Alcool,,,2.2,0.2,1.9,2.6,mcg (ÉFA),0.6,0.1,,2
 Folate,Femmes adultes* 19 ans +,5777,des,Boissons (excluant laits),du,Café et thé,,,11,0.3,10.4,11.5,mcg (ÉFA),3.1,0.1,,2
@@ -2068,7 +2068,7 @@ Folate,Femmes adultes* 19 ans +,2244,des,Produits laitiers et Boissons à base d
 Folate,Femmes adultes* 19 ans +,358,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,1.3,0.2,1,1.6,mcg (ÉFA),0.4,0,,3
 Folate,Femmes adultes* 19 ans +,2211,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0.8,0.1,0.7,0.9,mcg (ÉFA),0.2,0,,3
 Folate,Femmes adultes* 19 ans +,1928,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,0.8,0.1,0.6,1.1,mcg (ÉFA),0.2,0,,3
-Folate,Femmes adultes* 19 ans +,1769,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0.4,0,0.3,0.4,mcg (ÉFA),0.1,0,,3
+Folate,Femmes adultes* 19 ans +,1769,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,0.4,0,0.3,0.4,mcg (ÉFA),0.1,0,,3
 Folate,Femmes adultes* 19 ans +,6356,des,Graisses et huiles,,,,,0.4,0,0.4,0.4,mcg (ÉFA),0.1,0,,1
 Folate,Femmes adultes* 19 ans +,369,des,Graisses et huiles,des,Graisses animales,,,0,0,0,0,mcg (ÉFA),0,0,,2
 Folate,Femmes adultes* 19 ans +,1972,des,Graisses et huiles,du,Beurre,,,0.1,0,0.1,0.1,mcg (ÉFA),0,0,,2
@@ -2082,11 +2082,11 @@ Folate,Femmes adultes* 19 ans +,370,des,Poissons et fruits de mer,des,Mollusques
 Folate,Femmes adultes* 19 ans +,6595,des,Fruits et légumes,,,,,82.8,2.3,78.2,87.4,mcg (ÉFA),23.5,0.6,,1
 Folate,Femmes adultes* 19 ans +,4951,des,Fruits et légumes,des,Fruits,,,21.5,0.8,19.9,23.1,mcg (ÉFA),6.1,0.2,,2
 Folate,Femmes adultes* 19 ans +,6291,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,61.3,2,57.3,65.3,mcg (ÉFA),17.4,0.5,,2
-Folate,Femmes adultes* 19 ans +,1919,des,Fruits et légumes,des,Fruits,des,Bananes,5.3,0.2,4.8,5.8,mcg (ÉFA),1.5,0.1,,3
+Folate,Femmes adultes* 19 ans +,1919,des,Fruits et légumes,des,Fruits,des,Banane,5.3,0.2,4.8,5.8,mcg (ÉFA),1.5,0.1,,3
 Folate,Femmes adultes* 19 ans +,854,des,Fruits et légumes,des,Fruits,des,Autres fruits,5.3,0.6,4.2,6.4,mcg (ÉFA),1.5,0.2,,3
 Folate,Femmes adultes* 19 ans +,1356,des,Fruits et légumes,des,Fruits,des,Agrumes,5.1,0.3,4.5,5.7,mcg (ÉFA),1.5,0.1,,3
 Folate,Femmes adultes* 19 ans +,1597,des,Fruits et légumes,des,Fruits,des,Baies,2.3,0.2,2,2.6,mcg (ÉFA),0.7,0,,3
-Folate,Femmes adultes* 19 ans +,1574,des,Fruits et légumes,des,Fruits,des,Pommes,1,0.1,0.9,1.1,mcg (ÉFA),0.3,0,,3
+Folate,Femmes adultes* 19 ans +,1574,des,Fruits et légumes,des,Fruits,des,Pomme,1,0.1,0.9,1.1,mcg (ÉFA),0.3,0,,3
 Folate,Femmes adultes* 19 ans +,306,des,Fruits et légumes,des,Fruits,des,Melons,0.9,0.1,0.7,1.2,mcg (ÉFA),0.3,0,,3
 Folate,Femmes adultes* 19 ans +,1006,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,0.2,0,0.1,0.2,mcg (ÉFA),0.1,0,,3
 Folate,Femmes adultes* 19 ans +,259,des,Fruits et légumes,des,Fruits,des,Pêches et nectarines,0.2,0,0.2,0.3,mcg (ÉFA),0.1,0,,3
@@ -2101,7 +2101,7 @@ Folate,Femmes adultes* 19 ans +,2348,des,Fruits et légumes,des,Légumes incluan
 Folate,Femmes adultes* 19 ans +,6669,des,Produits céréaliers,,,,,177.9,3.7,170.6,185.2,mcg (ÉFA),50.5,0.7,,1
 Folate,Femmes adultes* 19 ans +,5520,des,Produits céréaliers,des,Pains,,,85,2.1,80.9,89.2,mcg (ÉFA),24.2,0.6,,2
 Folate,Femmes adultes* 19 ans +,2230,des,Produits céréaliers,des,Céréales pour déjeuner,,,12.4,0.6,11.1,13.6,mcg (ÉFA),3.5,0.2,,2
-Folate,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,5.3,0.4,4.6,6.1,mcg (ÉFA),1.5,0.1,,2
+Folate,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,5.3,0.4,4.6,6.1,mcg (ÉFA),1.5,0.1,,2
 Folate,Femmes adultes* 19 ans +,4893,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,75.1,3,69.2,81.1,mcg (ÉFA),21.3,0.7,,2
 Folate,Femmes adultes* 19 ans +,2551,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,44.7,1.8,41.3,48.2,mcg (ÉFA),12.7,0.5,,3
 Folate,Femmes adultes* 19 ans +,1994,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,24.6,1.5,21.6,27.7,mcg (ÉFA),7,0.4,,3
@@ -2109,10 +2109,10 @@ Folate,Femmes adultes* 19 ans +,2239,des,Produits céréaliers,des,Pains,des,Pai
 Folate,Femmes adultes* 19 ans +,914,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,3.1,0.2,2.6,3.5,mcg (ÉFA),0.9,0.1,,3
 Folate,Femmes adultes* 19 ans +,1756,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,9.4,0.6,8.2,10.6,mcg (ÉFA),2.7,0.2,,3
 Folate,Femmes adultes* 19 ans +,555,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),3,0.3,2.4,3.5,mcg (ÉFA),0.8,0.1,,3
-Folate,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.3,0,0.2,0.3,mcg (ÉFA),0.1,0,,3
-Folate,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.2,0,0.1,0.2,mcg (ÉFA),0,0,,3
-Folate,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,F,F,,,mcg (ÉFA),F,F,F,3
-Folate,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mcg (ÉFA),X,X,<10,3
+Folate,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,0.3,0,0.2,0.3,mcg (ÉFA),0.1,0,,3
+Folate,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0.2,0,0.1,0.2,mcg (ÉFA),0,0,,3
+Folate,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,F,F,,,mcg (ÉFA),F,F,F,3
+Folate,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mcg (ÉFA),X,X,<10,3
 Folate,Femmes adultes* 19 ans +,3664,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,38.9,2.1,34.8,43.1,mcg (ÉFA),11.1,0.6,,3
 Folate,Femmes adultes* 19 ans +,1358,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,33.5,2.1,29.5,37.6,mcg (ÉFA),9.5,0.5,,3
 Folate,Femmes adultes* 19 ans +,1522,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,2.7,0.3,2.1,3.2,mcg (ÉFA),0.8,0.1,,3
@@ -2142,23 +2142,23 @@ Folate,Femmes adultes* 19 ans +,6382,des,Soupes - sauces - Épices et autres ing
 Folate,Femmes adultes* 19 ans +,2243,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.8,0.1,0.7,0.9,mcg (ÉFA),0.2,0,,2
 Folate,Femmes adultes* 19 ans +,1853,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,2.7,0.3,2.1,3.3,mcg (ÉFA),0.8,0.1,,2
 Folate,Femmes adultes* 19 ans +,6077,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,3.1,0.2,2.7,3.6,mcg (ÉFA),0.9,0.1,,2
-Folate,Femmes adultes* 19 ans +,5713,des,Confiseries - sucres et grignotines salées,,,,,4,0.2,3.6,4.4,mcg (ÉFA),1.1,0.1,,1
-Folate,Femmes adultes* 19 ans +,1936,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,0.7,0.1,0.6,0.9,mcg (ÉFA),0.2,0,,2
-Folate,Femmes adultes* 19 ans +,844,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,0.9,0.1,0.7,1,mcg (ÉFA),0.2,0,,2
-Folate,Femmes adultes* 19 ans +,1411,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,2.1,0.2,1.8,2.5,mcg (ÉFA),0.6,0.1,,2
-Folate,Femmes adultes* 19 ans +,4937,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.3,0,0.2,0.3,mcg (ÉFA),0.1,0,,2
-Folate,Femmes adultes* 19 ans +,1238,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0.6,0.1,0.4,0.7,mcg (ÉFA),0.2,0,E,3
-Folate,Femmes adultes* 19 ans +,685,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0.1,0,0.1,0.2,mcg (ÉFA),0,0,,3
-Folate,Femmes adultes* 19 ans +,229,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0.1,0,0,0.1,mcg (ÉFA),0,0,,3
-Folate,Femmes adultes* 19 ans +,762,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.8,0.1,0.7,1,mcg (ÉFA),0.2,0,,3
-Folate,Femmes adultes* 19 ans +,87,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,mcg (ÉFA),0,0,,3
-Folate,Femmes adultes* 19 ans +,773,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.2,0,0.1,0.2,mcg (ÉFA),0,0,,3
-Folate,Femmes adultes* 19 ans +,1529,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.1,0,0.1,0.1,mcg (ÉFA),0,0,,3
-Folate,Femmes adultes* 19 ans +,360,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mcg (ÉFA),0,0,,3
-Folate,Femmes adultes* 19 ans +,4229,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,mcg (ÉFA),0,0,,3
+Folate,Femmes adultes* 19 ans +,5713,des,Confiserie - sucres et grignotines salées,,,,,4,0.2,3.6,4.4,mcg (ÉFA),1.1,0.1,,1
+Folate,Femmes adultes* 19 ans +,1936,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,0.7,0.1,0.6,0.9,mcg (ÉFA),0.2,0,,2
+Folate,Femmes adultes* 19 ans +,844,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,0.9,0.1,0.7,1,mcg (ÉFA),0.2,0,,2
+Folate,Femmes adultes* 19 ans +,1411,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,2.1,0.2,1.8,2.5,mcg (ÉFA),0.6,0.1,,2
+Folate,Femmes adultes* 19 ans +,4937,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.3,0,0.2,0.3,mcg (ÉFA),0.1,0,,2
+Folate,Femmes adultes* 19 ans +,1238,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,0.6,0.1,0.4,0.7,mcg (ÉFA),0.2,0,E,3
+Folate,Femmes adultes* 19 ans +,685,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,0.1,0,0.1,0.2,mcg (ÉFA),0,0,,3
+Folate,Femmes adultes* 19 ans +,229,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0.1,0,0,0.1,mcg (ÉFA),0,0,,3
+Folate,Femmes adultes* 19 ans +,762,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.8,0.1,0.7,1,mcg (ÉFA),0.2,0,,3
+Folate,Femmes adultes* 19 ans +,87,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,mcg (ÉFA),0,0,,3
+Folate,Femmes adultes* 19 ans +,773,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.2,0,0.1,0.2,mcg (ÉFA),0,0,,3
+Folate,Femmes adultes* 19 ans +,1529,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.1,0,0.1,0.1,mcg (ÉFA),0,0,,3
+Folate,Femmes adultes* 19 ans +,360,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mcg (ÉFA),0,0,,3
+Folate,Femmes adultes* 19 ans +,4229,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,mcg (ÉFA),0,0,,3
 Folate,Enfants 1 à 8 ans,122,des,Aliments pour bébés,,,,,F,F,,,mcg (ÉFA),F,F,F,1
 Folate,Enfants 1 à 8 ans,95,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,F,F,,,mcg (ÉFA),F,F,F,2
-Folate,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0,0,0,0,mcg (ÉFA),0,0,,2
+Folate,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparation pour nourrissons,,,0,0,0,0,mcg (ÉFA),0,0,,2
 Folate,Enfants 1 à 8 ans,2443,des,Boissons (excluant laits),,,,,12.8,0.8,11.3,14.4,mcg (ÉFA),3.9,0.2,,1
 Folate,Enfants 1 à 8 ans,20,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0.1,mcg (ÉFA),0,0,,2
 Folate,Enfants 1 à 8 ans,141,des,Boissons (excluant laits),du,Café et thé,,,0.3,0.1,0.1,0.5,mcg (ÉFA),0.1,0,E,2
@@ -2181,7 +2181,7 @@ Folate,Enfants 1 à 8 ans,1810,des,Produits laitiers et Boissons à base de plan
 Folate,Enfants 1 à 8 ans,1078,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,5.3,0.3,4.7,6,mcg (ÉFA),1.6,0.1,,3
 Folate,Enfants 1 à 8 ans,854,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,2.9,0.3,2.2,3.5,mcg (ÉFA),0.9,0.1,,3
 Folate,Enfants 1 à 8 ans,128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,1,0.2,0.7,1.4,mcg (ÉFA),0.3,0.1,E,3
-Folate,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0.3,0.1,0.1,0.5,mcg (ÉFA),0.1,0,E,3
+Folate,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,0.3,0.1,0.1,0.5,mcg (ÉFA),0.1,0,E,3
 Folate,Enfants 1 à 8 ans,739,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0.4,0.1,0.3,0.6,mcg (ÉFA),0.1,0,E,3
 Folate,Enfants 1 à 8 ans,2270,des,Graisses et huiles,,,,,0.2,0,0.2,0.2,mcg (ÉFA),0.1,0,,1
 Folate,Enfants 1 à 8 ans,83,des,Graisses et huiles,des,Graisses animales,,,0,0,0,0,mcg (ÉFA),0,0,,2
@@ -2196,11 +2196,11 @@ Folate,Enfants 1 à 8 ans,50,des,Poissons et fruits de mer,des,Mollusques et cru
 Folate,Enfants 1 à 8 ans,2428,des,Fruits et légumes,,,,,52,1.7,48.6,55.3,mcg (ÉFA),15.8,0.5,,1
 Folate,Enfants 1 à 8 ans,2117,des,Fruits et légumes,des,Fruits,,,22.2,0.9,20.5,23.9,mcg (ÉFA),6.8,0.3,,2
 Folate,Enfants 1 à 8 ans,2235,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,29.8,1.4,27.1,32.4,mcg (ÉFA),9,0.4,,2
-Folate,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Bananes,5.8,0.3,5.1,6.5,mcg (ÉFA),1.8,0.1,,3
+Folate,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Banane,5.8,0.3,5.1,6.5,mcg (ÉFA),1.8,0.1,,3
 Folate,Enfants 1 à 8 ans,421,des,Fruits et légumes,des,Fruits,des,Agrumes,4.6,0.4,3.8,5.4,mcg (ÉFA),1.4,0.1,,3
 Folate,Enfants 1 à 8 ans,830,des,Fruits et légumes,des,Fruits,des,Baies,3.9,0.4,3.2,4.6,mcg (ÉFA),1.2,0.1,,3
 Folate,Enfants 1 à 8 ans,260,des,Fruits et légumes,des,Fruits,des,Autres fruits,3,0.5,2,3.9,mcg (ÉFA),0.9,0.1,E,3
-Folate,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pommes,1.6,0.1,1.5,1.8,mcg (ÉFA),0.5,0,,3
+Folate,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pomme,1.6,0.1,1.5,1.8,mcg (ÉFA),0.5,0,,3
 Folate,Enfants 1 à 8 ans,219,des,Fruits et légumes,des,Fruits,des,Melons,1.7,0.3,1.1,2.3,mcg (ÉFA),0.5,0.1,E,3
 Folate,Enfants 1 à 8 ans,572,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,0.3,0,0.2,0.4,mcg (ÉFA),0.1,0,,3
 Folate,Enfants 1 à 8 ans,118,des,Fruits et légumes,des,Fruits,des,Pêches et nectarines,0.3,0,0.2,0.3,mcg (ÉFA),0.1,0,,3
@@ -2215,7 +2215,7 @@ Folate,Enfants 1 à 8 ans,875,des,Fruits et légumes,des,Légumes incluant pomme
 Folate,Enfants 1 à 8 ans,2475,des,Produits céréaliers,,,,,200,5.6,189.1,211,mcg (ÉFA),60.8,0.9,,1
 Folate,Enfants 1 à 8 ans,2114,des,Produits céréaliers,des,Pains,,,82.2,3.3,75.7,88.8,mcg (ÉFA),25,0.9,,2
 Folate,Enfants 1 à 8 ans,1282,des,Produits céréaliers,des,Céréales pour déjeuner,,,20.3,0.9,18.5,22.1,mcg (ÉFA),6.2,0.3,,2
-Folate,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,9.9,0.7,8.7,11.2,mcg (ÉFA),3,0.2,,2
+Folate,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,9.9,0.7,8.7,11.2,mcg (ÉFA),3,0.2,,2
 Folate,Enfants 1 à 8 ans,2037,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,87.6,4.4,79,96.2,mcg (ÉFA),26.6,1.1,,2
 Folate,Enfants 1 à 8 ans,951,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,41.2,2.9,35.5,47,mcg (ÉFA),12.5,0.8,,3
 Folate,Enfants 1 à 8 ans,805,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,20.5,1.7,17.1,24,mcg (ÉFA),6.2,0.5,,3
@@ -2223,9 +2223,9 @@ Folate,Enfants 1 à 8 ans,745,des,Produits céréaliers,des,Pains,des,Craquelins
 Folate,Enfants 1 à 8 ans,813,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,8.2,0.7,6.9,9.6,mcg (ÉFA),2.5,0.2,,3
 Folate,Enfants 1 à 8 ans,670,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),11.4,0.7,10,12.9,mcg (ÉFA),3.5,0.2,,3
 Folate,Enfants 1 à 8 ans,728,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,8.9,0.7,7.5,10.3,mcg (ÉFA),2.7,0.2,,3
-Folate,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.4,0.1,0.1,0.6,mcg (ÉFA),0.1,0,E,3
-Folate,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.3,0.1,0,0.5,mcg (ÉFA),0.1,0,E,3
-Folate,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.4,0,0.3,0.5,mcg (ÉFA),0.1,0,,3
+Folate,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0.4,0.1,0.1,0.6,mcg (ÉFA),0.1,0,E,3
+Folate,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.3,0.1,0,0.5,mcg (ÉFA),0.1,0,E,3
+Folate,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,0.4,0,0.3,0.5,mcg (ÉFA),0.1,0,,3
 Folate,Enfants 1 à 8 ans,1461,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,38.4,2.7,33.2,43.6,mcg (ÉFA),11.7,0.7,,3
 Folate,Enfants 1 à 8 ans,834,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,46.1,3.7,39,53.3,mcg (ÉFA),14,1,,3
 Folate,Enfants 1 à 8 ans,654,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,3,0.5,2,4.1,mcg (ÉFA),0.9,0.2,E,3
@@ -2255,23 +2255,23 @@ Folate,Enfants 1 à 8 ans,2295,des,Soupes - sauces - Épices et autres ingrédie
 Folate,Enfants 1 à 8 ans,761,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.7,0.1,0.5,0.8,mcg (ÉFA),0.2,0,,2
 Folate,Enfants 1 à 8 ans,532,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,1.7,0.2,1.2,2.1,mcg (ÉFA),0.5,0.1,,2
 Folate,Enfants 1 à 8 ans,2205,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,3.3,0.3,2.7,3.9,mcg (ÉFA),1,0.1,,2
-Folate,Enfants 1 à 8 ans,2106,des,Confiseries - sucres et grignotines salées,,,,,6.8,1.5,3.8,9.8,mcg (ÉFA),2.1,0.5,E,1
-Folate,Enfants 1 à 8 ans,1048,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,0.8,0.1,0.7,0.9,mcg (ÉFA),0.2,0,,2
-Folate,Enfants 1 à 8 ans,497,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,1.1,0.1,0.8,1.3,mcg (ÉFA),0.3,0,,2
-Folate,Enfants 1 à 8 ans,615,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,2.4,0.4,1.7,3.2,mcg (ÉFA),0.7,0.1,E,2
-Folate,Enfants 1 à 8 ans,1642,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,F,F,,,mcg (ÉFA),F,F,F,2
-Folate,Enfants 1 à 8 ans,557,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0.2,0,0.1,0.3,mcg (ÉFA),0.1,0,,3
-Folate,Enfants 1 à 8 ans,548,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0.5,0,0.4,0.6,mcg (ÉFA),0.1,0,,3
-Folate,Enfants 1 à 8 ans,131,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0.1,0,0.1,0.1,mcg (ÉFA),0,0,,3
-Folate,Enfants 1 à 8 ans,346,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,1,0.1,0.8,1.3,mcg (ÉFA),0.3,0,,3
-Folate,Enfants 1 à 8 ans,184,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0.1,mcg (ÉFA),0,0,,3
-Folate,Enfants 1 à 8 ans,257,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.1,0,0.1,0.2,mcg (ÉFA),0,0,,3
-Folate,Enfants 1 à 8 ans,1341,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,mcg (ÉFA),0,0,,3
-Folate,Enfants 1 à 8 ans,720,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,F,F,,,mcg (ÉFA),F,F,F,3
-Folate,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,mcg (ÉFA),X,X,<10,3
+Folate,Enfants 1 à 8 ans,2106,des,Confiserie - sucres et grignotines salées,,,,,6.8,1.5,3.8,9.8,mcg (ÉFA),2.1,0.5,E,1
+Folate,Enfants 1 à 8 ans,1048,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,0.8,0.1,0.7,0.9,mcg (ÉFA),0.2,0,,2
+Folate,Enfants 1 à 8 ans,497,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,1.1,0.1,0.8,1.3,mcg (ÉFA),0.3,0,,2
+Folate,Enfants 1 à 8 ans,615,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,2.4,0.4,1.7,3.2,mcg (ÉFA),0.7,0.1,E,2
+Folate,Enfants 1 à 8 ans,1642,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,F,F,,,mcg (ÉFA),F,F,F,2
+Folate,Enfants 1 à 8 ans,557,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,0.2,0,0.1,0.3,mcg (ÉFA),0.1,0,,3
+Folate,Enfants 1 à 8 ans,548,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,0.5,0,0.4,0.6,mcg (ÉFA),0.1,0,,3
+Folate,Enfants 1 à 8 ans,131,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0.1,0,0.1,0.1,mcg (ÉFA),0,0,,3
+Folate,Enfants 1 à 8 ans,346,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,1,0.1,0.8,1.3,mcg (ÉFA),0.3,0,,3
+Folate,Enfants 1 à 8 ans,184,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0.1,mcg (ÉFA),0,0,,3
+Folate,Enfants 1 à 8 ans,257,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.1,0,0.1,0.2,mcg (ÉFA),0,0,,3
+Folate,Enfants 1 à 8 ans,1341,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,mcg (ÉFA),0,0,,3
+Folate,Enfants 1 à 8 ans,720,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,F,F,,,mcg (ÉFA),F,F,F,3
+Folate,Enfants 1 à 8 ans,,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,mcg (ÉFA),X,X,<10,3
 Fer,Population 1 an et +,186,des,Aliments pour bébés,,,,,0,0,0,0.1,mg,0.3,0.1,,1
 Fer,Population 1 an et +,154,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0,mg,0.2,0.1,,2
-Fer,Population 1 an et +,51,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0,0,0,0,mg,0.1,0,,2
+Fer,Population 1 an et +,51,des,Aliments pour bébés,des,Préparation pour nourrissons,,,0,0,0,0,mg,0.1,0,,2
 Fer,Population 1 an et +,19574,des,Boissons (excluant laits),,,,,0.5,0,0.5,0.5,mg,4.1,0.1,,1
 Fer,Population 1 an et +,3540,des,Boissons (excluant laits),de l',Alcool,,,0.1,0,0.1,0.1,mg,1.1,0.1,,2
 Fer,Population 1 an et +,12127,des,Boissons (excluant laits),du,Café et thé,,,0.1,0,0.1,0.1,mg,0.7,0,,2
@@ -2294,7 +2294,7 @@ Fer,Population 1 an et +,814,des,Produits laitiers et Boissons à base de plante
 Fer,Population 1 an et +,6481,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,0,0,0,0,mg,0.2,0,,3
 Fer,Population 1 an et +,12441,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,0,0,0,0,mg,0.2,0,,3
 Fer,Population 1 an et +,5835,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,0,0,0,0,mg,0.1,0,,3
-Fer,Population 1 an et +,4411,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0,0,0,0,mg,0,0,,3
+Fer,Population 1 an et +,4411,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,0,0,0,0,mg,0,0,,3
 Fer,Population 1 an et +,6026,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0,0,0,0,mg,0,0,,3
 Fer,Population 1 an et +,18258,des,Graisses et huiles,,,,,0,0,0,0,mg,0.3,0,,1
 Fer,Population 1 an et +,944,des,Graisses et huiles,des,Graisses animales,,,0,0,0,0,mg,0,0,,2
@@ -2309,9 +2309,9 @@ Fer,Population 1 an et +,924,des,Poissons et fruits de mer,des,Mollusques et cru
 Fer,Population 1 an et +,18914,des,Fruits et légumes,,,,,1.7,0,1.6,1.7,mg,13.6,0.2,,1
 Fer,Population 1 an et +,13689,des,Fruits et légumes,des,Fruits,,,0.4,0,0.4,0.4,mg,3.2,0.1,,2
 Fer,Population 1 an et +,17977,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,1.3,0,1.2,1.3,mg,10.5,0.2,,2
-Fer,Population 1 an et +,5308,des,Fruits et légumes,des,Fruits,des,Bananes,0.1,0,0.1,0.1,mg,0.6,0,,3
+Fer,Population 1 an et +,5308,des,Fruits et légumes,des,Fruits,des,Banane,0.1,0,0.1,0.1,mg,0.6,0,,3
 Fer,Population 1 an et +,4326,des,Fruits et légumes,des,Fruits,des,Baies,0.1,0,0.1,0.1,mg,0.5,0,,3
-Fer,Population 1 an et +,5026,des,Fruits et légumes,des,Fruits,des,Pommes,0.1,0,0,0.1,mg,0.4,0,,3
+Fer,Population 1 an et +,5026,des,Fruits et légumes,des,Fruits,des,Pomme,0.1,0,0,0.1,mg,0.4,0,,3
 Fer,Population 1 an et +,2881,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,0,0,0,0,mg,0.4,0,,3
 Fer,Population 1 an et +,2103,des,Fruits et légumes,des,Fruits,des,Autres fruits,0.1,0,0,0.1,mg,0.4,0,,3
 Fer,Population 1 an et +,3372,des,Fruits et légumes,des,Fruits,des,Agrumes,0,0,0,0,mg,0.2,0,,3
@@ -2328,7 +2328,7 @@ Fer,Population 1 an et +,6318,des,Fruits et légumes,des,Légumes incluant pomme
 Fer,Population 1 an et +,19327,des,Produits céréaliers,,,,,6,0.1,5.9,6.1,mg,48.6,0.3,,1
 Fer,Population 1 an et +,16168,des,Produits céréaliers,des,Pains,,,2.7,0,2.6,2.7,mg,21.7,0.3,,2
 Fer,Population 1 an et +,6966,des,Produits céréaliers,des,Céréales pour déjeuner,,,1.4,0,1.3,1.4,mg,11.1,0.3,,2
-Fer,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.3,0,0.3,0.4,mg,2.7,0.1,,2
+Fer,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,0.3,0,0.3,0.4,mg,2.7,0.1,,2
 Fer,Population 1 an et +,14820,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,1.6,0,1.6,1.7,mg,13.2,0.2,,2
 Fer,Population 1 an et +,8159,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,1.2,0,1.2,1.3,mg,10,0.3,,3
 Fer,Population 1 an et +,6257,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,0.7,0,0.7,0.8,mg,5.9,0.2,,3
@@ -2336,10 +2336,10 @@ Fer,Population 1 an et +,5962,des,Produits céréaliers,des,Pains,des,Pains et p
 Fer,Population 1 an et +,2918,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.1,0,0.1,0.1,mg,1,0,,3
 Fer,Population 1 an et +,4760,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.9,0,0.8,1,mg,7.4,0.3,,3
 Fer,Population 1 an et +,2573,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.4,0,0.4,0.5,mg,3.6,0.2,,3
-Fer,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.1,mg,0.5,0,,3
-Fer,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mg,0.1,0,,3
-Fer,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mg,0.1,0,,3
-Fer,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
+Fer,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.1,mg,0.5,0,,3
+Fer,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mg,0.1,0,,3
+Fer,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mg,0.1,0,,3
+Fer,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
 Fer,Population 1 an et +,11102,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,1.1,0,1,1.1,mg,8.8,0.2,,3
 Fer,Population 1 an et +,4543,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.4,0,0.4,0.5,mg,3.6,0.1,,3
 Fer,Population 1 an et +,4598,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0.1,0,0.1,0.1,mg,0.8,0,,3
@@ -2369,23 +2369,23 @@ Fer,Population 1 an et +,18438,des,Soupes - sauces - Épices et autres ingrédie
 Fer,Population 1 an et +,7054,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.1,0,0.1,0.1,mg,0.8,0,,2
 Fer,Population 1 an et +,4710,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0.1,0,0.1,0.1,mg,1.1,0.1,,2
 Fer,Population 1 an et +,17547,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.1,0,0.1,0.1,mg,1.1,0,,2
-Fer,Population 1 an et +,16725,des,Confiseries - sucres et grignotines salées,,,,,0.5,0,0.4,0.5,mg,3.7,0.1,,1
-Fer,Population 1 an et +,6211,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,0.2,0,0.1,0.2,mg,1.3,0.1,,2
-Fer,Population 1 an et +,2912,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,0,0,0,0,mg,0.3,0,,2
-Fer,Population 1 an et +,4652,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0.2,0,0.1,0.2,mg,1.3,0.1,,2
-Fer,Population 1 an et +,14214,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.1,0,0.1,0.1,mg,0.8,0,,2
-Fer,Population 1 an et +,3815,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0.1,0,0.1,0.1,mg,1,0.1,,3
-Fer,Population 1 an et +,2559,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0,0,0,0,mg,0.2,0,,3
-Fer,Population 1 an et +,703,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0,0,0,0,mg,0.1,0,,3
-Fer,Population 1 an et +,2447,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0,0,0,0,mg,0.3,0,,3
-Fer,Population 1 an et +,560,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,mg,0.1,0,,3
-Fer,Population 1 an et +,4750,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.1,0,0.1,0.1,mg,0.7,0,,3
-Fer,Population 1 an et +,2044,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,mg,0.1,0,,3
-Fer,Population 1 an et +,12217,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,mg,0.1,0,,3
-Fer,Population 1 an et +,715,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mg,0,0,,3
+Fer,Population 1 an et +,16725,des,Confiserie - sucres et grignotines salées,,,,,0.5,0,0.4,0.5,mg,3.7,0.1,,1
+Fer,Population 1 an et +,6211,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,0.2,0,0.1,0.2,mg,1.3,0.1,,2
+Fer,Population 1 an et +,2912,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,0,0,0,0,mg,0.3,0,,2
+Fer,Population 1 an et +,4652,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,0.2,0,0.1,0.2,mg,1.3,0.1,,2
+Fer,Population 1 an et +,14214,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.1,0,0.1,0.1,mg,0.8,0,,2
+Fer,Population 1 an et +,3815,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,0.1,0,0.1,0.1,mg,1,0.1,,3
+Fer,Population 1 an et +,2559,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,0,0,0,0,mg,0.2,0,,3
+Fer,Population 1 an et +,703,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0,0,0,0,mg,0.1,0,,3
+Fer,Population 1 an et +,2447,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0,0,0,0,mg,0.3,0,,3
+Fer,Population 1 an et +,560,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,mg,0.1,0,,3
+Fer,Population 1 an et +,4750,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.1,0,0.1,0.1,mg,0.7,0,,3
+Fer,Population 1 an et +,2044,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,mg,0.1,0,,3
+Fer,Population 1 an et +,12217,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,mg,0.1,0,,3
+Fer,Population 1 an et +,715,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mg,0,0,,3
 Fer,Hommes adultes 19 ans +,22,des,Aliments pour bébés,,,,,0,0,0,0,mg,0.1,0,,1
 Fer,Hommes adultes 19 ans +,21,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0,mg,0.1,0,,2
-Fer,Hommes adultes 19 ans +,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,mg,X,X,<10,2
+Fer,Hommes adultes 19 ans +,,des,Aliments pour bébés,des,Préparation pour nourrissons,,,X,X,,,mg,X,X,<10,2
 Fer,Hommes adultes 19 ans +,6187,des,Boissons (excluant laits),,,,,0.6,0,0.5,0.6,mg,4.1,0.1,,1
 Fer,Hommes adultes 19 ans +,1946,des,Boissons (excluant laits),de l',Alcool,,,0.2,0,0.2,0.2,mg,1.2,0.1,,2
 Fer,Hommes adultes 19 ans +,5104,des,Boissons (excluant laits),du,Café et thé,,,0.1,0,0.1,0.1,mg,0.7,0,,2
@@ -2407,7 +2407,7 @@ Fer,Hommes adultes 19 ans +,926,des,Produits laitiers et Boissons à base de pla
 Fer,Hommes adultes 19 ans +,1819,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,0,0,0,0,mg,0.2,0,,3
 Fer,Hommes adultes 19 ans +,3759,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,0,0,0,0,mg,0.2,0,,3
 Fer,Hommes adultes 19 ans +,208,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0,0,0,0,mg,0.2,0,,3
-Fer,Hommes adultes 19 ans +,1727,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0,0,0,0,mg,0.1,0,,3
+Fer,Hommes adultes 19 ans +,1727,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,0,0,0,0,mg,0.1,0,,3
 Fer,Hommes adultes 19 ans +,1648,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,0,0,0,0,mg,0.1,0,,3
 Fer,Hommes adultes 19 ans +,1812,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0,0,0,0,mg,0,0,,3
 Fer,Hommes adultes 19 ans +,5767,des,Graisses et huiles,,,,,0,0,0,0,mg,0.3,0,,1
@@ -2423,8 +2423,8 @@ Fer,Hommes adultes 19 ans +,343,des,Poissons et fruits de mer,des,Mollusques et 
 Fer,Hommes adultes 19 ans +,5918,des,Fruits et légumes,,,,,1.8,0,1.7,1.9,mg,12.9,0.3,,1
 Fer,Hommes adultes 19 ans +,3876,des,Fruits et légumes,des,Fruits,,,0.4,0,0.3,0.4,mg,2.7,0.1,,2
 Fer,Hommes adultes 19 ans +,5694,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,1.4,0,1.4,1.5,mg,10.2,0.3,,2
-Fer,Hommes adultes 19 ans +,1590,des,Fruits et légumes,des,Fruits,des,Bananes,0.1,0,0.1,0.1,mg,0.6,0,,3
-Fer,Hommes adultes 19 ans +,1350,des,Fruits et légumes,des,Fruits,des,Pommes,0,0,0,0.1,mg,0.4,0,,3
+Fer,Hommes adultes 19 ans +,1590,des,Fruits et légumes,des,Fruits,des,Banane,0.1,0,0.1,0.1,mg,0.6,0,,3
+Fer,Hommes adultes 19 ans +,1350,des,Fruits et légumes,des,Fruits,des,Pomme,0,0,0,0.1,mg,0.4,0,,3
 Fer,Hommes adultes 19 ans +,1066,des,Fruits et légumes,des,Fruits,des,Baies,0.1,0,0,0.1,mg,0.4,0,,3
 Fer,Hommes adultes 19 ans +,603,des,Fruits et légumes,des,Fruits,des,Autres fruits,0.1,0,0,0.1,mg,0.4,0.1,,3
 Fer,Hommes adultes 19 ans +,782,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,0,0,0,0,mg,0.3,0,,3
@@ -2442,7 +2442,7 @@ Fer,Hommes adultes 19 ans +,1991,des,Fruits et légumes,des,Légumes incluant po
 Fer,Hommes adultes 19 ans +,6068,des,Produits céréaliers,,,,,6.7,0.1,6.5,6.9,mg,47.5,0.6,,1
 Fer,Hommes adultes 19 ans +,5104,des,Produits céréaliers,des,Pains,,,3.1,0.1,3,3.3,mg,22.2,0.5,,2
 Fer,Hommes adultes 19 ans +,1921,des,Produits céréaliers,des,Céréales pour déjeuner,,,1.4,0.1,1.2,1.5,mg,9.9,0.5,,2
-Fer,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.3,0,0.3,0.4,mg,2.2,0.2,,2
+Fer,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,0.3,0,0.3,0.4,mg,2.2,0.2,,2
 Fer,Hommes adultes 19 ans +,4551,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,1.8,0.1,1.7,2,mg,13.2,0.4,,2
 Fer,Hommes adultes 19 ans +,2752,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,1.6,0.1,1.4,1.7,mg,11.1,0.4,,3
 Fer,Hommes adultes 19 ans +,1885,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,0.8,0,0.7,0.9,mg,5.8,0.3,,3
@@ -2450,9 +2450,9 @@ Fer,Hommes adultes 19 ans +,1980,des,Produits céréaliers,des,Pains,des,Pains e
 Fer,Hommes adultes 19 ans +,593,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.1,0,0.1,0.1,mg,0.8,0.1,,3
 Fer,Hommes adultes 19 ans +,1481,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,1.1,0.1,0.9,1.2,mg,7.7,0.5,,3
 Fer,Hommes adultes 19 ans +,523,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.3,0,0.3,0.4,mg,2.2,0.2,,3
-Fer,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.1,mg,0.5,0.1,,3
-Fer,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mg,0.1,0,,3
-Fer,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mg,0,0,,3
+Fer,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.1,mg,0.5,0.1,,3
+Fer,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mg,0.1,0,,3
+Fer,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mg,0,0,,3
 Fer,Hommes adultes 19 ans +,3442,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,1.3,0.1,1.2,1.4,mg,9,0.4,,3
 Fer,Hommes adultes 19 ans +,1250,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.5,0,0.4,0.5,mg,3.3,0.2,,3
 Fer,Hommes adultes 19 ans +,1449,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0.1,0,0.1,0.1,mg,0.8,0.1,,3
@@ -2482,23 +2482,23 @@ Fer,Hommes adultes 19 ans +,5856,des,Soupes - sauces - Épices et autres ingréd
 Fer,Hommes adultes 19 ans +,2384,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.1,0,0.1,0.1,mg,0.8,0.1,,2
 Fer,Hommes adultes 19 ans +,1511,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0.2,0,0.1,0.2,mg,1.1,0.1,,2
 Fer,Hommes adultes 19 ans +,5575,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.2,0,0.1,0.2,mg,1.1,0.1,,2
-Fer,Hommes adultes 19 ans +,5232,des,Confiseries - sucres et grignotines salées,,,,,0.4,0,0.4,0.5,mg,3.1,0.1,,1
-Fer,Hommes adultes 19 ans +,1527,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,0.1,0,0.1,0.2,mg,1,0.1,,2
-Fer,Hommes adultes 19 ans +,771,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,0,0,0,0,mg,0.3,0,,2
-Fer,Hommes adultes 19 ans +,1268,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0.2,0,0.1,0.2,mg,1.1,0.1,,2
-Fer,Hommes adultes 19 ans +,4671,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.1,0,0.1,0.1,mg,0.7,0.1,,2
-Fer,Hommes adultes 19 ans +,1023,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0.1,0,0.1,0.1,mg,0.8,0.1,,3
-Fer,Hommes adultes 19 ans +,497,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0,0,0,0,mg,0.1,0,,3
-Fer,Hommes adultes 19 ans +,170,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0,0,0,0,mg,0,0,,3
-Fer,Hommes adultes 19 ans +,702,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0,0,0,0,mg,0.2,0,,3
-Fer,Hommes adultes 19 ans +,80,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,mg,0.1,0,,3
-Fer,Hommes adultes 19 ans +,1360,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.1,0,0.1,0.1,mg,0.5,0,,3
-Fer,Hommes adultes 19 ans +,726,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,mg,0.1,0,,3
-Fer,Hommes adultes 19 ans +,4068,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,mg,0.1,0,,3
-Fer,Hommes adultes 19 ans +,322,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mg,0,0,,3
+Fer,Hommes adultes 19 ans +,5232,des,Confiserie - sucres et grignotines salées,,,,,0.4,0,0.4,0.5,mg,3.1,0.1,,1
+Fer,Hommes adultes 19 ans +,1527,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,0.1,0,0.1,0.2,mg,1,0.1,,2
+Fer,Hommes adultes 19 ans +,771,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,0,0,0,0,mg,0.3,0,,2
+Fer,Hommes adultes 19 ans +,1268,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,0.2,0,0.1,0.2,mg,1.1,0.1,,2
+Fer,Hommes adultes 19 ans +,4671,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.1,0,0.1,0.1,mg,0.7,0.1,,2
+Fer,Hommes adultes 19 ans +,1023,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,0.1,0,0.1,0.1,mg,0.8,0.1,,3
+Fer,Hommes adultes 19 ans +,497,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,0,0,0,0,mg,0.1,0,,3
+Fer,Hommes adultes 19 ans +,170,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0,0,0,0,mg,0,0,,3
+Fer,Hommes adultes 19 ans +,702,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0,0,0,0,mg,0.2,0,,3
+Fer,Hommes adultes 19 ans +,80,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,mg,0.1,0,,3
+Fer,Hommes adultes 19 ans +,1360,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.1,0,0.1,0.1,mg,0.5,0,,3
+Fer,Hommes adultes 19 ans +,726,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,mg,0.1,0,,3
+Fer,Hommes adultes 19 ans +,4068,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,mg,0.1,0,,3
+Fer,Hommes adultes 19 ans +,322,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mg,0,0,,3
 Fer,Femmes adultes* 19 ans +,21,des,Aliments pour bébés,,,,,0,0,0,0.1,mg,0.3,0.2,,1
 Fer,Femmes adultes* 19 ans +,19,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0.1,mg,0.3,0.2,,2
-Fer,Femmes adultes* 19 ans +,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,mg,X,X,<10,2
+Fer,Femmes adultes* 19 ans +,,des,Aliments pour bébés,des,Préparation pour nourrissons,,,X,X,,,mg,X,X,<10,2
 Fer,Femmes adultes* 19 ans +,6828,des,Boissons (excluant laits),,,,,0.5,0,0.5,0.5,mg,4.6,0.1,,1
 Fer,Femmes adultes* 19 ans +,1439,des,Boissons (excluant laits),de l',Alcool,,,0.2,0,0.1,0.2,mg,1.4,0.1,,2
 Fer,Femmes adultes* 19 ans +,5777,des,Boissons (excluant laits),du,Café et thé,,,0.1,0,0.1,0.1,mg,1,0,,2
@@ -2520,7 +2520,7 @@ Fer,Femmes adultes* 19 ans +,1629,des,Produits laitiers et Boissons à base de p
 Fer,Femmes adultes* 19 ans +,358,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0,0,0,0,mg,0.3,0,,3
 Fer,Femmes adultes* 19 ans +,4136,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,0,0,0,0,mg,0.2,0,,3
 Fer,Femmes adultes* 19 ans +,2244,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,0,0,0,0,mg,0.1,0,,3
-Fer,Femmes adultes* 19 ans +,1769,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0,0,0,0,mg,0.1,0,,3
+Fer,Femmes adultes* 19 ans +,1769,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,0,0,0,0,mg,0.1,0,,3
 Fer,Femmes adultes* 19 ans +,1928,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,0,0,0,0,mg,0.1,0,,3
 Fer,Femmes adultes* 19 ans +,2211,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0,0,0,0,mg,0,0,,3
 Fer,Femmes adultes* 19 ans +,6356,des,Graisses et huiles,,,,,0,0,0,0,mg,0.3,0,,1
@@ -2536,10 +2536,10 @@ Fer,Femmes adultes* 19 ans +,370,des,Poissons et fruits de mer,des,Mollusques et
 Fer,Femmes adultes* 19 ans +,6595,des,Fruits et légumes,,,,,1.7,0,1.6,1.8,mg,15.9,0.4,,1
 Fer,Femmes adultes* 19 ans +,4951,des,Fruits et légumes,des,Fruits,,,0.4,0,0.4,0.4,mg,3.6,0.1,,2
 Fer,Femmes adultes* 19 ans +,6291,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,1.3,0,1.2,1.4,mg,12.3,0.3,,2
-Fer,Femmes adultes* 19 ans +,1919,des,Fruits et légumes,des,Fruits,des,Bananes,0.1,0,0.1,0.1,mg,0.6,0,,3
+Fer,Femmes adultes* 19 ans +,1919,des,Fruits et légumes,des,Fruits,des,Banane,0.1,0,0.1,0.1,mg,0.6,0,,3
 Fer,Femmes adultes* 19 ans +,1597,des,Fruits et légumes,des,Fruits,des,Baies,0.1,0,0.1,0.1,mg,0.6,0,,3
 Fer,Femmes adultes* 19 ans +,854,des,Fruits et légumes,des,Fruits,des,Autres fruits,0.1,0,0,0.1,mg,0.5,0,,3
-Fer,Femmes adultes* 19 ans +,1574,des,Fruits et légumes,des,Fruits,des,Pommes,0,0,0,0,mg,0.4,0,,3
+Fer,Femmes adultes* 19 ans +,1574,des,Fruits et légumes,des,Fruits,des,Pomme,0,0,0,0,mg,0.4,0,,3
 Fer,Femmes adultes* 19 ans +,1006,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,0,0,0,0.1,mg,0.4,0,,3
 Fer,Femmes adultes* 19 ans +,1356,des,Fruits et légumes,des,Fruits,des,Agrumes,0,0,0,0,mg,0.3,0,,3
 Fer,Femmes adultes* 19 ans +,306,des,Fruits et légumes,des,Fruits,des,Melons,0,0,0,0,mg,0.2,0,,3
@@ -2555,7 +2555,7 @@ Fer,Femmes adultes* 19 ans +,2348,des,Fruits et légumes,des,Légumes incluant p
 Fer,Femmes adultes* 19 ans +,6669,des,Produits céréaliers,,,,,4.8,0.1,4.7,5,mg,45.5,0.6,,1
 Fer,Femmes adultes* 19 ans +,5520,des,Produits céréaliers,des,Pains,,,2.2,0,2.1,2.3,mg,21,0.4,,2
 Fer,Femmes adultes* 19 ans +,2230,des,Produits céréaliers,des,Céréales pour déjeuner,,,1.1,0,1,1.2,mg,9.9,0.4,,2
-Fer,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.2,0,0.2,0.3,mg,2.3,0.1,,2
+Fer,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,0.2,0,0.2,0.3,mg,2.3,0.1,,2
 Fer,Femmes adultes* 19 ans +,4893,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,1.3,0,1.2,1.4,mg,12.4,0.4,,2
 Fer,Femmes adultes* 19 ans +,2551,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,1,0,0.9,1,mg,9,0.4,,3
 Fer,Femmes adultes* 19 ans +,1994,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,0.6,0,0.5,0.7,mg,5.7,0.3,,3
@@ -2563,10 +2563,10 @@ Fer,Femmes adultes* 19 ans +,2239,des,Produits céréaliers,des,Pains,des,Pains 
 Fer,Femmes adultes* 19 ans +,914,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.1,0,0.1,0.1,mg,0.9,0.1,,3
 Fer,Femmes adultes* 19 ans +,1756,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.8,0,0.7,0.9,mg,7.5,0.4,,3
 Fer,Femmes adultes* 19 ans +,555,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.3,0,0.2,0.3,mg,2.4,0.2,,3
-Fer,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0,0,0,0,mg,0.4,0,,3
-Fer,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mg,0.1,0,,3
-Fer,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mg,0,0,,3
-Fer,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
+Fer,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,0,0,0,0,mg,0.4,0,,3
+Fer,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mg,0.1,0,,3
+Fer,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mg,0,0,,3
+Fer,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
 Fer,Femmes adultes* 19 ans +,3664,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.9,0,0.8,1,mg,8.1,0.4,,3
 Fer,Femmes adultes* 19 ans +,1358,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.4,0,0.3,0.4,mg,3.4,0.2,,3
 Fer,Femmes adultes* 19 ans +,1522,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0.1,0,0.1,0.1,mg,0.9,0.1,,3
@@ -2596,23 +2596,23 @@ Fer,Femmes adultes* 19 ans +,6382,des,Soupes - sauces - Épices et autres ingré
 Fer,Femmes adultes* 19 ans +,2243,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.1,0,0.1,0.1,mg,0.8,0.1,,2
 Fer,Femmes adultes* 19 ans +,1853,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0.1,0,0.1,0.1,mg,1.2,0.1,,2
 Fer,Femmes adultes* 19 ans +,6077,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.1,0,0.1,0.1,mg,1.2,0.1,,2
-Fer,Femmes adultes* 19 ans +,5713,des,Confiseries - sucres et grignotines salées,,,,,0.4,0,0.4,0.4,mg,3.8,0.2,,1
-Fer,Femmes adultes* 19 ans +,1936,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,0.2,0,0.1,0.2,mg,1.5,0.1,,2
-Fer,Femmes adultes* 19 ans +,844,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,0,0,0,0,mg,0.3,0,,2
-Fer,Femmes adultes* 19 ans +,1411,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0.1,0,0.1,0.2,mg,1.2,0.1,,2
-Fer,Femmes adultes* 19 ans +,4937,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.1,0,0.1,0.1,mg,0.8,0.1,,2
-Fer,Femmes adultes* 19 ans +,1238,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0.1,0,0.1,0.2,mg,1.2,0.1,,3
-Fer,Femmes adultes* 19 ans +,685,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0,0,0,0,mg,0.2,0,,3
-Fer,Femmes adultes* 19 ans +,229,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0,0,0,0,mg,0.1,0,,3
-Fer,Femmes adultes* 19 ans +,762,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0,0,0,0,mg,0.2,0,,3
-Fer,Femmes adultes* 19 ans +,87,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,mg,0,0,,3
-Fer,Femmes adultes* 19 ans +,1529,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.1,0,0.1,0.1,mg,0.6,0.1,,3
-Fer,Femmes adultes* 19 ans +,773,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,mg,0.1,0,,3
-Fer,Femmes adultes* 19 ans +,4229,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,mg,0.1,0,,3
-Fer,Femmes adultes* 19 ans +,360,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mg,0,0,,3
+Fer,Femmes adultes* 19 ans +,5713,des,Confiserie - sucres et grignotines salées,,,,,0.4,0,0.4,0.4,mg,3.8,0.2,,1
+Fer,Femmes adultes* 19 ans +,1936,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,0.2,0,0.1,0.2,mg,1.5,0.1,,2
+Fer,Femmes adultes* 19 ans +,844,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,0,0,0,0,mg,0.3,0,,2
+Fer,Femmes adultes* 19 ans +,1411,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,0.1,0,0.1,0.2,mg,1.2,0.1,,2
+Fer,Femmes adultes* 19 ans +,4937,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.1,0,0.1,0.1,mg,0.8,0.1,,2
+Fer,Femmes adultes* 19 ans +,1238,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,0.1,0,0.1,0.2,mg,1.2,0.1,,3
+Fer,Femmes adultes* 19 ans +,685,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,0,0,0,0,mg,0.2,0,,3
+Fer,Femmes adultes* 19 ans +,229,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0,0,0,0,mg,0.1,0,,3
+Fer,Femmes adultes* 19 ans +,762,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0,0,0,0,mg,0.2,0,,3
+Fer,Femmes adultes* 19 ans +,87,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,mg,0,0,,3
+Fer,Femmes adultes* 19 ans +,1529,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.1,0,0.1,0.1,mg,0.6,0.1,,3
+Fer,Femmes adultes* 19 ans +,773,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,mg,0.1,0,,3
+Fer,Femmes adultes* 19 ans +,4229,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,mg,0.1,0,,3
+Fer,Femmes adultes* 19 ans +,360,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mg,0,0,,3
 Fer,Enfants 1 à 8 ans,122,des,Aliments pour bébés,,,,,F,F,,,mg,F,F,F,1
 Fer,Enfants 1 à 8 ans,95,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0.2,0,0.1,0.3,mg,1.6,0.4,,2
-Fer,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0.1,0,0,0.1,mg,0.8,0.2,,2
+Fer,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparation pour nourrissons,,,0.1,0,0,0.1,mg,0.8,0.2,,2
 Fer,Enfants 1 à 8 ans,2443,des,Boissons (excluant laits),,,,,0.3,0,0.3,0.4,mg,3.2,0.2,,1
 Fer,Enfants 1 à 8 ans,20,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0,mg,0,0,,2
 Fer,Enfants 1 à 8 ans,141,des,Boissons (excluant laits),du,Café et thé,,,0,0,0,0,mg,0,0,,2
@@ -2635,7 +2635,7 @@ Fer,Enfants 1 à 8 ans,1810,des,Produits laitiers et Boissons à base de plantes
 Fer,Enfants 1 à 8 ans,854,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,0,0,0,0,mg,0.4,0.1,,3
 Fer,Enfants 1 à 8 ans,128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0,0,0,0,mg,0.3,0,,3
 Fer,Enfants 1 à 8 ans,1078,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,0,0,0,0,mg,0.3,0,,3
-Fer,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0,0,0,0,mg,0,0,,3
+Fer,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,0,0,0,0,mg,0,0,,3
 Fer,Enfants 1 à 8 ans,739,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0,0,0,0,mg,0,0,,3
 Fer,Enfants 1 à 8 ans,2270,des,Graisses et huiles,,,,,0,0,0,0,mg,0.1,0,,1
 Fer,Enfants 1 à 8 ans,83,des,Graisses et huiles,des,Graisses animales,,,0,0,0,0,mg,0,0,,2
@@ -2651,8 +2651,8 @@ Fer,Enfants 1 à 8 ans,2428,des,Fruits et légumes,,,,,1.2,0,1.2,1.3,mg,12.1,0.4
 Fer,Enfants 1 à 8 ans,2117,des,Fruits et légumes,des,Fruits,,,0.4,0,0.4,0.5,mg,4.3,0.2,,2
 Fer,Enfants 1 à 8 ans,2235,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,0.8,0,0.7,0.9,mg,7.8,0.3,,2
 Fer,Enfants 1 à 8 ans,830,des,Fruits et légumes,des,Fruits,des,Baies,0.1,0,0.1,0.1,mg,0.9,0.1,,3
-Fer,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pommes,0.1,0,0.1,0.1,mg,0.8,0,,3
-Fer,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Bananes,0.1,0,0.1,0.1,mg,0.7,0,,3
+Fer,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pomme,0.1,0,0.1,0.1,mg,0.8,0,,3
+Fer,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Banane,0.1,0,0.1,0.1,mg,0.7,0,,3
 Fer,Enfants 1 à 8 ans,572,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,0.1,0,0,0.1,mg,0.6,0.1,,3
 Fer,Enfants 1 à 8 ans,219,des,Fruits et légumes,des,Fruits,des,Melons,0,0,0,0,mg,0.3,0,,3
 Fer,Enfants 1 à 8 ans,260,des,Fruits et légumes,des,Fruits,des,Autres fruits,0,0,0,0,mg,0.3,0,,3
@@ -2669,7 +2669,7 @@ Fer,Enfants 1 à 8 ans,875,des,Fruits et légumes,des,Légumes incluant pommes d
 Fer,Enfants 1 à 8 ans,2475,des,Produits céréaliers,,,,,5.8,0.1,5.6,6,mg,56.7,0.8,,1
 Fer,Enfants 1 à 8 ans,2114,des,Produits céréaliers,des,Pains,,,2.2,0.1,2,2.3,mg,21.1,0.7,,2
 Fer,Enfants 1 à 8 ans,1282,des,Produits céréaliers,des,Céréales pour déjeuner,,,1.8,0.1,1.6,1.9,mg,17.2,0.7,,2
-Fer,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.5,0,0.4,0.5,mg,4.8,0.3,,2
+Fer,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,0.5,0,0.4,0.5,mg,4.8,0.3,,2
 Fer,Enfants 1 à 8 ans,2037,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,1.4,0.1,1.3,1.5,mg,13.6,0.6,,2
 Fer,Enfants 1 à 8 ans,951,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,0.9,0.1,0.8,1,mg,8.6,0.6,,3
 Fer,Enfants 1 à 8 ans,805,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,0.6,0,0.5,0.7,mg,5.5,0.5,,3
@@ -2677,9 +2677,9 @@ Fer,Enfants 1 à 8 ans,813,des,Produits céréaliers,des,Pains,des,Pains et peti
 Fer,Enfants 1 à 8 ans,745,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.3,0,0.2,0.3,mg,2.8,0.3,,3
 Fer,Enfants 1 à 8 ans,670,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),1,0.1,0.8,1.1,mg,9.3,0.6,,3
 Fer,Enfants 1 à 8 ans,728,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.8,0.1,0.7,0.9,mg,7.9,0.6,,3
-Fer,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.1,mg,0.7,0.1,,3
-Fer,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mg,0.1,0,,3
-Fer,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mg,0.1,0,,3
+Fer,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.1,mg,0.7,0.1,,3
+Fer,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mg,0.1,0,,3
+Fer,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mg,0.1,0,,3
 Fer,Enfants 1 à 8 ans,1461,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.8,0.1,0.7,0.9,mg,8.1,0.5,,3
 Fer,Enfants 1 à 8 ans,834,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.5,0,0.4,0.5,mg,4.7,0.3,,3
 Fer,Enfants 1 à 8 ans,654,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0.1,0,0.1,0.1,mg,0.8,0.1,,3
@@ -2709,23 +2709,23 @@ Fer,Enfants 1 à 8 ans,2295,des,Soupes - sauces - Épices et autres ingrédients
 Fer,Enfants 1 à 8 ans,761,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.1,0,0,0.1,mg,0.6,0.1,,2
 Fer,Enfants 1 à 8 ans,532,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0.1,0,0,0.1,mg,0.7,0.1,,2
 Fer,Enfants 1 à 8 ans,2205,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.1,0,0.1,0.1,mg,0.8,0.1,,2
-Fer,Enfants 1 à 8 ans,2106,des,Confiseries - sucres et grignotines salées,,,,,0.5,0,0.4,0.6,mg,4.9,0.4,,1
-Fer,Enfants 1 à 8 ans,1048,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,0.2,0,0.1,0.2,mg,1.5,0.1,,2
-Fer,Enfants 1 à 8 ans,497,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,0.1,0,0.1,0.1,mg,0.7,0.1,,2
-Fer,Enfants 1 à 8 ans,615,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0.1,0,0.1,0.1,mg,1.2,0.1,,2
-Fer,Enfants 1 à 8 ans,1642,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.2,0,0.1,0.2,mg,1.6,0.4,,2
-Fer,Enfants 1 à 8 ans,548,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0.1,0,0.1,0.1,mg,1,0.1,,3
-Fer,Enfants 1 à 8 ans,131,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0,0,0,0,mg,0.3,0.1,,3
-Fer,Enfants 1 à 8 ans,557,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0,0,0,0,mg,0.2,0,,3
-Fer,Enfants 1 à 8 ans,346,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0,0,0,0.1,mg,0.4,0.1,,3
-Fer,Enfants 1 à 8 ans,184,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,mg,0.3,0,,3
-Fer,Enfants 1 à 8 ans,720,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.2,0,0.1,0.2,mg,1.5,0.4,,3
-Fer,Enfants 1 à 8 ans,257,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,mg,0.1,0,,3
-Fer,Enfants 1 à 8 ans,1341,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,mg,0,0,,3
-Fer,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,mg,X,X,<10,3
+Fer,Enfants 1 à 8 ans,2106,des,Confiserie - sucres et grignotines salées,,,,,0.5,0,0.4,0.6,mg,4.9,0.4,,1
+Fer,Enfants 1 à 8 ans,1048,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,0.2,0,0.1,0.2,mg,1.5,0.1,,2
+Fer,Enfants 1 à 8 ans,497,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,0.1,0,0.1,0.1,mg,0.7,0.1,,2
+Fer,Enfants 1 à 8 ans,615,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,0.1,0,0.1,0.1,mg,1.2,0.1,,2
+Fer,Enfants 1 à 8 ans,1642,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.2,0,0.1,0.2,mg,1.6,0.4,,2
+Fer,Enfants 1 à 8 ans,548,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,0.1,0,0.1,0.1,mg,1,0.1,,3
+Fer,Enfants 1 à 8 ans,131,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0,0,0,0,mg,0.3,0.1,,3
+Fer,Enfants 1 à 8 ans,557,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,0,0,0,0,mg,0.2,0,,3
+Fer,Enfants 1 à 8 ans,346,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0,0,0,0.1,mg,0.4,0.1,,3
+Fer,Enfants 1 à 8 ans,184,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,mg,0.3,0,,3
+Fer,Enfants 1 à 8 ans,720,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.2,0,0.1,0.2,mg,1.5,0.4,,3
+Fer,Enfants 1 à 8 ans,257,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,mg,0.1,0,,3
+Fer,Enfants 1 à 8 ans,1341,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,mg,0,0,,3
+Fer,Enfants 1 à 8 ans,,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,mg,X,X,<10,3
 Potassium,Population 1 an et +,186,des,Aliments pour bébés,,,,,1.8,0.4,1.1,2.5,mg,0.1,0,E,1
 Potassium,Population 1 an et +,154,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,1.3,0.3,0.7,2,mg,0.1,0,E,2
-Potassium,Population 1 an et +,51,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0.5,0.1,0.2,0.7,mg,0,0,E,2
+Potassium,Population 1 an et +,51,des,Aliments pour bébés,des,Préparation pour nourrissons,,,0.5,0.1,0.2,0.7,mg,0,0,E,2
 Potassium,Population 1 an et +,19574,des,Boissons (excluant laits),,,,,375.6,5.1,365.5,385.6,mg,14.3,0.2,,1
 Potassium,Population 1 an et +,3540,des,Boissons (excluant laits),de l',Alcool,,,50.4,2.1,46.2,54.5,mg,1.9,0.1,,2
 Potassium,Population 1 an et +,12127,des,Boissons (excluant laits),du,Café et thé,,,166.2,3,160.4,172,mg,6.3,0.1,,2
@@ -2748,7 +2748,7 @@ Potassium,Population 1 an et +,12441,des,Produits laitiers et Boissons à base d
 Potassium,Population 1 an et +,6481,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,67.8,2.6,62.6,72.9,mg,2.6,0.1,,3
 Potassium,Population 1 an et +,5835,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,40.3,2.5,35.4,45.1,mg,1.5,0.1,,3
 Potassium,Population 1 an et +,6026,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,24.8,1.3,22.1,27.4,mg,0.9,0.1,,3
-Potassium,Population 1 an et +,4411,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,13,0.7,11.6,14.4,mg,0.5,0,,3
+Potassium,Population 1 an et +,4411,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,13,0.7,11.6,14.4,mg,0.5,0,,3
 Potassium,Population 1 an et +,814,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,13.7,1.2,11.4,16,mg,0.5,0,,3
 Potassium,Population 1 an et +,18258,des,Graisses et huiles,,,,,6.5,0.2,6.2,6.8,mg,0.2,0,,1
 Potassium,Population 1 an et +,944,des,Graisses et huiles,des,Graisses animales,,,0.1,0,0.1,0.1,mg,0,0,,2
@@ -2763,8 +2763,8 @@ Potassium,Population 1 an et +,924,des,Poissons et fruits de mer,des,Mollusques 
 Potassium,Population 1 an et +,18914,des,Fruits et légumes,,,,,866.6,10.8,845.3,887.8,mg,33.1,0.3,,1
 Potassium,Population 1 an et +,13689,des,Fruits et légumes,des,Fruits,,,300.2,5.5,289.5,311,mg,11.5,0.2,,2
 Potassium,Population 1 an et +,17977,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,566.3,8.5,549.7,583,mg,21.6,0.3,,2
-Potassium,Population 1 an et +,5308,des,Fruits et légumes,des,Fruits,des,Bananes,104.4,2.8,98.8,109.9,mg,4,0.1,,3
-Potassium,Population 1 an et +,5026,des,Fruits et légumes,des,Fruits,des,Pommes,42.8,1.4,40.1,45.6,mg,1.6,0.1,,3
+Potassium,Population 1 an et +,5308,des,Fruits et légumes,des,Fruits,des,Banane,104.4,2.8,98.8,109.9,mg,4,0.1,,3
+Potassium,Population 1 an et +,5026,des,Fruits et légumes,des,Fruits,des,Pomme,42.8,1.4,40.1,45.6,mg,1.6,0.1,,3
 Potassium,Population 1 an et +,3372,des,Fruits et légumes,des,Fruits,des,Agrumes,33.5,1.4,30.8,36.3,mg,1.3,0.1,,3
 Potassium,Population 1 an et +,2103,des,Fruits et légumes,des,Fruits,des,Autres fruits,35.3,2.3,30.8,39.9,mg,1.3,0.1,,3
 Potassium,Population 1 an et +,2881,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,20.3,1.2,17.9,22.6,mg,0.8,0,,3
@@ -2782,7 +2782,7 @@ Potassium,Population 1 an et +,6318,des,Fruits et légumes,des,Légumes incluant
 Potassium,Population 1 an et +,19327,des,Produits céréaliers,,,,,251.1,2.5,246.1,256.1,mg,9.6,0.1,,1
 Potassium,Population 1 an et +,16168,des,Produits céréaliers,des,Pains,,,125.5,1.9,121.8,129.3,mg,4.8,0.1,,2
 Potassium,Population 1 an et +,6966,des,Produits céréaliers,des,Céréales pour déjeuner,,,45.6,1.5,42.7,48.5,mg,1.7,0.1,,2
-Potassium,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,18.3,0.7,17,19.7,mg,0.7,0,,2
+Potassium,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,18.3,0.7,17,19.7,mg,0.7,0,,2
 Potassium,Population 1 an et +,14820,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,61.6,1.1,59.4,63.8,mg,2.4,0,,2
 Potassium,Population 1 an et +,8159,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,40.9,1.1,38.8,43,mg,1.6,0,,3
 Potassium,Population 1 an et +,5962,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,43,1.2,40.6,45.5,mg,1.6,0,,3
@@ -2790,10 +2790,10 @@ Potassium,Population 1 an et +,6257,des,Produits céréaliers,des,Pains,des,Autr
 Potassium,Population 1 an et +,2918,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,5.6,0.3,5,6.2,mg,0.2,0,,3
 Potassium,Population 1 an et +,4760,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,40.4,1.5,37.5,43.3,mg,1.5,0.1,,3
 Potassium,Population 1 an et +,2573,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),5.2,0.3,4.7,5.7,mg,0.2,0,,3
-Potassium,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,7.9,0.5,6.9,8.9,mg,0.3,0,,3
-Potassium,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.6,0.1,0.4,0.8,mg,0,0,E,3
-Potassium,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.2,0,0.1,0.3,mg,0,0,,3
-Potassium,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
+Potassium,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,7.9,0.5,6.9,8.9,mg,0.3,0,,3
+Potassium,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0.6,0.1,0.4,0.8,mg,0,0,E,3
+Potassium,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.2,0,0.1,0.3,mg,0,0,,3
+Potassium,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
 Potassium,Population 1 an et +,11102,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,30,0.9,28.3,31.8,mg,1.1,0,,3
 Potassium,Population 1 an et +,4543,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,16.3,0.6,15.2,17.5,mg,0.6,0,,3
 Potassium,Population 1 an et +,4598,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,15.3,0.6,14.1,16.4,mg,0.6,0,,3
@@ -2823,23 +2823,23 @@ Potassium,Population 1 an et +,18438,des,Soupes - sauces - Épices et autres ing
 Potassium,Population 1 an et +,7054,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,27.5,0.9,25.6,29.3,mg,1,0,,2
 Potassium,Population 1 an et +,4710,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,35.3,1.8,31.8,38.7,mg,1.3,0.1,,2
 Potassium,Population 1 an et +,17547,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,14.4,0.7,13.1,15.8,mg,0.6,0,,2
-Potassium,Population 1 an et +,16725,des,Confiseries - sucres et grignotines salées,,,,,125.1,3.5,118.2,132,mg,4.8,0.1,,1
-Potassium,Population 1 an et +,6211,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,20.9,1.1,18.7,23,mg,0.8,0,,2
-Potassium,Population 1 an et +,2912,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,28.6,1.3,26,31.2,mg,1.1,0,,2
-Potassium,Population 1 an et +,4652,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,58.8,3.2,52.5,65.1,mg,2.2,0.1,,2
-Potassium,Population 1 an et +,14214,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,16.8,0.9,15.1,18.6,mg,0.6,0,,2
-Potassium,Population 1 an et +,3815,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,15.4,0.8,13.8,17.1,mg,0.6,0,,3
-Potassium,Population 1 an et +,2559,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,3.5,0.7,2.1,5,mg,0.1,0,E,3
-Potassium,Population 1 an et +,703,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,2,0.2,1.5,2.4,mg,0.1,0,,3
-Potassium,Population 1 an et +,2447,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,28.1,1.3,25.5,30.6,mg,1.1,0,,3
-Potassium,Population 1 an et +,560,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0.6,0.1,0.4,0.7,mg,0,0,E,3
-Potassium,Population 1 an et +,4750,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,14.1,0.9,12.4,15.8,mg,0.5,0,,3
-Potassium,Population 1 an et +,2044,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,1.6,0.1,1.3,1.8,mg,0.1,0,,3
-Potassium,Population 1 an et +,715,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mg,0,0,,3
-Potassium,Population 1 an et +,12217,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,1.2,0.1,1,1.3,mg,0,0,,3
+Potassium,Population 1 an et +,16725,des,Confiserie - sucres et grignotines salées,,,,,125.1,3.5,118.2,132,mg,4.8,0.1,,1
+Potassium,Population 1 an et +,6211,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,20.9,1.1,18.7,23,mg,0.8,0,,2
+Potassium,Population 1 an et +,2912,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,28.6,1.3,26,31.2,mg,1.1,0,,2
+Potassium,Population 1 an et +,4652,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,58.8,3.2,52.5,65.1,mg,2.2,0.1,,2
+Potassium,Population 1 an et +,14214,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,16.8,0.9,15.1,18.6,mg,0.6,0,,2
+Potassium,Population 1 an et +,3815,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,15.4,0.8,13.8,17.1,mg,0.6,0,,3
+Potassium,Population 1 an et +,2559,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,3.5,0.7,2.1,5,mg,0.1,0,E,3
+Potassium,Population 1 an et +,703,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,2,0.2,1.5,2.4,mg,0.1,0,,3
+Potassium,Population 1 an et +,2447,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,28.1,1.3,25.5,30.6,mg,1.1,0,,3
+Potassium,Population 1 an et +,560,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0.6,0.1,0.4,0.7,mg,0,0,E,3
+Potassium,Population 1 an et +,4750,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,14.1,0.9,12.4,15.8,mg,0.5,0,,3
+Potassium,Population 1 an et +,2044,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,1.6,0.1,1.3,1.8,mg,0.1,0,,3
+Potassium,Population 1 an et +,715,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mg,0,0,,3
+Potassium,Population 1 an et +,12217,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,1.2,0.1,1,1.3,mg,0,0,,3
 Potassium,Hommes adultes 19 ans +,22,des,Aliments pour bébés,,,,,F,F,,,mg,F,F,F,1
 Potassium,Hommes adultes 19 ans +,21,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,F,F,,,mg,F,F,F,2
-Potassium,Hommes adultes 19 ans +,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,mg,X,X,<10,2
+Potassium,Hommes adultes 19 ans +,,des,Aliments pour bébés,des,Préparation pour nourrissons,,,X,X,,,mg,X,X,<10,2
 Potassium,Hommes adultes 19 ans +,6187,des,Boissons (excluant laits),,,,,462.7,9.9,443.3,482,mg,15.6,0.3,,1
 Potassium,Hommes adultes 19 ans +,1946,des,Boissons (excluant laits),de l',Alcool,,,79.8,4.2,71.6,88.1,mg,2.7,0.1,,2
 Potassium,Hommes adultes 19 ans +,5104,des,Boissons (excluant laits),du,Café et thé,,,220.5,6.1,208.6,232.5,mg,7.5,0.2,,2
@@ -2862,7 +2862,7 @@ Potassium,Hommes adultes 19 ans +,3759,des,Produits laitiers et Boissons à base
 Potassium,Hommes adultes 19 ans +,1819,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,65.4,4.1,57.2,73.5,mg,2.2,0.1,,3
 Potassium,Hommes adultes 19 ans +,1648,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,34.9,5,25.2,44.6,mg,1.2,0.2,,3
 Potassium,Hommes adultes 19 ans +,1812,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,24,2.4,19.3,28.6,mg,0.8,0.1,,3
-Potassium,Hommes adultes 19 ans +,1727,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,16.4,1.6,13.3,19.6,mg,0.6,0.1,,3
+Potassium,Hommes adultes 19 ans +,1727,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,16.4,1.6,13.3,19.6,mg,0.6,0.1,,3
 Potassium,Hommes adultes 19 ans +,208,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,13.4,2.3,9,17.8,mg,0.5,0.1,E,3
 Potassium,Hommes adultes 19 ans +,5767,des,Graisses et huiles,,,,,7.3,0.2,6.9,7.8,mg,0.2,0,,1
 Potassium,Hommes adultes 19 ans +,333,des,Graisses et huiles,des,Graisses animales,,,0.1,0,0.1,0.1,mg,0,0,,2
@@ -2877,8 +2877,8 @@ Potassium,Hommes adultes 19 ans +,343,des,Poissons et fruits de mer,des,Mollusqu
 Potassium,Hommes adultes 19 ans +,5918,des,Fruits et légumes,,,,,941.6,18.9,904.4,978.8,mg,31.8,0.5,,1
 Potassium,Hommes adultes 19 ans +,3876,des,Fruits et légumes,des,Fruits,,,301.2,9.3,283,319.4,mg,10.2,0.3,,2
 Potassium,Hommes adultes 19 ans +,5694,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,640.4,16.2,608.6,672.3,mg,21.6,0.4,,2
-Potassium,Hommes adultes 19 ans +,1590,des,Fruits et légumes,des,Fruits,des,Bananes,120.7,5.7,109.5,131.8,mg,4.1,0.2,,3
-Potassium,Hommes adultes 19 ans +,1350,des,Fruits et légumes,des,Fruits,des,Pommes,42.3,2.6,37.2,47.3,mg,1.4,0.1,,3
+Potassium,Hommes adultes 19 ans +,1590,des,Fruits et légumes,des,Fruits,des,Banane,120.7,5.7,109.5,131.8,mg,4.1,0.2,,3
+Potassium,Hommes adultes 19 ans +,1350,des,Fruits et légumes,des,Fruits,des,Pomme,42.3,2.6,37.2,47.3,mg,1.4,0.1,,3
 Potassium,Hommes adultes 19 ans +,1019,des,Fruits et légumes,des,Fruits,des,Agrumes,32.2,2.4,27.5,36.8,mg,1.1,0.1,,3
 Potassium,Hommes adultes 19 ans +,603,des,Fruits et légumes,des,Fruits,des,Autres fruits,31,3.5,24.2,37.9,mg,1,0.1,,3
 Potassium,Hommes adultes 19 ans +,782,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,17.2,1.6,14.1,20.3,mg,0.6,0.1,,3
@@ -2896,7 +2896,7 @@ Potassium,Hommes adultes 19 ans +,1991,des,Fruits et légumes,des,Légumes inclu
 Potassium,Hommes adultes 19 ans +,6068,des,Produits céréaliers,,,,,283.3,4.5,274.4,292.3,mg,9.6,0.2,,1
 Potassium,Hommes adultes 19 ans +,5104,des,Produits céréaliers,des,Pains,,,144.7,3.5,137.9,151.5,mg,4.9,0.1,,2
 Potassium,Hommes adultes 19 ans +,1921,des,Produits céréaliers,des,Céréales pour déjeuner,,,50.6,2.7,45.3,56,mg,1.7,0.1,,2
-Potassium,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,18.8,1.4,16.1,21.5,mg,0.6,0,,2
+Potassium,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,18.8,1.4,16.1,21.5,mg,0.6,0,,2
 Potassium,Hommes adultes 19 ans +,4551,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,69.2,2.2,65,73.4,mg,2.3,0.1,,2
 Potassium,Hommes adultes 19 ans +,2752,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,51.4,2.1,47.2,55.6,mg,1.7,0.1,,3
 Potassium,Hommes adultes 19 ans +,1980,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,48.9,2.3,44.4,53.3,mg,1.7,0.1,,3
@@ -2904,9 +2904,9 @@ Potassium,Hommes adultes 19 ans +,1885,des,Produits céréaliers,des,Pains,des,A
 Potassium,Hommes adultes 19 ans +,593,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,4.2,0.4,3.4,4.9,mg,0.1,0,,3
 Potassium,Hommes adultes 19 ans +,1481,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,47.2,2.7,41.9,52.5,mg,1.6,0.1,,3
 Potassium,Hommes adultes 19 ans +,523,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),3.5,0.4,2.8,4.1,mg,0.1,0,,3
-Potassium,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,8.9,1.1,6.7,11.1,mg,0.3,0,,3
-Potassium,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.6,0.2,0.1,1.1,mg,0,0,E,3
-Potassium,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,F,F,,,mg,F,F,F,3
+Potassium,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,8.9,1.1,6.7,11.1,mg,0.3,0,,3
+Potassium,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0.6,0.2,0.1,1.1,mg,0,0,E,3
+Potassium,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,F,F,,,mg,F,F,F,3
 Potassium,Hommes adultes 19 ans +,3442,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,35.4,1.7,32,38.9,mg,1.2,0.1,,3
 Potassium,Hommes adultes 19 ans +,1250,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,16.9,1,14.9,18.9,mg,0.6,0,,3
 Potassium,Hommes adultes 19 ans +,1449,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,16.8,1,14.8,18.8,mg,0.6,0,,3
@@ -2936,23 +2936,23 @@ Potassium,Hommes adultes 19 ans +,5856,des,Soupes - sauces - Épices et autres i
 Potassium,Hommes adultes 19 ans +,2384,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,32.3,1.8,28.7,35.9,mg,1.1,0.1,,2
 Potassium,Hommes adultes 19 ans +,1511,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,41.8,3.4,35.2,48.5,mg,1.4,0.1,,2
 Potassium,Hommes adultes 19 ans +,5575,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,16.8,1.1,14.5,19,mg,0.6,0,,2
-Potassium,Hommes adultes 19 ans +,5232,des,Confiseries - sucres et grignotines salées,,,,,129.5,6.9,115.8,143.1,mg,4.4,0.2,,1
-Potassium,Hommes adultes 19 ans +,1527,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,19,1.9,15.2,22.8,mg,0.6,0.1,,2
-Potassium,Hommes adultes 19 ans +,771,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,25,2.2,20.8,29.2,mg,0.8,0.1,,2
-Potassium,Hommes adultes 19 ans +,1268,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,68.2,6.4,55.5,80.8,mg,2.3,0.2,,2
-Potassium,Hommes adultes 19 ans +,4671,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,17.3,1.6,14.2,20.5,mg,0.6,0.1,,2
-Potassium,Hommes adultes 19 ans +,1023,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,13.8,1,11.7,15.8,mg,0.5,0,,3
-Potassium,Hommes adultes 19 ans +,170,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,1.2,0.2,0.8,1.6,mg,0,0,E,3
-Potassium,Hommes adultes 19 ans +,497,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,F,F,,,mg,F,F,F,3
-Potassium,Hommes adultes 19 ans +,702,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,24.7,2.2,20.4,28.9,mg,0.8,0.1,,3
-Potassium,Hommes adultes 19 ans +,80,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0.4,0.1,0.1,0.6,mg,0,0,E,3
-Potassium,Hommes adultes 19 ans +,1360,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,14,1.5,11,17,mg,0.5,0.1,,3
-Potassium,Hommes adultes 19 ans +,726,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,2,0.3,1.4,2.5,mg,0.1,0,,3
-Potassium,Hommes adultes 19 ans +,322,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mg,0,0,,3
-Potassium,Hommes adultes 19 ans +,4068,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,1.4,0.1,1.1,1.7,mg,0,0,,3
+Potassium,Hommes adultes 19 ans +,5232,des,Confiserie - sucres et grignotines salées,,,,,129.5,6.9,115.8,143.1,mg,4.4,0.2,,1
+Potassium,Hommes adultes 19 ans +,1527,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,19,1.9,15.2,22.8,mg,0.6,0.1,,2
+Potassium,Hommes adultes 19 ans +,771,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,25,2.2,20.8,29.2,mg,0.8,0.1,,2
+Potassium,Hommes adultes 19 ans +,1268,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,68.2,6.4,55.5,80.8,mg,2.3,0.2,,2
+Potassium,Hommes adultes 19 ans +,4671,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,17.3,1.6,14.2,20.5,mg,0.6,0.1,,2
+Potassium,Hommes adultes 19 ans +,1023,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,13.8,1,11.7,15.8,mg,0.5,0,,3
+Potassium,Hommes adultes 19 ans +,170,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,1.2,0.2,0.8,1.6,mg,0,0,E,3
+Potassium,Hommes adultes 19 ans +,497,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,F,F,,,mg,F,F,F,3
+Potassium,Hommes adultes 19 ans +,702,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,24.7,2.2,20.4,28.9,mg,0.8,0.1,,3
+Potassium,Hommes adultes 19 ans +,80,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0.4,0.1,0.1,0.6,mg,0,0,E,3
+Potassium,Hommes adultes 19 ans +,1360,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,14,1.5,11,17,mg,0.5,0.1,,3
+Potassium,Hommes adultes 19 ans +,726,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,2,0.3,1.4,2.5,mg,0.1,0,,3
+Potassium,Hommes adultes 19 ans +,322,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mg,0,0,,3
+Potassium,Hommes adultes 19 ans +,4068,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,1.4,0.1,1.1,1.7,mg,0,0,,3
 Potassium,Femmes adultes* 19 ans +,21,des,Aliments pour bébés,,,,,0.4,0.1,0.1,0.6,mg,0,0,E,1
 Potassium,Femmes adultes* 19 ans +,19,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0.3,0.1,0.1,0.6,mg,0,0,E,2
-Potassium,Femmes adultes* 19 ans +,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,mg,X,X,<10,2
+Potassium,Femmes adultes* 19 ans +,,des,Aliments pour bébés,des,Préparation pour nourrissons,,,X,X,,,mg,X,X,<10,2
 Potassium,Femmes adultes* 19 ans +,6828,des,Boissons (excluant laits),,,,,356.1,7.6,341.1,371.1,mg,14.9,0.3,,1
 Potassium,Femmes adultes* 19 ans +,1439,des,Boissons (excluant laits),de l',Alcool,,,46.7,3,40.7,52.7,mg,1.9,0.1,,2
 Potassium,Femmes adultes* 19 ans +,5777,des,Boissons (excluant laits),du,Café et thé,,,188.4,4.3,180,196.8,mg,7.9,0.2,,2
@@ -2976,7 +2976,7 @@ Potassium,Femmes adultes* 19 ans +,2244,des,Produits laitiers et Boissons à bas
 Potassium,Femmes adultes* 19 ans +,2211,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,25.9,1.9,22.1,29.6,mg,1.1,0.1,,3
 Potassium,Femmes adultes* 19 ans +,1928,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,23,3.1,16.9,29.2,mg,1,0.1,,3
 Potassium,Femmes adultes* 19 ans +,358,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,14.9,1.7,11.5,18.3,mg,0.6,0.1,,3
-Potassium,Femmes adultes* 19 ans +,1769,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,12.4,0.8,10.9,13.9,mg,0.5,0,,3
+Potassium,Femmes adultes* 19 ans +,1769,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,12.4,0.8,10.9,13.9,mg,0.5,0,,3
 Potassium,Femmes adultes* 19 ans +,6356,des,Graisses et huiles,,,,,6.8,0.3,6.3,7.3,mg,0.3,0,,1
 Potassium,Femmes adultes* 19 ans +,369,des,Graisses et huiles,des,Graisses animales,,,0.1,0,0.1,0.2,mg,0,0,,2
 Potassium,Femmes adultes* 19 ans +,1972,des,Graisses et huiles,du,Beurre,,,0.8,0.1,0.6,0.9,mg,0,0,,2
@@ -2990,10 +2990,10 @@ Potassium,Femmes adultes* 19 ans +,370,des,Poissons et fruits de mer,des,Mollusq
 Potassium,Femmes adultes* 19 ans +,6595,des,Fruits et légumes,,,,,863.9,17.3,829.9,898,mg,36.1,0.5,,1
 Potassium,Femmes adultes* 19 ans +,4951,des,Fruits et légumes,des,Fruits,,,297.4,8.4,280.9,313.9,mg,12.4,0.3,,2
 Potassium,Femmes adultes* 19 ans +,6291,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,566.5,13.4,540.2,592.9,mg,23.6,0.4,,2
-Potassium,Femmes adultes* 19 ans +,1919,des,Fruits et légumes,des,Fruits,des,Bananes,94.6,4.4,86,103.2,mg,3.9,0.2,,3
+Potassium,Femmes adultes* 19 ans +,1919,des,Fruits et légumes,des,Fruits,des,Banane,94.6,4.4,86,103.2,mg,3.9,0.2,,3
 Potassium,Femmes adultes* 19 ans +,854,des,Fruits et légumes,des,Fruits,des,Autres fruits,42.6,4,34.6,50.5,mg,1.8,0.2,,3
 Potassium,Femmes adultes* 19 ans +,1356,des,Fruits et légumes,des,Fruits,des,Agrumes,37.6,2.3,33.1,42,mg,1.6,0.1,,3
-Potassium,Femmes adultes* 19 ans +,1574,des,Fruits et légumes,des,Fruits,des,Pommes,36.9,2.1,32.7,41,mg,1.5,0.1,,3
+Potassium,Femmes adultes* 19 ans +,1574,des,Fruits et légumes,des,Fruits,des,Pomme,36.9,2.1,32.7,41,mg,1.5,0.1,,3
 Potassium,Femmes adultes* 19 ans +,1006,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,20.9,2.2,16.7,25.2,mg,0.9,0.1,,3
 Potassium,Femmes adultes* 19 ans +,1597,des,Fruits et légumes,des,Fruits,des,Baies,17.1,1.1,15.1,19.2,mg,0.7,0,,3
 Potassium,Femmes adultes* 19 ans +,306,des,Fruits et légumes,des,Fruits,des,Melons,17.6,2.5,12.7,22.5,mg,0.7,0.1,,3
@@ -3009,7 +3009,7 @@ Potassium,Femmes adultes* 19 ans +,2348,des,Fruits et légumes,des,Légumes incl
 Potassium,Femmes adultes* 19 ans +,6669,des,Produits céréaliers,,,,,216.5,3.7,209.3,223.7,mg,9,0.2,,1
 Potassium,Femmes adultes* 19 ans +,5520,des,Produits céréaliers,des,Pains,,,109.6,2.4,104.9,114.2,mg,4.6,0.1,,2
 Potassium,Femmes adultes* 19 ans +,2230,des,Produits céréaliers,des,Céréales pour déjeuner,,,41.2,2.2,36.7,45.6,mg,1.7,0.1,,2
-Potassium,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,12.9,0.8,11.4,14.5,mg,0.5,0,,2
+Potassium,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,12.9,0.8,11.4,14.5,mg,0.5,0,,2
 Potassium,Femmes adultes* 19 ans +,4893,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,52.9,1.8,49.4,56.4,mg,2.2,0.1,,2
 Potassium,Femmes adultes* 19 ans +,2239,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,42.2,1.7,38.9,45.5,mg,1.8,0.1,,3
 Potassium,Femmes adultes* 19 ans +,1994,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,30.2,1.7,26.8,33.6,mg,1.3,0.1,,3
@@ -3017,10 +3017,10 @@ Potassium,Femmes adultes* 19 ans +,2551,des,Produits céréaliers,des,Pains,des,
 Potassium,Femmes adultes* 19 ans +,914,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,5,0.6,3.9,6.2,mg,0.2,0,,3
 Potassium,Femmes adultes* 19 ans +,1756,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,38.4,2.3,34,42.9,mg,1.6,0.1,,3
 Potassium,Femmes adultes* 19 ans +,555,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),2.8,0.3,2.2,3.3,mg,0.1,0,,3
-Potassium,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,4.4,0.5,3.4,5.4,mg,0.2,0,,3
-Potassium,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.3,0.1,0.2,0.5,mg,0,0,E,3
-Potassium,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,F,F,,,mg,F,F,F,3
-Potassium,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
+Potassium,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,4.4,0.5,3.4,5.4,mg,0.2,0,,3
+Potassium,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0.3,0.1,0.2,0.5,mg,0,0,E,3
+Potassium,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,F,F,,,mg,F,F,F,3
+Potassium,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
 Potassium,Femmes adultes* 19 ans +,3664,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,25.5,1.3,22.9,28.1,mg,1.1,0.1,,3
 Potassium,Femmes adultes* 19 ans +,1358,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,13.2,0.9,11.5,14.9,mg,0.6,0,,3
 Potassium,Femmes adultes* 19 ans +,1522,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,14.2,0.9,12.3,16,mg,0.6,0,,3
@@ -3050,23 +3050,23 @@ Potassium,Femmes adultes* 19 ans +,6382,des,Soupes - sauces - Épices et autres 
 Potassium,Femmes adultes* 19 ans +,2243,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,23.7,1.3,21.1,26.3,mg,1,0.1,,2
 Potassium,Femmes adultes* 19 ans +,1853,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,37,3,31.1,42.8,mg,1.5,0.1,,2
 Potassium,Femmes adultes* 19 ans +,6077,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,14.2,1.1,12,16.5,mg,0.6,0,,2
-Potassium,Femmes adultes* 19 ans +,5713,des,Confiseries - sucres et grignotines salées,,,,,106.8,4.8,97.3,116.3,mg,4.5,0.2,,1
-Potassium,Femmes adultes* 19 ans +,1936,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,21.4,2,17.4,25.4,mg,0.9,0.1,,2
-Potassium,Femmes adultes* 19 ans +,844,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,26.5,2.2,22.2,30.7,mg,1.1,0.1,,2
-Potassium,Femmes adultes* 19 ans +,1411,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,43.3,3.8,35.9,50.7,mg,1.8,0.2,,2
-Potassium,Femmes adultes* 19 ans +,4937,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,15.7,1.4,13,18.3,mg,0.7,0.1,,2
-Potassium,Femmes adultes* 19 ans +,1238,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,16.3,1.8,12.8,19.8,mg,0.7,0.1,,3
-Potassium,Femmes adultes* 19 ans +,685,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,3.1,0.7,1.7,4.5,mg,0.1,0,E,3
-Potassium,Femmes adultes* 19 ans +,229,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,2,0.4,1.2,2.9,mg,0.1,0,E,3
-Potassium,Femmes adultes* 19 ans +,762,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,26,2.2,21.7,30.3,mg,1.1,0.1,,3
-Potassium,Femmes adultes* 19 ans +,87,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0.4,0.1,0.2,0.7,mg,0,0,E,3
-Potassium,Femmes adultes* 19 ans +,1529,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,13.3,1.4,10.6,16,mg,0.6,0.1,,3
-Potassium,Femmes adultes* 19 ans +,773,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,1.2,0.1,1,1.4,mg,0.1,0,,3
-Potassium,Femmes adultes* 19 ans +,360,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mg,0,0,,3
-Potassium,Femmes adultes* 19 ans +,4229,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,1.1,0.1,1,1.3,mg,0,0,,3
+Potassium,Femmes adultes* 19 ans +,5713,des,Confiserie - sucres et grignotines salées,,,,,106.8,4.8,97.3,116.3,mg,4.5,0.2,,1
+Potassium,Femmes adultes* 19 ans +,1936,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,21.4,2,17.4,25.4,mg,0.9,0.1,,2
+Potassium,Femmes adultes* 19 ans +,844,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,26.5,2.2,22.2,30.7,mg,1.1,0.1,,2
+Potassium,Femmes adultes* 19 ans +,1411,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,43.3,3.8,35.9,50.7,mg,1.8,0.2,,2
+Potassium,Femmes adultes* 19 ans +,4937,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,15.7,1.4,13,18.3,mg,0.7,0.1,,2
+Potassium,Femmes adultes* 19 ans +,1238,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,16.3,1.8,12.8,19.8,mg,0.7,0.1,,3
+Potassium,Femmes adultes* 19 ans +,685,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,3.1,0.7,1.7,4.5,mg,0.1,0,E,3
+Potassium,Femmes adultes* 19 ans +,229,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,2,0.4,1.2,2.9,mg,0.1,0,E,3
+Potassium,Femmes adultes* 19 ans +,762,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,26,2.2,21.7,30.3,mg,1.1,0.1,,3
+Potassium,Femmes adultes* 19 ans +,87,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0.4,0.1,0.2,0.7,mg,0,0,E,3
+Potassium,Femmes adultes* 19 ans +,1529,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,13.3,1.4,10.6,16,mg,0.6,0.1,,3
+Potassium,Femmes adultes* 19 ans +,773,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,1.2,0.1,1,1.4,mg,0.1,0,,3
+Potassium,Femmes adultes* 19 ans +,360,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mg,0,0,,3
+Potassium,Femmes adultes* 19 ans +,4229,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,1.1,0.1,1,1.3,mg,0,0,,3
 Potassium,Enfants 1 à 8 ans,122,des,Aliments pour bébés,,,,,11.9,2.4,7.1,16.6,mg,0.5,0.1,E,1
 Potassium,Enfants 1 à 8 ans,95,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,6.5,1.6,3.4,9.6,mg,0.3,0.1,E,2
-Potassium,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparations pour nourrissons,,,5.4,1.5,2.4,8.3,mg,0.2,0.1,E,2
+Potassium,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparation pour nourrissons,,,5.4,1.5,2.4,8.3,mg,0.2,0.1,E,2
 Potassium,Enfants 1 à 8 ans,2443,des,Boissons (excluant laits),,,,,214,9,196.3,231.8,mg,9.8,0.4,,1
 Potassium,Enfants 1 à 8 ans,20,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0.1,mg,0,0,,2
 Potassium,Enfants 1 à 8 ans,141,des,Boissons (excluant laits),du,Café et thé,,,F,F,,,mg,F,F,F,2
@@ -3090,7 +3090,7 @@ Potassium,Enfants 1 à 8 ans,1078,des,Produits laitiers et Boissons à base de p
 Potassium,Enfants 1 à 8 ans,854,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,88,9.9,68.6,107.4,mg,4,0.4,,3
 Potassium,Enfants 1 à 8 ans,739,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,14.5,2.4,9.7,19.3,mg,0.7,0.1,,3
 Potassium,Enfants 1 à 8 ans,128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,12.1,2.1,8.1,16.2,mg,0.6,0.1,E,3
-Potassium,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,6.1,1.5,3.2,9,mg,0.3,0.1,E,3
+Potassium,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,6.1,1.5,3.2,9,mg,0.3,0.1,E,3
 Potassium,Enfants 1 à 8 ans,2270,des,Graisses et huiles,,,,,3.2,0.2,2.8,3.6,mg,0.1,0,,1
 Potassium,Enfants 1 à 8 ans,83,des,Graisses et huiles,des,Graisses animales,,,0.1,0,0,0.1,mg,0,0,,2
 Potassium,Enfants 1 à 8 ans,657,des,Graisses et huiles,du,Beurre,,,0.4,0,0.4,0.5,mg,0,0,,2
@@ -3104,8 +3104,8 @@ Potassium,Enfants 1 à 8 ans,50,des,Poissons et fruits de mer,des,Mollusques et 
 Potassium,Enfants 1 à 8 ans,2428,des,Fruits et légumes,,,,,680.1,18.2,644.4,715.8,mg,31.2,0.6,,1
 Potassium,Enfants 1 à 8 ans,2117,des,Fruits et légumes,des,Fruits,,,331.3,11.1,309.5,353.1,mg,15.2,0.4,,2
 Potassium,Enfants 1 à 8 ans,2235,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,348.8,12.7,323.9,373.6,mg,16,0.5,,2
-Potassium,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Bananes,103.9,6,92.1,115.8,mg,4.8,0.3,,3
-Potassium,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pommes,57.8,3.6,50.7,65,mg,2.7,0.2,,3
+Potassium,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Banane,103.9,6,92.1,115.8,mg,4.8,0.3,,3
+Potassium,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pomme,57.8,3.6,50.7,65,mg,2.7,0.2,,3
 Potassium,Enfants 1 à 8 ans,421,des,Fruits et légumes,des,Fruits,des,Agrumes,31,2.7,25.8,36.3,mg,1.4,0.1,,3
 Potassium,Enfants 1 à 8 ans,572,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,31.5,4.5,22.7,40.3,mg,1.4,0.2,,3
 Potassium,Enfants 1 à 8 ans,830,des,Fruits et légumes,des,Fruits,des,Baies,27.4,2.3,22.8,32,mg,1.3,0.1,,3
@@ -3123,7 +3123,7 @@ Potassium,Enfants 1 à 8 ans,875,des,Fruits et légumes,des,Légumes incluant po
 Potassium,Enfants 1 à 8 ans,2475,des,Produits céréaliers,,,,,216.1,4.5,207.3,224.9,mg,9.9,0.2,,1
 Potassium,Enfants 1 à 8 ans,2114,des,Produits céréaliers,des,Pains,,,99.7,3.8,92.3,107.2,mg,4.6,0.2,,2
 Potassium,Enfants 1 à 8 ans,1282,des,Produits céréaliers,des,Céréales pour déjeuner,,,39,2,35.2,42.8,mg,1.8,0.1,,2
-Potassium,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,23.9,1.3,21.4,26.4,mg,1.1,0.1,,2
+Potassium,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,23.9,1.3,21.4,26.4,mg,1.1,0.1,,2
 Potassium,Enfants 1 à 8 ans,2037,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,53.5,2,49.5,57.4,mg,2.5,0.1,,2
 Potassium,Enfants 1 à 8 ans,813,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,32.1,1.9,28.3,35.9,mg,1.5,0.1,,3
 Potassium,Enfants 1 à 8 ans,951,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,31.2,2.9,25.5,37,mg,1.4,0.1,,3
@@ -3131,9 +3131,9 @@ Potassium,Enfants 1 à 8 ans,805,des,Produits céréaliers,des,Pains,des,Autres 
 Potassium,Enfants 1 à 8 ans,745,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,11.3,1.1,9.1,13.4,mg,0.5,0,,3
 Potassium,Enfants 1 à 8 ans,728,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,27,2,23.1,30.9,mg,1.2,0.1,,3
 Potassium,Enfants 1 à 8 ans,670,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),12,0.8,10.4,13.6,mg,0.6,0,,3
-Potassium,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,8.4,0.8,6.9,9.9,mg,0.4,0,,3
-Potassium,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.3,0.1,0.1,0.6,mg,0,0,E,3
-Potassium,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,F,F,,,mg,F,F,F,3
+Potassium,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,8.4,0.8,6.9,9.9,mg,0.4,0,,3
+Potassium,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.3,0.1,0.1,0.6,mg,0,0,E,3
+Potassium,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,F,F,,,mg,F,F,F,3
 Potassium,Enfants 1 à 8 ans,1461,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,21.6,1.4,18.9,24.3,mg,1,0.1,,3
 Potassium,Enfants 1 à 8 ans,834,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,20.3,1.5,17.3,23.2,mg,0.9,0.1,,3
 Potassium,Enfants 1 à 8 ans,654,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,11.6,0.9,9.9,13.3,mg,0.5,0,,3
@@ -3163,23 +3163,23 @@ Potassium,Enfants 1 à 8 ans,2295,des,Soupes - sauces - Épices et autres ingré
 Potassium,Enfants 1 à 8 ans,761,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,17.8,1.9,14,21.6,mg,0.8,0.1,,2
 Potassium,Enfants 1 à 8 ans,532,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,18.1,2.4,13.3,22.9,mg,0.8,0.1,,2
 Potassium,Enfants 1 à 8 ans,2205,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,8,0.7,6.6,9.4,mg,0.4,0,,2
-Potassium,Enfants 1 à 8 ans,2106,des,Confiseries - sucres et grignotines salées,,,,,99.2,5.5,88.4,109.9,mg,4.6,0.2,,1
-Potassium,Enfants 1 à 8 ans,1048,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,20.4,1.5,17.4,23.4,mg,0.9,0.1,,2
-Potassium,Enfants 1 à 8 ans,497,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,28,2.8,22.4,33.5,mg,1.3,0.1,,2
-Potassium,Enfants 1 à 8 ans,615,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,35.8,4,28,43.6,mg,1.6,0.2,,2
-Potassium,Enfants 1 à 8 ans,1642,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,15,1.6,11.9,18.2,mg,0.7,0.1,,2
-Potassium,Enfants 1 à 8 ans,548,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,12.1,1.1,10,14.2,mg,0.6,0,,3
-Potassium,Enfants 1 à 8 ans,557,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,3.4,0.5,2.5,4.4,mg,0.2,0,,3
-Potassium,Enfants 1 à 8 ans,131,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,4.9,1,3,6.8,mg,0.2,0,E,3
-Potassium,Enfants 1 à 8 ans,346,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,27,2.8,21.4,32.5,mg,1.2,0.1,,3
-Potassium,Enfants 1 à 8 ans,184,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,1,0.2,0.7,1.3,mg,0,0,E,3
-Potassium,Enfants 1 à 8 ans,720,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,13.3,1.6,10.2,16.4,mg,0.6,0.1,,3
-Potassium,Enfants 1 à 8 ans,257,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,1.1,0.2,0.8,1.5,mg,0.1,0,E,3
-Potassium,Enfants 1 à 8 ans,1341,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0.6,0.1,0.4,0.7,mg,0,0,E,3
-Potassium,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,mg,X,X,<10,3
+Potassium,Enfants 1 à 8 ans,2106,des,Confiserie - sucres et grignotines salées,,,,,99.2,5.5,88.4,109.9,mg,4.6,0.2,,1
+Potassium,Enfants 1 à 8 ans,1048,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,20.4,1.5,17.4,23.4,mg,0.9,0.1,,2
+Potassium,Enfants 1 à 8 ans,497,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,28,2.8,22.4,33.5,mg,1.3,0.1,,2
+Potassium,Enfants 1 à 8 ans,615,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,35.8,4,28,43.6,mg,1.6,0.2,,2
+Potassium,Enfants 1 à 8 ans,1642,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,15,1.6,11.9,18.2,mg,0.7,0.1,,2
+Potassium,Enfants 1 à 8 ans,548,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,12.1,1.1,10,14.2,mg,0.6,0,,3
+Potassium,Enfants 1 à 8 ans,557,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,3.4,0.5,2.5,4.4,mg,0.2,0,,3
+Potassium,Enfants 1 à 8 ans,131,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,4.9,1,3,6.8,mg,0.2,0,E,3
+Potassium,Enfants 1 à 8 ans,346,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,27,2.8,21.4,32.5,mg,1.2,0.1,,3
+Potassium,Enfants 1 à 8 ans,184,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,1,0.2,0.7,1.3,mg,0,0,E,3
+Potassium,Enfants 1 à 8 ans,720,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,13.3,1.6,10.2,16.4,mg,0.6,0.1,,3
+Potassium,Enfants 1 à 8 ans,257,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,1.1,0.2,0.8,1.5,mg,0.1,0,E,3
+Potassium,Enfants 1 à 8 ans,1341,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0.6,0.1,0.4,0.7,mg,0,0,E,3
+Potassium,Enfants 1 à 8 ans,,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,mg,X,X,<10,3
 Protéine,Population 1 an et +,186,des,Aliments pour bébés,,,,,0,0,0,0,g,0,0,,1
 Protéine,Population 1 an et +,154,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0,g,0,0,,2
-Protéine,Population 1 an et +,51,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0,0,0,0,g,0,0,,2
+Protéine,Population 1 an et +,51,des,Aliments pour bébés,des,Préparation pour nourrissons,,,0,0,0,0,g,0,0,,2
 Protéine,Population 1 an et +,19574,des,Boissons (excluant laits),,,,,1.2,0,1.1,1.2,g,1.5,0,,1
 Protéine,Population 1 an et +,3540,des,Boissons (excluant laits),de l',Alcool,,,0.4,0,0.3,0.4,g,0.5,0,,2
 Protéine,Population 1 an et +,12127,des,Boissons (excluant laits),du,Café et thé,,,0.3,0,0.3,0.3,g,0.4,0,,2
@@ -3202,7 +3202,7 @@ Protéine,Population 1 an et +,12441,des,Produits laitiers et Boissons à base d
 Protéine,Population 1 an et +,6481,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,1.5,0.1,1.4,1.6,g,1.9,0.1,,3
 Protéine,Population 1 an et +,5835,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,0.9,0.1,0.8,1.1,g,1.2,0.1,,3
 Protéine,Population 1 an et +,6026,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0.6,0,0.5,0.6,g,0.7,0,,3
-Protéine,Population 1 an et +,4411,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0.3,0,0.3,0.3,g,0.4,0,,3
+Protéine,Population 1 an et +,4411,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,0.3,0,0.3,0.3,g,0.4,0,,3
 Protéine,Population 1 an et +,814,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0.1,0,0.1,0.1,g,0.1,0,,3
 Protéine,Population 1 an et +,18258,des,Graisses et huiles,,,,,0.1,0,0.1,0.1,g,0.1,0,,1
 Protéine,Population 1 an et +,944,des,Graisses et huiles,des,Graisses animales,,,0,0,0,0,g,0,0,,2
@@ -3217,10 +3217,10 @@ Protéine,Population 1 an et +,924,des,Poissons et fruits de mer,des,Mollusques 
 Protéine,Population 1 an et +,18914,des,Fruits et légumes,,,,,4.4,0.1,4.3,4.5,g,5.7,0.1,,1
 Protéine,Population 1 an et +,13689,des,Fruits et légumes,des,Fruits,,,1.1,0,1.1,1.2,g,1.4,0,,2
 Protéine,Population 1 an et +,17977,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,3.3,0,3.2,3.4,g,4.2,0.1,,2
-Protéine,Population 1 an et +,5308,des,Fruits et légumes,des,Fruits,des,Bananes,0.3,0,0.3,0.3,g,0.4,0,,3
+Protéine,Population 1 an et +,5308,des,Fruits et légumes,des,Fruits,des,Banane,0.3,0,0.3,0.3,g,0.4,0,,3
 Protéine,Population 1 an et +,3372,des,Fruits et légumes,des,Fruits,des,Agrumes,0.2,0,0.2,0.2,g,0.2,0,,3
 Protéine,Population 1 an et +,2103,des,Fruits et légumes,des,Fruits,des,Autres fruits,0.1,0,0.1,0.2,g,0.2,0,,3
-Protéine,Population 1 an et +,5026,des,Fruits et légumes,des,Fruits,des,Pommes,0.1,0,0.1,0.1,g,0.1,0,,3
+Protéine,Population 1 an et +,5026,des,Fruits et légumes,des,Fruits,des,Pomme,0.1,0,0.1,0.1,g,0.1,0,,3
 Protéine,Population 1 an et +,4326,des,Fruits et légumes,des,Fruits,des,Baies,0.1,0,0.1,0.1,g,0.1,0,,3
 Protéine,Population 1 an et +,2881,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,0.1,0,0.1,0.1,g,0.1,0,,3
 Protéine,Population 1 an et +,982,des,Fruits et légumes,des,Fruits,des,Melons,0.1,0,0.1,0.1,g,0.1,0,,3
@@ -3236,7 +3236,7 @@ Protéine,Population 1 an et +,6318,des,Fruits et légumes,des,Légumes incluant
 Protéine,Population 1 an et +,19327,des,Produits céréaliers,,,,,15.7,0.1,15.4,15.9,g,20.2,0.2,,1
 Protéine,Population 1 an et +,16168,des,Produits céréaliers,des,Pains,,,8,0.1,7.8,8.2,g,10.3,0.1,,2
 Protéine,Population 1 an et +,6966,des,Produits céréaliers,des,Céréales pour déjeuner,,,1.4,0,1.3,1.4,g,1.8,0.1,,2
-Protéine,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.6,0,0.5,0.6,g,0.7,0,,2
+Protéine,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,0.6,0,0.5,0.6,g,0.7,0,,2
 Protéine,Population 1 an et +,14820,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,5.7,0.1,5.5,5.9,g,7.4,0.1,,2
 Protéine,Population 1 an et +,8159,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,3.3,0.1,3.1,3.4,g,4.2,0.1,,3
 Protéine,Population 1 an et +,5962,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,2.3,0.1,2.1,2.4,g,2.9,0.1,,3
@@ -3244,10 +3244,10 @@ Protéine,Population 1 an et +,6257,des,Produits céréaliers,des,Pains,des,Autr
 Protéine,Population 1 an et +,2918,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.3,0,0.2,0.3,g,0.3,0,,3
 Protéine,Population 1 an et +,4760,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,1.1,0,1.1,1.2,g,1.5,0.1,,3
 Protéine,Population 1 an et +,2573,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.2,0,0.2,0.3,g,0.3,0,,3
-Protéine,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.2,0,0.2,0.2,g,0.2,0,,3
-Protéine,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0,0,,3
-Protéine,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
-Protéine,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
+Protéine,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,0.2,0,0.2,0.2,g,0.2,0,,3
+Protéine,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0,0,,3
+Protéine,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
+Protéine,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
 Protéine,Population 1 an et +,11102,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,2.8,0.1,2.6,2.9,g,3.6,0.1,,3
 Protéine,Population 1 an et +,4543,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,1.9,0.1,1.7,2,g,2.4,0.1,,3
 Protéine,Population 1 an et +,4598,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,1.1,0,1,1.2,g,1.4,0.1,,3
@@ -3277,23 +3277,23 @@ Protéine,Population 1 an et +,18438,des,Soupes - sauces - Épices et autres ing
 Protéine,Population 1 an et +,7054,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.3,0,0.3,0.3,g,0.4,0,,2
 Protéine,Population 1 an et +,4710,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0.6,0,0.5,0.7,g,0.8,0,,2
 Protéine,Population 1 an et +,17547,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.2,0,0.2,0.2,g,0.2,0,,2
-Protéine,Population 1 an et +,16725,des,Confiseries - sucres et grignotines salées,,,,,1.7,0,1.6,1.8,g,2.2,0.1,,1
-Protéine,Population 1 an et +,6211,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,0.4,0,0.4,0.5,g,0.5,0,,2
-Protéine,Population 1 an et +,2912,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,0.5,0,0.5,0.6,g,0.7,0,,2
-Protéine,Population 1 an et +,4652,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0.7,0,0.6,0.7,g,0.9,0,,2
-Protéine,Population 1 an et +,14214,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.1,0,0.1,0.1,g,0.1,0,,2
-Protéine,Population 1 an et +,3815,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0.3,0,0.3,0.3,g,0.4,0,,3
-Protéine,Population 1 an et +,2559,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0.1,0,0,0.1,g,0.1,0,,3
-Protéine,Population 1 an et +,703,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0,0,0,0,g,0.1,0,,3
-Protéine,Population 1 an et +,2447,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.5,0,0.5,0.6,g,0.7,0,,3
-Protéine,Population 1 an et +,560,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0,0,,3
-Protéine,Population 1 an et +,4750,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.1,0,0,0.1,g,0.1,0,,3
-Protéine,Population 1 an et +,2044,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0,0,,3
-Protéine,Population 1 an et +,715,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
-Protéine,Population 1 an et +,12217,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
+Protéine,Population 1 an et +,16725,des,Confiserie - sucres et grignotines salées,,,,,1.7,0,1.6,1.8,g,2.2,0.1,,1
+Protéine,Population 1 an et +,6211,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,0.4,0,0.4,0.5,g,0.5,0,,2
+Protéine,Population 1 an et +,2912,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,0.5,0,0.5,0.6,g,0.7,0,,2
+Protéine,Population 1 an et +,4652,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,0.7,0,0.6,0.7,g,0.9,0,,2
+Protéine,Population 1 an et +,14214,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.1,0,0.1,0.1,g,0.1,0,,2
+Protéine,Population 1 an et +,3815,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,0.3,0,0.3,0.3,g,0.4,0,,3
+Protéine,Population 1 an et +,2559,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,0.1,0,0,0.1,g,0.1,0,,3
+Protéine,Population 1 an et +,703,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0,0,0,0,g,0.1,0,,3
+Protéine,Population 1 an et +,2447,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.5,0,0.5,0.6,g,0.7,0,,3
+Protéine,Population 1 an et +,560,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0,0,,3
+Protéine,Population 1 an et +,4750,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.1,0,0,0.1,g,0.1,0,,3
+Protéine,Population 1 an et +,2044,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0,0,,3
+Protéine,Population 1 an et +,715,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
+Protéine,Population 1 an et +,12217,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
 Protéine,Hommes adultes 19 ans +,22,des,Aliments pour bébés,,,,,0,0,0,0,g,0,0,,1
 Protéine,Hommes adultes 19 ans +,21,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0,g,0,0,,2
-Protéine,Hommes adultes 19 ans +,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,g,X,X,<10,2
+Protéine,Hommes adultes 19 ans +,,des,Aliments pour bébés,des,Préparation pour nourrissons,,,X,X,,,g,X,X,<10,2
 Protéine,Hommes adultes 19 ans +,6187,des,Boissons (excluant laits),,,,,1.7,0.1,1.6,1.8,g,1.9,0.1,,1
 Protéine,Hommes adultes 19 ans +,1946,des,Boissons (excluant laits),de l',Alcool,,,0.7,0.1,0.6,0.8,g,0.8,0.1,,2
 Protéine,Hommes adultes 19 ans +,5104,des,Boissons (excluant laits),du,Café et thé,,,0.4,0,0.4,0.5,g,0.5,0,,2
@@ -3316,7 +3316,7 @@ Protéine,Hommes adultes 19 ans +,3759,des,Produits laitiers et Boissons à base
 Protéine,Hommes adultes 19 ans +,1819,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,1.4,0.1,1.3,1.6,g,1.5,0.1,,3
 Protéine,Hommes adultes 19 ans +,1648,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,0.8,0.1,0.6,1,g,0.9,0.1,,3
 Protéine,Hommes adultes 19 ans +,1812,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0.6,0.1,0.4,0.7,g,0.6,0.1,E,3
-Protéine,Hommes adultes 19 ans +,1727,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0.4,0,0.3,0.5,g,0.4,0,,3
+Protéine,Hommes adultes 19 ans +,1727,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,0.4,0,0.3,0.5,g,0.4,0,,3
 Protéine,Hommes adultes 19 ans +,208,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0.1,0,0.1,0.2,g,0.1,0,,3
 Protéine,Hommes adultes 19 ans +,5767,des,Graisses et huiles,,,,,0.1,0,0.1,0.1,g,0.1,0,,1
 Protéine,Hommes adultes 19 ans +,333,des,Graisses et huiles,des,Graisses animales,,,0,0,0,0,g,0,0,,2
@@ -3331,9 +3331,9 @@ Protéine,Hommes adultes 19 ans +,343,des,Poissons et fruits de mer,des,Mollusqu
 Protéine,Hommes adultes 19 ans +,5918,des,Fruits et légumes,,,,,4.8,0.1,4.6,5,g,5.2,0.1,,1
 Protéine,Hommes adultes 19 ans +,3876,des,Fruits et légumes,des,Fruits,,,1.1,0,1,1.2,g,1.2,0,,2
 Protéine,Hommes adultes 19 ans +,5694,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,3.7,0.1,3.5,3.8,g,4,0.1,,2
-Protéine,Hommes adultes 19 ans +,1590,des,Fruits et légumes,des,Fruits,des,Bananes,0.4,0,0.3,0.4,g,0.4,0,,3
+Protéine,Hommes adultes 19 ans +,1590,des,Fruits et légumes,des,Fruits,des,Banane,0.4,0,0.3,0.4,g,0.4,0,,3
 Protéine,Hommes adultes 19 ans +,1019,des,Fruits et légumes,des,Fruits,des,Agrumes,0.2,0,0.1,0.2,g,0.2,0,,3
-Protéine,Hommes adultes 19 ans +,1350,des,Fruits et légumes,des,Fruits,des,Pommes,0.1,0,0.1,0.1,g,0.1,0,,3
+Protéine,Hommes adultes 19 ans +,1350,des,Fruits et légumes,des,Fruits,des,Pomme,0.1,0,0.1,0.1,g,0.1,0,,3
 Protéine,Hommes adultes 19 ans +,1066,des,Fruits et légumes,des,Fruits,des,Baies,0.1,0,0.1,0.1,g,0.1,0,,3
 Protéine,Hommes adultes 19 ans +,782,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,0.1,0,0.1,0.1,g,0.1,0,,3
 Protéine,Hommes adultes 19 ans +,247,des,Fruits et légumes,des,Fruits,des,Melons,0.1,0,0.1,0.1,g,0.1,0,,3
@@ -3350,7 +3350,7 @@ Protéine,Hommes adultes 19 ans +,1991,des,Fruits et légumes,des,Légumes inclu
 Protéine,Hommes adultes 19 ans +,6068,des,Produits céréaliers,,,,,17.9,0.3,17.4,18.4,g,19.4,0.3,,1
 Protéine,Hommes adultes 19 ans +,5104,des,Produits céréaliers,des,Pains,,,9.4,0.2,9,9.8,g,10.2,0.2,,2
 Protéine,Hommes adultes 19 ans +,1921,des,Produits céréaliers,des,Céréales pour déjeuner,,,1.5,0.1,1.3,1.7,g,1.6,0.1,,2
-Protéine,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.6,0,0.5,0.7,g,0.6,0,,2
+Protéine,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,0.6,0,0.5,0.7,g,0.6,0,,2
 Protéine,Hommes adultes 19 ans +,4551,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,6.4,0.2,6.1,6.8,g,7,0.2,,2
 Protéine,Hommes adultes 19 ans +,2752,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,4.2,0.2,3.8,4.5,g,4.5,0.2,,3
 Protéine,Hommes adultes 19 ans +,1980,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,2.6,0.1,2.3,2.8,g,2.8,0.1,,3
@@ -3358,9 +3358,9 @@ Protéine,Hommes adultes 19 ans +,1885,des,Produits céréaliers,des,Pains,des,A
 Protéine,Hommes adultes 19 ans +,593,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.2,0,0.2,0.2,g,0.2,0,,3
 Protéine,Hommes adultes 19 ans +,1481,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,1.3,0.1,1.2,1.5,g,1.5,0.1,,3
 Protéine,Hommes adultes 19 ans +,523,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.2,0,0.1,0.2,g,0.2,0,,3
-Protéine,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.2,0,0.2,0.3,g,0.2,0,,3
-Protéine,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0,0,,3
-Protéine,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
+Protéine,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,0.2,0,0.2,0.3,g,0.2,0,,3
+Protéine,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0,0,,3
+Protéine,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
 Protéine,Hommes adultes 19 ans +,3442,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,3.2,0.1,3,3.5,g,3.5,0.1,,3
 Protéine,Hommes adultes 19 ans +,1250,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,2,0.1,1.7,2.2,g,2.2,0.1,,3
 Protéine,Hommes adultes 19 ans +,1449,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,1.2,0.1,1.1,1.3,g,1.3,0.1,,3
@@ -3390,23 +3390,23 @@ Protéine,Hommes adultes 19 ans +,5856,des,Soupes - sauces - Épices et autres i
 Protéine,Hommes adultes 19 ans +,2384,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.4,0,0.3,0.4,g,0.4,0,,2
 Protéine,Hommes adultes 19 ans +,1511,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0.7,0.1,0.6,0.8,g,0.8,0.1,,2
 Protéine,Hommes adultes 19 ans +,5575,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.2,0,0.2,0.3,g,0.2,0,,2
-Protéine,Hommes adultes 19 ans +,5232,des,Confiseries - sucres et grignotines salées,,,,,1.6,0.1,1.5,1.8,g,1.8,0.1,,1
-Protéine,Hommes adultes 19 ans +,1527,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,0.4,0.1,0.3,0.5,g,0.4,0.1,E,2
-Protéine,Hommes adultes 19 ans +,771,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,0.5,0,0.4,0.5,g,0.5,0,,2
-Protéine,Hommes adultes 19 ans +,1268,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0.7,0.1,0.6,0.8,g,0.8,0.1,,2
-Protéine,Hommes adultes 19 ans +,4671,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0,0,0,0.1,g,0,0,,2
-Protéine,Hommes adultes 19 ans +,1023,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0.3,0,0.2,0.3,g,0.3,0,,3
-Protéine,Hommes adultes 19 ans +,497,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0.1,0,0,0.2,g,0.1,0.1,,3
-Protéine,Hommes adultes 19 ans +,170,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0,0,0,0,g,0,0,,3
-Protéine,Hommes adultes 19 ans +,702,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.5,0,0.4,0.5,g,0.5,0,,3
-Protéine,Hommes adultes 19 ans +,80,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0,0,,3
-Protéine,Hommes adultes 19 ans +,726,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0,0,,3
-Protéine,Hommes adultes 19 ans +,1360,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0,0,0,0,g,0,0,,3
-Protéine,Hommes adultes 19 ans +,322,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
-Protéine,Hommes adultes 19 ans +,4068,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
+Protéine,Hommes adultes 19 ans +,5232,des,Confiserie - sucres et grignotines salées,,,,,1.6,0.1,1.5,1.8,g,1.8,0.1,,1
+Protéine,Hommes adultes 19 ans +,1527,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,0.4,0.1,0.3,0.5,g,0.4,0.1,E,2
+Protéine,Hommes adultes 19 ans +,771,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,0.5,0,0.4,0.5,g,0.5,0,,2
+Protéine,Hommes adultes 19 ans +,1268,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,0.7,0.1,0.6,0.8,g,0.8,0.1,,2
+Protéine,Hommes adultes 19 ans +,4671,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0,0,0,0.1,g,0,0,,2
+Protéine,Hommes adultes 19 ans +,1023,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,0.3,0,0.2,0.3,g,0.3,0,,3
+Protéine,Hommes adultes 19 ans +,497,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,0.1,0,0,0.2,g,0.1,0.1,,3
+Protéine,Hommes adultes 19 ans +,170,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0,0,0,0,g,0,0,,3
+Protéine,Hommes adultes 19 ans +,702,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.5,0,0.4,0.5,g,0.5,0,,3
+Protéine,Hommes adultes 19 ans +,80,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0,0,,3
+Protéine,Hommes adultes 19 ans +,726,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0,0,,3
+Protéine,Hommes adultes 19 ans +,1360,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0,0,0,0,g,0,0,,3
+Protéine,Hommes adultes 19 ans +,322,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
+Protéine,Hommes adultes 19 ans +,4068,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
 Protéine,Femmes adultes* 19 ans +,21,des,Aliments pour bébés,,,,,0,0,0,0,g,0,0,,1
 Protéine,Femmes adultes* 19 ans +,19,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0,g,0,0,,2
-Protéine,Femmes adultes* 19 ans +,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,g,X,X,<10,2
+Protéine,Femmes adultes* 19 ans +,,des,Aliments pour bébés,des,Préparation pour nourrissons,,,X,X,,,g,X,X,<10,2
 Protéine,Femmes adultes* 19 ans +,6828,des,Boissons (excluant laits),,,,,0.9,0,0.9,1,g,1.4,0,,1
 Protéine,Femmes adultes* 19 ans +,1439,des,Boissons (excluant laits),de l',Alcool,,,0.2,0,0.1,0.2,g,0.2,0,,2
 Protéine,Femmes adultes* 19 ans +,5777,des,Boissons (excluant laits),du,Café et thé,,,0.3,0,0.3,0.4,g,0.5,0,,2
@@ -3429,7 +3429,7 @@ Protéine,Femmes adultes* 19 ans +,4136,des,Produits laitiers et Boissons à bas
 Protéine,Femmes adultes* 19 ans +,2244,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,1.1,0.1,0.9,1.2,g,1.6,0.1,,3
 Protéine,Femmes adultes* 19 ans +,2211,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0.6,0,0.5,0.7,g,0.9,0.1,,3
 Protéine,Femmes adultes* 19 ans +,1928,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,0.5,0.1,0.4,0.7,g,0.8,0.1,E,3
-Protéine,Femmes adultes* 19 ans +,1769,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0.3,0,0.3,0.3,g,0.5,0,,3
+Protéine,Femmes adultes* 19 ans +,1769,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,0.3,0,0.3,0.3,g,0.5,0,,3
 Protéine,Femmes adultes* 19 ans +,358,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0.1,0,0.1,0.2,g,0.2,0,,3
 Protéine,Femmes adultes* 19 ans +,6356,des,Graisses et huiles,,,,,0.1,0,0.1,0.1,g,0.2,0,,1
 Protéine,Femmes adultes* 19 ans +,369,des,Graisses et huiles,des,Graisses animales,,,0,0,0,0,g,0,0,,2
@@ -3444,11 +3444,11 @@ Protéine,Femmes adultes* 19 ans +,370,des,Poissons et fruits de mer,des,Mollusq
 Protéine,Femmes adultes* 19 ans +,6595,des,Fruits et légumes,,,,,4.5,0.1,4.3,4.6,g,6.7,0.1,,1
 Protéine,Femmes adultes* 19 ans +,4951,des,Fruits et légumes,des,Fruits,,,1.1,0,1.1,1.2,g,1.7,0,,2
 Protéine,Femmes adultes* 19 ans +,6291,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,3.3,0.1,3.2,3.5,g,5,0.1,,2
-Protéine,Femmes adultes* 19 ans +,1919,des,Fruits et légumes,des,Fruits,des,Bananes,0.3,0,0.3,0.3,g,0.4,0,,3
+Protéine,Femmes adultes* 19 ans +,1919,des,Fruits et légumes,des,Fruits,des,Banane,0.3,0,0.3,0.3,g,0.4,0,,3
 Protéine,Femmes adultes* 19 ans +,1356,des,Fruits et légumes,des,Fruits,des,Agrumes,0.2,0,0.2,0.2,g,0.3,0,,3
 Protéine,Femmes adultes* 19 ans +,854,des,Fruits et légumes,des,Fruits,des,Autres fruits,0.2,0,0.1,0.2,g,0.3,0,,3
 Protéine,Femmes adultes* 19 ans +,1597,des,Fruits et légumes,des,Fruits,des,Baies,0.1,0,0.1,0.1,g,0.2,0,,3
-Protéine,Femmes adultes* 19 ans +,1574,des,Fruits et légumes,des,Fruits,des,Pommes,0.1,0,0.1,0.1,g,0.1,0,,3
+Protéine,Femmes adultes* 19 ans +,1574,des,Fruits et légumes,des,Fruits,des,Pomme,0.1,0,0.1,0.1,g,0.1,0,,3
 Protéine,Femmes adultes* 19 ans +,1006,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,0.1,0,0.1,0.1,g,0.1,0,,3
 Protéine,Femmes adultes* 19 ans +,306,des,Fruits et légumes,des,Fruits,des,Melons,0.1,0,0.1,0.1,g,0.1,0,,3
 Protéine,Femmes adultes* 19 ans +,259,des,Fruits et légumes,des,Fruits,des,Pêches et nectarines,0,0,0,0.1,g,0.1,0,,3
@@ -3463,7 +3463,7 @@ Protéine,Femmes adultes* 19 ans +,2348,des,Fruits et légumes,des,Légumes incl
 Protéine,Femmes adultes* 19 ans +,6669,des,Produits céréaliers,,,,,13.2,0.2,12.7,13.6,g,19.9,0.3,,1
 Protéine,Femmes adultes* 19 ans +,5520,des,Produits céréaliers,des,Pains,,,6.8,0.1,6.5,7.1,g,10.3,0.2,,2
 Protéine,Femmes adultes* 19 ans +,2230,des,Produits céréaliers,des,Céréales pour déjeuner,,,1.2,0.1,1.1,1.3,g,1.8,0.1,,2
-Protéine,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.4,0,0.4,0.5,g,0.7,0,,2
+Protéine,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,0.4,0,0.4,0.5,g,0.7,0,,2
 Protéine,Femmes adultes* 19 ans +,4893,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,4.7,0.2,4.4,5,g,7.1,0.2,,2
 Protéine,Femmes adultes* 19 ans +,2551,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,2.6,0.1,2.4,2.8,g,3.9,0.2,,3
 Protéine,Femmes adultes* 19 ans +,2239,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,2.2,0.1,2.1,2.4,g,3.4,0.1,,3
@@ -3471,10 +3471,10 @@ Protéine,Femmes adultes* 19 ans +,1994,des,Produits céréaliers,des,Pains,des,
 Protéine,Femmes adultes* 19 ans +,914,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.2,0,0.2,0.2,g,0.3,0,,3
 Protéine,Femmes adultes* 19 ans +,1756,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,1,0.1,0.9,1.1,g,1.6,0.1,,3
 Protéine,Femmes adultes* 19 ans +,555,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.1,0,0.1,0.2,g,0.2,0,,3
-Protéine,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.1,g,0.2,0,,3
-Protéine,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0,0,,3
-Protéine,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
-Protéine,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
+Protéine,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.1,g,0.2,0,,3
+Protéine,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0,0,,3
+Protéine,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
+Protéine,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
 Protéine,Femmes adultes* 19 ans +,3664,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,2.2,0.1,2,2.4,g,3.4,0.2,,3
 Protéine,Femmes adultes* 19 ans +,1358,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,1.5,0.1,1.4,1.7,g,2.3,0.1,,3
 Protéine,Femmes adultes* 19 ans +,1522,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,1,0.1,0.9,1.1,g,1.4,0.1,,3
@@ -3504,23 +3504,23 @@ Protéine,Femmes adultes* 19 ans +,6382,des,Soupes - sauces - Épices et autres 
 Protéine,Femmes adultes* 19 ans +,2243,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.3,0,0.3,0.3,g,0.4,0,,2
 Protéine,Femmes adultes* 19 ans +,1853,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0.6,0,0.5,0.7,g,0.9,0.1,,2
 Protéine,Femmes adultes* 19 ans +,6077,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.2,0,0.1,0.2,g,0.2,0,,2
-Protéine,Femmes adultes* 19 ans +,5713,des,Confiseries - sucres et grignotines salées,,,,,1.5,0.1,1.4,1.7,g,2.3,0.1,,1
-Protéine,Femmes adultes* 19 ans +,1936,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,0.4,0,0.3,0.5,g,0.6,0.1,,2
-Protéine,Femmes adultes* 19 ans +,844,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,0.5,0,0.4,0.6,g,0.7,0.1,,2
-Protéine,Femmes adultes* 19 ans +,1411,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0.5,0,0.5,0.6,g,0.8,0.1,,2
-Protéine,Femmes adultes* 19 ans +,4937,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0,0,0,0.1,g,0.1,0,,2
-Protéine,Femmes adultes* 19 ans +,1238,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0.3,0,0.2,0.4,g,0.5,0.1,,3
-Protéine,Femmes adultes* 19 ans +,685,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0.1,0,0,0.1,g,0.1,0,,3
-Protéine,Femmes adultes* 19 ans +,229,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0,0,0,0.1,g,0.1,0,,3
-Protéine,Femmes adultes* 19 ans +,762,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.5,0,0.4,0.6,g,0.7,0.1,,3
-Protéine,Femmes adultes* 19 ans +,87,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0,0,,3
-Protéine,Femmes adultes* 19 ans +,1529,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0,0,0,0.1,g,0.1,0,,3
-Protéine,Femmes adultes* 19 ans +,773,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0,0,,3
-Protéine,Femmes adultes* 19 ans +,360,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
-Protéine,Femmes adultes* 19 ans +,4229,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
+Protéine,Femmes adultes* 19 ans +,5713,des,Confiserie - sucres et grignotines salées,,,,,1.5,0.1,1.4,1.7,g,2.3,0.1,,1
+Protéine,Femmes adultes* 19 ans +,1936,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,0.4,0,0.3,0.5,g,0.6,0.1,,2
+Protéine,Femmes adultes* 19 ans +,844,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,0.5,0,0.4,0.6,g,0.7,0.1,,2
+Protéine,Femmes adultes* 19 ans +,1411,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,0.5,0,0.5,0.6,g,0.8,0.1,,2
+Protéine,Femmes adultes* 19 ans +,4937,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0,0,0,0.1,g,0.1,0,,2
+Protéine,Femmes adultes* 19 ans +,1238,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,0.3,0,0.2,0.4,g,0.5,0.1,,3
+Protéine,Femmes adultes* 19 ans +,685,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,0.1,0,0,0.1,g,0.1,0,,3
+Protéine,Femmes adultes* 19 ans +,229,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0,0,0,0.1,g,0.1,0,,3
+Protéine,Femmes adultes* 19 ans +,762,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.5,0,0.4,0.6,g,0.7,0.1,,3
+Protéine,Femmes adultes* 19 ans +,87,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0,0,,3
+Protéine,Femmes adultes* 19 ans +,1529,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0,0,0,0.1,g,0.1,0,,3
+Protéine,Femmes adultes* 19 ans +,773,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0,0,,3
+Protéine,Femmes adultes* 19 ans +,360,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
+Protéine,Femmes adultes* 19 ans +,4229,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
 Protéine,Enfants 1 à 8 ans,122,des,Aliments pour bébés,,,,,0.2,0,0.1,0.3,g,0.4,0.1,,1
 Protéine,Enfants 1 à 8 ans,95,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0.1,0,0.1,0.2,g,0.2,0,,2
-Protéine,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0.1,0,0,0.2,g,0.2,0,,2
+Protéine,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparation pour nourrissons,,,0.1,0,0,0.2,g,0.2,0,,2
 Protéine,Enfants 1 à 8 ans,2443,des,Boissons (excluant laits),,,,,0.6,0,0.5,0.7,g,1,0.1,,1
 Protéine,Enfants 1 à 8 ans,20,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0,g,0,0,,2
 Protéine,Enfants 1 à 8 ans,141,des,Boissons (excluant laits),du,Café et thé,,,0,0,0,0,g,0,0,,2
@@ -3543,7 +3543,7 @@ Protéine,Enfants 1 à 8 ans,1810,des,Produits laitiers et Boissons à base de p
 Protéine,Enfants 1 à 8 ans,1078,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,3.4,0.2,2.9,3.8,g,5.6,0.3,,3
 Protéine,Enfants 1 à 8 ans,854,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,1.9,0.2,1.5,2.4,g,3.2,0.4,,3
 Protéine,Enfants 1 à 8 ans,739,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0.3,0.1,0.2,0.4,g,0.5,0.1,E,3
-Protéine,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0.1,0,0.1,0.2,g,0.2,0.1,,3
+Protéine,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,0.1,0,0.1,0.2,g,0.2,0.1,,3
 Protéine,Enfants 1 à 8 ans,128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0.1,0,0.1,0.2,g,0.2,0,,3
 Protéine,Enfants 1 à 8 ans,2270,des,Graisses et huiles,,,,,0,0,0,0.1,g,0.1,0,,1
 Protéine,Enfants 1 à 8 ans,83,des,Graisses et huiles,des,Graisses animales,,,0,0,0,0,g,0,0,,2
@@ -3558,10 +3558,10 @@ Protéine,Enfants 1 à 8 ans,50,des,Poissons et fruits de mer,des,Mollusques et 
 Protéine,Enfants 1 à 8 ans,2428,des,Fruits et légumes,,,,,3.2,0.1,3,3.4,g,5.4,0.2,,1
 Protéine,Enfants 1 à 8 ans,2117,des,Fruits et légumes,des,Fruits,,,1.2,0,1.1,1.3,g,2,0.1,,2
 Protéine,Enfants 1 à 8 ans,2235,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,2,0.1,1.9,2.2,g,3.4,0.1,,2
-Protéine,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Bananes,0.3,0,0.3,0.4,g,0.5,0,,3
+Protéine,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Banane,0.3,0,0.3,0.4,g,0.5,0,,3
 Protéine,Enfants 1 à 8 ans,830,des,Fruits et légumes,des,Fruits,des,Baies,0.2,0,0.1,0.2,g,0.3,0,,3
 Protéine,Enfants 1 à 8 ans,421,des,Fruits et légumes,des,Fruits,des,Agrumes,0.2,0,0.1,0.2,g,0.3,0,,3
-Protéine,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pommes,0.1,0,0.1,0.2,g,0.2,0,,3
+Protéine,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pomme,0.1,0,0.1,0.2,g,0.2,0,,3
 Protéine,Enfants 1 à 8 ans,572,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,0.1,0,0.1,0.2,g,0.2,0,,3
 Protéine,Enfants 1 à 8 ans,219,des,Fruits et légumes,des,Fruits,des,Melons,0.1,0,0.1,0.1,g,0.2,0,,3
 Protéine,Enfants 1 à 8 ans,260,des,Fruits et légumes,des,Fruits,des,Autres fruits,0.1,0,0.1,0.1,g,0.2,0,,3
@@ -3577,7 +3577,7 @@ Protéine,Enfants 1 à 8 ans,875,des,Fruits et légumes,des,Légumes incluant po
 Protéine,Enfants 1 à 8 ans,2475,des,Produits céréaliers,,,,,13.4,0.3,12.8,13.9,g,22.4,0.5,,1
 Protéine,Enfants 1 à 8 ans,2114,des,Produits céréaliers,des,Pains,,,6.1,0.2,5.8,6.5,g,10.3,0.3,,2
 Protéine,Enfants 1 à 8 ans,1282,des,Produits céréaliers,des,Céréales pour déjeuner,,,1.3,0.1,1.2,1.5,g,2.3,0.1,,2
-Protéine,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.7,0,0.6,0.8,g,1.2,0.1,,2
+Protéine,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,0.7,0,0.6,0.8,g,1.2,0.1,,2
 Protéine,Enfants 1 à 8 ans,2037,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,5.2,0.2,4.8,5.6,g,8.7,0.3,,2
 Protéine,Enfants 1 à 8 ans,951,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,2.3,0.2,2,2.7,g,3.9,0.3,,3
 Protéine,Enfants 1 à 8 ans,813,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,1.7,0.1,1.5,1.9,g,2.8,0.2,,3
@@ -3585,9 +3585,9 @@ Protéine,Enfants 1 à 8 ans,805,des,Produits céréaliers,des,Pains,des,Autres 
 Protéine,Enfants 1 à 8 ans,745,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.6,0.1,0.5,0.7,g,1,0.1,E,3
 Protéine,Enfants 1 à 8 ans,728,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.9,0.1,0.7,1,g,1.4,0.1,,3
 Protéine,Enfants 1 à 8 ans,670,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.5,0,0.4,0.6,g,0.8,0.1,,3
-Protéine,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.2,0,0.2,0.2,g,0.3,0,,3
-Protéine,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0,0,,3
-Protéine,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
+Protéine,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,0.2,0,0.2,0.2,g,0.3,0,,3
+Protéine,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0,0,,3
+Protéine,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
 Protéine,Enfants 1 à 8 ans,834,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,2.2,0.2,1.9,2.5,g,3.7,0.3,,3
 Protéine,Enfants 1 à 8 ans,1461,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,2.1,0.1,1.9,2.4,g,3.6,0.2,,3
 Protéine,Enfants 1 à 8 ans,654,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0.9,0.1,0.7,1,g,1.4,0.1,,3
@@ -3617,23 +3617,23 @@ Protéine,Enfants 1 à 8 ans,2295,des,Soupes - sauces - Épices et autres ingré
 Protéine,Enfants 1 à 8 ans,761,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.2,0,0.1,0.2,g,0.3,0,,2
 Protéine,Enfants 1 à 8 ans,532,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0.3,0,0.2,0.4,g,0.5,0.1,,2
 Protéine,Enfants 1 à 8 ans,2205,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.1,0,0.1,0.1,g,0.2,0,,2
-Protéine,Enfants 1 à 8 ans,2106,des,Confiseries - sucres et grignotines salées,,,,,1.4,0.1,1.3,1.6,g,2.4,0.1,,1
-Protéine,Enfants 1 à 8 ans,1048,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,0.3,0,0.3,0.4,g,0.6,0,,2
-Protéine,Enfants 1 à 8 ans,497,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,0.5,0.1,0.4,0.6,g,0.9,0.1,E,2
-Protéine,Enfants 1 à 8 ans,615,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0.5,0,0.4,0.5,g,0.8,0.1,,2
-Protéine,Enfants 1 à 8 ans,1642,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.1,0,0.1,0.1,g,0.2,0,,2
-Protéine,Enfants 1 à 8 ans,548,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0.2,0,0.2,0.3,g,0.4,0,,3
-Protéine,Enfants 1 à 8 ans,557,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0,0,0,0,g,0.1,0,,3
-Protéine,Enfants 1 à 8 ans,131,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0.1,0,0.1,0.1,g,0.1,0,,3
-Protéine,Enfants 1 à 8 ans,346,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.5,0.1,0.4,0.6,g,0.8,0.1,E,3
-Protéine,Enfants 1 à 8 ans,184,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0.1,g,0.1,0,,3
-Protéine,Enfants 1 à 8 ans,720,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.1,0,0.1,0.1,g,0.2,0,,3
-Protéine,Enfants 1 à 8 ans,257,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0,0,,3
-Protéine,Enfants 1 à 8 ans,1341,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
-Protéine,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,g,X,X,<10,3
+Protéine,Enfants 1 à 8 ans,2106,des,Confiserie - sucres et grignotines salées,,,,,1.4,0.1,1.3,1.6,g,2.4,0.1,,1
+Protéine,Enfants 1 à 8 ans,1048,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,0.3,0,0.3,0.4,g,0.6,0,,2
+Protéine,Enfants 1 à 8 ans,497,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,0.5,0.1,0.4,0.6,g,0.9,0.1,E,2
+Protéine,Enfants 1 à 8 ans,615,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,0.5,0,0.4,0.5,g,0.8,0.1,,2
+Protéine,Enfants 1 à 8 ans,1642,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.1,0,0.1,0.1,g,0.2,0,,2
+Protéine,Enfants 1 à 8 ans,548,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,0.2,0,0.2,0.3,g,0.4,0,,3
+Protéine,Enfants 1 à 8 ans,557,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,0,0,0,0,g,0.1,0,,3
+Protéine,Enfants 1 à 8 ans,131,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0.1,0,0.1,0.1,g,0.1,0,,3
+Protéine,Enfants 1 à 8 ans,346,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.5,0.1,0.4,0.6,g,0.8,0.1,E,3
+Protéine,Enfants 1 à 8 ans,184,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0.1,g,0.1,0,,3
+Protéine,Enfants 1 à 8 ans,720,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.1,0,0.1,0.1,g,0.2,0,,3
+Protéine,Enfants 1 à 8 ans,257,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0,0,,3
+Protéine,Enfants 1 à 8 ans,1341,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
+Protéine,Enfants 1 à 8 ans,,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,g,X,X,<10,3
 Acides gras saturés,Population 1 an et +,186,des,Aliments pour bébés,,,,,0,0,0,0,g,0.1,0,,1
 Acides gras saturés,Population 1 an et +,154,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0,g,0,0,,2
-Acides gras saturés,Population 1 an et +,51,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0,0,0,0,g,0,0,,2
+Acides gras saturés,Population 1 an et +,51,des,Aliments pour bébés,des,Préparation pour nourrissons,,,0,0,0,0,g,0,0,,2
 Acides gras saturés,Population 1 an et +,19574,des,Boissons (excluant laits),,,,,0.1,0,0.1,0.1,g,0.4,0.1,,1
 Acides gras saturés,Population 1 an et +,3540,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0,g,0.1,0,,2
 Acides gras saturés,Population 1 an et +,12127,des,Boissons (excluant laits),du,Café et thé,,,0,0,0,0.1,g,0.2,0,,2
@@ -3653,7 +3653,7 @@ Acides gras saturés,Population 1 an et +,11627,des,Produits laitiers et Boisson
 Acides gras saturés,Population 1 an et +,17005,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,2.9,0.1,2.7,3,g,12.5,0.2,,2
 Acides gras saturés,Population 1 an et +,4392,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,,,0.3,0,0.3,0.3,g,1.4,0.1,,2
 Acides gras saturés,Population 1 an et +,12441,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,1.2,0,1.2,1.3,g,5.3,0.1,,3
-Acides gras saturés,Population 1 an et +,4411,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0.8,0,0.7,0.8,g,3.4,0.1,,3
+Acides gras saturés,Population 1 an et +,4411,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,0.8,0,0.7,0.8,g,3.4,0.1,,3
 Acides gras saturés,Population 1 an et +,5835,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,0.6,0,0.5,0.6,g,2.5,0.1,,3
 Acides gras saturés,Population 1 an et +,6481,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,0.3,0,0.3,0.3,g,1.2,0,,3
 Acides gras saturés,Population 1 an et +,814,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0,0,0,0,g,0,0,,3
@@ -3672,8 +3672,8 @@ Acides gras saturés,Population 1 an et +,18914,des,Fruits et légumes,,,,,0.4,0
 Acides gras saturés,Population 1 an et +,13689,des,Fruits et légumes,des,Fruits,,,0.1,0,0.1,0.1,g,0.6,0,,2
 Acides gras saturés,Population 1 an et +,17977,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,0.2,0,0.2,0.2,g,1,0,,2
 Acides gras saturés,Population 1 an et +,2103,des,Fruits et légumes,des,Fruits,des,Autres fruits,0.1,0,0.1,0.1,g,0.3,0,,3
-Acides gras saturés,Population 1 an et +,5308,des,Fruits et légumes,des,Fruits,des,Bananes,0,0,0,0,g,0.1,0,,3
-Acides gras saturés,Population 1 an et +,5026,des,Fruits et légumes,des,Fruits,des,Pommes,0,0,0,0,g,0,0,,3
+Acides gras saturés,Population 1 an et +,5308,des,Fruits et légumes,des,Fruits,des,Banane,0,0,0,0,g,0.1,0,,3
+Acides gras saturés,Population 1 an et +,5026,des,Fruits et légumes,des,Fruits,des,Pomme,0,0,0,0,g,0,0,,3
 Acides gras saturés,Population 1 an et +,4326,des,Fruits et légumes,des,Fruits,des,Baies,0,0,0,0,g,0,0,,3
 Acides gras saturés,Population 1 an et +,513,des,Fruits et légumes,des,Fruits,des,Cerises,0,0,0,0,g,0,0,,3
 Acides gras saturés,Population 1 an et +,3372,des,Fruits et légumes,des,Fruits,des,Agrumes,0,0,0,0,g,0,0,,3
@@ -3690,7 +3690,7 @@ Acides gras saturés,Population 1 an et +,6318,des,Fruits et légumes,des,Légum
 Acides gras saturés,Population 1 an et +,19327,des,Produits céréaliers,,,,,2,0,1.9,2.1,g,8.7,0.2,,1
 Acides gras saturés,Population 1 an et +,16168,des,Produits céréaliers,des,Pains,,,1,0,1,1.1,g,4.5,0.1,,2
 Acides gras saturés,Population 1 an et +,6966,des,Produits céréaliers,des,Céréales pour déjeuner,,,0.2,0,0.2,0.2,g,0.9,0,,2
-Acides gras saturés,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.5,0,0.5,0.6,g,2.3,0.1,,2
+Acides gras saturés,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,0.5,0,0.5,0.6,g,2.3,0.1,,2
 Acides gras saturés,Population 1 an et +,14820,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,0.2,0,0.2,0.2,g,1,0,,2
 Acides gras saturés,Population 1 an et +,6257,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,0.5,0,0.4,0.5,g,2.1,0.1,,3
 Acides gras saturés,Population 1 an et +,8159,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,0.3,0,0.3,0.3,g,1.3,0.1,,3
@@ -3698,10 +3698,10 @@ Acides gras saturés,Population 1 an et +,5962,des,Produits céréaliers,des,Pai
 Acides gras saturés,Population 1 an et +,2918,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.1,0,0.1,0.1,g,0.4,0,,3
 Acides gras saturés,Population 1 an et +,4760,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.2,0,0.2,0.2,g,0.8,0,,3
 Acides gras saturés,Population 1 an et +,2573,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0,0,0,0,g,0.1,0,,3
-Acides gras saturés,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.1,g,0.5,0,,3
-Acides gras saturés,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0.1,0,,3
-Acides gras saturés,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
-Acides gras saturés,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
+Acides gras saturés,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.1,g,0.5,0,,3
+Acides gras saturés,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0.1,0,,3
+Acides gras saturés,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
+Acides gras saturés,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
 Acides gras saturés,Population 1 an et +,11102,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.1,0,0.1,0.1,g,0.4,0,,3
 Acides gras saturés,Population 1 an et +,4543,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.1,0,0.1,0.1,g,0.4,0,,3
 Acides gras saturés,Population 1 an et +,4598,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0,0,0,0,g,0.2,0,,3
@@ -3731,23 +3731,23 @@ Acides gras saturés,Population 1 an et +,18438,des,Soupes - sauces - Épices et
 Acides gras saturés,Population 1 an et +,7054,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.2,0,0.2,0.2,g,0.9,0.1,,2
 Acides gras saturés,Population 1 an et +,4710,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0.1,0,0.1,0.1,g,0.5,0,,2
 Acides gras saturés,Population 1 an et +,17547,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.1,0,0.1,0.1,g,0.3,0,,2
-Acides gras saturés,Population 1 an et +,16725,des,Confiseries - sucres et grignotines salées,,,,,2.2,0.1,2,2.3,g,9.5,0.3,,1
-Acides gras saturés,Population 1 an et +,6211,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,0.8,0,0.7,0.9,g,3.6,0.2,,2
-Acides gras saturés,Population 1 an et +,2912,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,0.8,0,0.7,0.9,g,3.6,0.2,,2
-Acides gras saturés,Population 1 an et +,4652,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0.4,0,0.3,0.4,g,1.6,0.1,,2
-Acides gras saturés,Population 1 an et +,14214,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.2,0,0.1,0.2,g,0.7,0.1,,2
-Acides gras saturés,Population 1 an et +,3815,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0.7,0,0.6,0.8,g,3.2,0.2,,3
-Acides gras saturés,Population 1 an et +,2559,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0.1,0,0,0.1,g,0.3,0,,3
-Acides gras saturés,Population 1 an et +,703,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0,0,0,0,g,0.1,0,,3
-Acides gras saturés,Population 1 an et +,2447,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.8,0,0.7,0.9,g,3.6,0.2,,3
-Acides gras saturés,Population 1 an et +,560,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0,0,,3
-Acides gras saturés,Population 1 an et +,4750,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.2,0,0.1,0.2,g,0.7,0.1,,3
-Acides gras saturés,Population 1 an et +,2044,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0,0,,3
-Acides gras saturés,Population 1 an et +,715,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
-Acides gras saturés,Population 1 an et +,12217,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
+Acides gras saturés,Population 1 an et +,16725,des,Confiserie - sucres et grignotines salées,,,,,2.2,0.1,2,2.3,g,9.5,0.3,,1
+Acides gras saturés,Population 1 an et +,6211,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,0.8,0,0.7,0.9,g,3.6,0.2,,2
+Acides gras saturés,Population 1 an et +,2912,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,0.8,0,0.7,0.9,g,3.6,0.2,,2
+Acides gras saturés,Population 1 an et +,4652,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,0.4,0,0.3,0.4,g,1.6,0.1,,2
+Acides gras saturés,Population 1 an et +,14214,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.2,0,0.1,0.2,g,0.7,0.1,,2
+Acides gras saturés,Population 1 an et +,3815,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,0.7,0,0.6,0.8,g,3.2,0.2,,3
+Acides gras saturés,Population 1 an et +,2559,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,0.1,0,0,0.1,g,0.3,0,,3
+Acides gras saturés,Population 1 an et +,703,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0,0,0,0,g,0.1,0,,3
+Acides gras saturés,Population 1 an et +,2447,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.8,0,0.7,0.9,g,3.6,0.2,,3
+Acides gras saturés,Population 1 an et +,560,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0,0,,3
+Acides gras saturés,Population 1 an et +,4750,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.2,0,0.1,0.2,g,0.7,0.1,,3
+Acides gras saturés,Population 1 an et +,2044,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0,0,,3
+Acides gras saturés,Population 1 an et +,715,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
+Acides gras saturés,Population 1 an et +,12217,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
 Acides gras saturés,Hommes adultes 19 ans +,22,des,Aliments pour bébés,,,,,0,0,0,0,g,0,0,,1
 Acides gras saturés,Hommes adultes 19 ans +,21,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0,g,0,0,,2
-Acides gras saturés,Hommes adultes 19 ans +,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,g,X,X,<10,2
+Acides gras saturés,Hommes adultes 19 ans +,,des,Aliments pour bébés,des,Préparation pour nourrissons,,,X,X,,,g,X,X,<10,2
 Acides gras saturés,Hommes adultes 19 ans +,6187,des,Boissons (excluant laits),,,,,0.1,0,0.1,0.1,g,0.3,0,,1
 Acides gras saturés,Hommes adultes 19 ans +,1946,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0,g,0.1,0,,2
 Acides gras saturés,Hommes adultes 19 ans +,5104,des,Boissons (excluant laits),du,Café et thé,,,0,0,0,0,g,0.1,0,,2
@@ -3767,7 +3767,7 @@ Acides gras saturés,Hommes adultes 19 ans +,3514,des,Produits laitiers et Boiss
 Acides gras saturés,Hommes adultes 19 ans +,5221,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,2.8,0.1,2.6,3,g,10.8,0.4,,2
 Acides gras saturés,Hommes adultes 19 ans +,926,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,,,0.2,0,0.2,0.3,g,0.9,0.1,,2
 Acides gras saturés,Hommes adultes 19 ans +,3759,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,1.1,0,1,1.2,g,4.2,0.2,,3
-Acides gras saturés,Hommes adultes 19 ans +,1727,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,1,0.1,0.8,1.1,g,3.7,0.3,,3
+Acides gras saturés,Hommes adultes 19 ans +,1727,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,1,0.1,0.8,1.1,g,3.7,0.3,,3
 Acides gras saturés,Hommes adultes 19 ans +,1648,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,0.5,0.1,0.4,0.6,g,1.9,0.3,E,3
 Acides gras saturés,Hommes adultes 19 ans +,1819,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,0.3,0,0.2,0.3,g,1,0.1,,3
 Acides gras saturés,Hommes adultes 19 ans +,208,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0,0,0,0,g,0,0,,3
@@ -3786,8 +3786,8 @@ Acides gras saturés,Hommes adultes 19 ans +,5918,des,Fruits et légumes,,,,,0.4
 Acides gras saturés,Hommes adultes 19 ans +,3876,des,Fruits et légumes,des,Fruits,,,0.1,0,0.1,0.2,g,0.5,0,,2
 Acides gras saturés,Hommes adultes 19 ans +,5694,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,0.3,0,0.3,0.3,g,1.1,0.1,,2
 Acides gras saturés,Hommes adultes 19 ans +,603,des,Fruits et légumes,des,Fruits,des,Autres fruits,0.1,0,0,0.1,g,0.3,0,,3
-Acides gras saturés,Hommes adultes 19 ans +,1590,des,Fruits et légumes,des,Fruits,des,Bananes,0,0,0,0,g,0.1,0,,3
-Acides gras saturés,Hommes adultes 19 ans +,1350,des,Fruits et légumes,des,Fruits,des,Pommes,0,0,0,0,g,0,0,,3
+Acides gras saturés,Hommes adultes 19 ans +,1590,des,Fruits et légumes,des,Fruits,des,Banane,0,0,0,0,g,0.1,0,,3
+Acides gras saturés,Hommes adultes 19 ans +,1350,des,Fruits et légumes,des,Fruits,des,Pomme,0,0,0,0,g,0,0,,3
 Acides gras saturés,Hommes adultes 19 ans +,1066,des,Fruits et légumes,des,Fruits,des,Baies,0,0,0,0,g,0,0,,3
 Acides gras saturés,Hommes adultes 19 ans +,169,des,Fruits et légumes,des,Fruits,des,Cerises,0,0,0,0,g,0,0,,3
 Acides gras saturés,Hommes adultes 19 ans +,1019,des,Fruits et légumes,des,Fruits,des,Agrumes,0,0,0,0,g,0,0,,3
@@ -3804,7 +3804,7 @@ Acides gras saturés,Hommes adultes 19 ans +,1991,des,Fruits et légumes,des,Lé
 Acides gras saturés,Hommes adultes 19 ans +,6068,des,Produits céréaliers,,,,,2.1,0.1,2,2.3,g,8.1,0.3,,1
 Acides gras saturés,Hommes adultes 19 ans +,5104,des,Produits céréaliers,des,Pains,,,1.1,0.1,1,1.3,g,4.4,0.2,,2
 Acides gras saturés,Hommes adultes 19 ans +,1921,des,Produits céréaliers,des,Céréales pour déjeuner,,,0.2,0,0.2,0.3,g,0.8,0.1,,2
-Acides gras saturés,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.5,0,0.4,0.6,g,2,0.2,,2
+Acides gras saturés,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,0.5,0,0.4,0.6,g,2,0.2,,2
 Acides gras saturés,Hommes adultes 19 ans +,4551,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,0.2,0,0.2,0.3,g,0.9,0,,2
 Acides gras saturés,Hommes adultes 19 ans +,1885,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,0.5,0.1,0.4,0.6,g,2,0.2,E,3
 Acides gras saturés,Hommes adultes 19 ans +,2752,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,0.4,0,0.3,0.5,g,1.5,0.1,,3
@@ -3812,9 +3812,9 @@ Acides gras saturés,Hommes adultes 19 ans +,1980,des,Produits céréaliers,des,
 Acides gras saturés,Hommes adultes 19 ans +,593,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.1,0,0,0.1,g,0.2,0,,3
 Acides gras saturés,Hommes adultes 19 ans +,1481,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.2,0,0.2,0.2,g,0.8,0.1,,3
 Acides gras saturés,Hommes adultes 19 ans +,523,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0,0,0,0,g,0.1,0,,3
-Acides gras saturés,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.1,g,0.4,0,,3
-Acides gras saturés,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0.1,0,,3
-Acides gras saturés,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
+Acides gras saturés,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.1,g,0.4,0,,3
+Acides gras saturés,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0.1,0,,3
+Acides gras saturés,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
 Acides gras saturés,Hommes adultes 19 ans +,3442,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.1,0,0.1,0.1,g,0.4,0,,3
 Acides gras saturés,Hommes adultes 19 ans +,1250,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.1,0,0.1,0.1,g,0.4,0,,3
 Acides gras saturés,Hommes adultes 19 ans +,1449,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0,0,0,0,g,0.1,0,,3
@@ -3844,23 +3844,23 @@ Acides gras saturés,Hommes adultes 19 ans +,5856,des,Soupes - sauces - Épices 
 Acides gras saturés,Hommes adultes 19 ans +,2384,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.2,0,0.1,0.2,g,0.7,0.1,,2
 Acides gras saturés,Hommes adultes 19 ans +,1511,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0.1,0,0.1,0.2,g,0.5,0.1,,2
 Acides gras saturés,Hommes adultes 19 ans +,5575,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.1,0,0.1,0.1,g,0.3,0,,2
-Acides gras saturés,Hommes adultes 19 ans +,5232,des,Confiseries - sucres et grignotines salées,,,,,2,0.1,1.8,2.2,g,7.6,0.4,,1
-Acides gras saturés,Hommes adultes 19 ans +,1527,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,0.7,0.1,0.6,0.9,g,2.9,0.2,,2
-Acides gras saturés,Hommes adultes 19 ans +,771,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,0.8,0.1,0.6,0.9,g,2.9,0.3,,2
-Acides gras saturés,Hommes adultes 19 ans +,1268,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0.4,0,0.3,0.5,g,1.6,0.1,,2
-Acides gras saturés,Hommes adultes 19 ans +,4671,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.1,0,0,0.1,g,0.3,0.1,,2
-Acides gras saturés,Hommes adultes 19 ans +,1023,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0.6,0.1,0.5,0.7,g,2.5,0.2,E,3
-Acides gras saturés,Hommes adultes 19 ans +,497,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0.1,0,0,0.1,g,0.3,0.1,,3
-Acides gras saturés,Hommes adultes 19 ans +,170,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0,0,0,0,g,0.1,0,,3
-Acides gras saturés,Hommes adultes 19 ans +,702,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.8,0.1,0.6,0.9,g,2.9,0.3,,3
-Acides gras saturés,Hommes adultes 19 ans +,80,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0,0,,3
-Acides gras saturés,Hommes adultes 19 ans +,1360,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.1,0,0,0.1,g,0.3,0.1,,3
-Acides gras saturés,Hommes adultes 19 ans +,726,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0,0,,3
-Acides gras saturés,Hommes adultes 19 ans +,322,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
-Acides gras saturés,Hommes adultes 19 ans +,4068,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
+Acides gras saturés,Hommes adultes 19 ans +,5232,des,Confiserie - sucres et grignotines salées,,,,,2,0.1,1.8,2.2,g,7.6,0.4,,1
+Acides gras saturés,Hommes adultes 19 ans +,1527,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,0.7,0.1,0.6,0.9,g,2.9,0.2,,2
+Acides gras saturés,Hommes adultes 19 ans +,771,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,0.8,0.1,0.6,0.9,g,2.9,0.3,,2
+Acides gras saturés,Hommes adultes 19 ans +,1268,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,0.4,0,0.3,0.5,g,1.6,0.1,,2
+Acides gras saturés,Hommes adultes 19 ans +,4671,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.1,0,0,0.1,g,0.3,0.1,,2
+Acides gras saturés,Hommes adultes 19 ans +,1023,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,0.6,0.1,0.5,0.7,g,2.5,0.2,E,3
+Acides gras saturés,Hommes adultes 19 ans +,497,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,0.1,0,0,0.1,g,0.3,0.1,,3
+Acides gras saturés,Hommes adultes 19 ans +,170,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0,0,0,0,g,0.1,0,,3
+Acides gras saturés,Hommes adultes 19 ans +,702,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.8,0.1,0.6,0.9,g,2.9,0.3,,3
+Acides gras saturés,Hommes adultes 19 ans +,80,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0,0,,3
+Acides gras saturés,Hommes adultes 19 ans +,1360,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.1,0,0,0.1,g,0.3,0.1,,3
+Acides gras saturés,Hommes adultes 19 ans +,726,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0,0,,3
+Acides gras saturés,Hommes adultes 19 ans +,322,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
+Acides gras saturés,Hommes adultes 19 ans +,4068,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
 Acides gras saturés,Femmes adultes* 19 ans +,21,des,Aliments pour bébés,,,,,0,0,0,0,g,0,0,,1
 Acides gras saturés,Femmes adultes* 19 ans +,19,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0,g,0,0,,2
-Acides gras saturés,Femmes adultes* 19 ans +,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,g,X,X,<10,2
+Acides gras saturés,Femmes adultes* 19 ans +,,des,Aliments pour bébés,des,Préparation pour nourrissons,,,X,X,,,g,X,X,<10,2
 Acides gras saturés,Femmes adultes* 19 ans +,6828,des,Boissons (excluant laits),,,,,0.1,0,0.1,0.2,g,0.5,0.1,,1
 Acides gras saturés,Femmes adultes* 19 ans +,1439,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0,g,0.1,0,,2
 Acides gras saturés,Femmes adultes* 19 ans +,5777,des,Boissons (excluant laits),du,Café et thé,,,0.1,0,0,0.1,g,0.3,0.1,,2
@@ -3880,7 +3880,7 @@ Acides gras saturés,Femmes adultes* 19 ans +,3758,des,Produits laitiers et Bois
 Acides gras saturés,Femmes adultes* 19 ans +,5851,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,2.2,0.1,2.1,2.4,g,11.6,0.4,,2
 Acides gras saturés,Femmes adultes* 19 ans +,1629,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,,,0.3,0,0.3,0.4,g,1.7,0.1,,2
 Acides gras saturés,Femmes adultes* 19 ans +,4136,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,0.9,0,0.9,1,g,4.9,0.2,,3
-Acides gras saturés,Femmes adultes* 19 ans +,1769,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0.8,0,0.7,0.8,g,3.9,0.2,,3
+Acides gras saturés,Femmes adultes* 19 ans +,1769,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,0.8,0,0.7,0.8,g,3.9,0.2,,3
 Acides gras saturés,Femmes adultes* 19 ans +,1928,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,0.3,0,0.2,0.4,g,1.7,0.2,,3
 Acides gras saturés,Femmes adultes* 19 ans +,2244,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,0.2,0,0.2,0.2,g,1,0.1,,3
 Acides gras saturés,Femmes adultes* 19 ans +,358,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0,0,0,0,g,0.1,0,,3
@@ -3899,8 +3899,8 @@ Acides gras saturés,Femmes adultes* 19 ans +,6595,des,Fruits et légumes,,,,,0.
 Acides gras saturés,Femmes adultes* 19 ans +,4951,des,Fruits et légumes,des,Fruits,,,0.1,0,0.1,0.2,g,0.8,0.1,,2
 Acides gras saturés,Femmes adultes* 19 ans +,6291,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,0.2,0,0.2,0.2,g,1,0,,2
 Acides gras saturés,Femmes adultes* 19 ans +,854,des,Fruits et légumes,des,Fruits,des,Autres fruits,0.1,0,0.1,0.1,g,0.5,0.1,,3
-Acides gras saturés,Femmes adultes* 19 ans +,1919,des,Fruits et légumes,des,Fruits,des,Bananes,0,0,0,0,g,0.2,0,,3
-Acides gras saturés,Femmes adultes* 19 ans +,1574,des,Fruits et légumes,des,Fruits,des,Pommes,0,0,0,0,g,0,0,,3
+Acides gras saturés,Femmes adultes* 19 ans +,1919,des,Fruits et légumes,des,Fruits,des,Banane,0,0,0,0,g,0.2,0,,3
+Acides gras saturés,Femmes adultes* 19 ans +,1574,des,Fruits et légumes,des,Fruits,des,Pomme,0,0,0,0,g,0,0,,3
 Acides gras saturés,Femmes adultes* 19 ans +,1597,des,Fruits et légumes,des,Fruits,des,Baies,0,0,0,0,g,0,0,,3
 Acides gras saturés,Femmes adultes* 19 ans +,215,des,Fruits et légumes,des,Fruits,des,Cerises,0,0,0,0,g,0,0,,3
 Acides gras saturés,Femmes adultes* 19 ans +,1356,des,Fruits et légumes,des,Fruits,des,Agrumes,0,0,0,0,g,0,0,,3
@@ -3917,7 +3917,7 @@ Acides gras saturés,Femmes adultes* 19 ans +,2348,des,Fruits et légumes,des,L�
 Acides gras saturés,Femmes adultes* 19 ans +,6669,des,Produits céréaliers,,,,,1.6,0.1,1.5,1.8,g,8.5,0.3,,1
 Acides gras saturés,Femmes adultes* 19 ans +,5520,des,Produits céréaliers,des,Pains,,,0.8,0,0.8,0.9,g,4.4,0.2,,2
 Acides gras saturés,Femmes adultes* 19 ans +,2230,des,Produits céréaliers,des,Céréales pour déjeuner,,,0.2,0,0.1,0.2,g,0.9,0.1,,2
-Acides gras saturés,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.4,0,0.4,0.5,g,2.3,0.2,,2
+Acides gras saturés,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,0.4,0,0.4,0.5,g,2.3,0.2,,2
 Acides gras saturés,Femmes adultes* 19 ans +,4893,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,0.2,0,0.2,0.2,g,1,0.1,,2
 Acides gras saturés,Femmes adultes* 19 ans +,1994,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,0.4,0,0.3,0.5,g,2,0.2,,3
 Acides gras saturés,Femmes adultes* 19 ans +,2551,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,0.2,0,0.2,0.3,g,1.2,0.1,,3
@@ -3925,10 +3925,10 @@ Acides gras saturés,Femmes adultes* 19 ans +,2239,des,Produits céréaliers,des
 Acides gras saturés,Femmes adultes* 19 ans +,914,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.1,0,0,0.1,g,0.3,0,,3
 Acides gras saturés,Femmes adultes* 19 ans +,1756,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.2,0,0.1,0.2,g,0.9,0.1,,3
 Acides gras saturés,Femmes adultes* 19 ans +,555,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0,0,0,0,g,0.1,0,,3
-Acides gras saturés,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.1,g,0.3,0,,3
-Acides gras saturés,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0,0,,3
-Acides gras saturés,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
-Acides gras saturés,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
+Acides gras saturés,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.1,g,0.3,0,,3
+Acides gras saturés,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0,0,,3
+Acides gras saturés,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
+Acides gras saturés,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
 Acides gras saturés,Femmes adultes* 19 ans +,3664,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.1,0,0.1,0.1,g,0.4,0,,3
 Acides gras saturés,Femmes adultes* 19 ans +,1358,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.1,0,0.1,0.1,g,0.4,0.1,,3
 Acides gras saturés,Femmes adultes* 19 ans +,1522,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0,0,0,0,g,0.2,0,,3
@@ -3958,23 +3958,23 @@ Acides gras saturés,Femmes adultes* 19 ans +,6382,des,Soupes - sauces - Épices
 Acides gras saturés,Femmes adultes* 19 ans +,2243,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.2,0,0.1,0.3,g,1.1,0.2,,2
 Acides gras saturés,Femmes adultes* 19 ans +,1853,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0.1,0,0.1,0.2,g,0.6,0.1,,2
 Acides gras saturés,Femmes adultes* 19 ans +,6077,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.1,0,0.1,0.1,g,0.3,0,,2
-Acides gras saturés,Femmes adultes* 19 ans +,5713,des,Confiseries - sucres et grignotines salées,,,,,1.9,0.1,1.7,2.2,g,10,0.6,,1
-Acides gras saturés,Femmes adultes* 19 ans +,1936,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,0.9,0.1,0.7,1,g,4.5,0.5,,2
-Acides gras saturés,Femmes adultes* 19 ans +,844,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,0.7,0.1,0.6,0.9,g,3.9,0.3,,2
-Acides gras saturés,Femmes adultes* 19 ans +,1411,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0.3,0,0.2,0.3,g,1.4,0.1,,2
-Acides gras saturés,Femmes adultes* 19 ans +,4937,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.1,0,0,0.1,g,0.3,0.1,,2
-Acides gras saturés,Femmes adultes* 19 ans +,1238,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0.8,0.1,0.6,0.9,g,4,0.5,,3
-Acides gras saturés,Femmes adultes* 19 ans +,685,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0.1,0,0,0.1,g,0.3,0.1,,3
-Acides gras saturés,Femmes adultes* 19 ans +,229,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0,0,0,0,g,0.1,0,,3
-Acides gras saturés,Femmes adultes* 19 ans +,762,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.7,0.1,0.6,0.9,g,3.8,0.3,,3
-Acides gras saturés,Femmes adultes* 19 ans +,87,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0,0,,3
-Acides gras saturés,Femmes adultes* 19 ans +,1529,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.1,0,0,0.1,g,0.3,0.1,,3
-Acides gras saturés,Femmes adultes* 19 ans +,773,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0,0,,3
-Acides gras saturés,Femmes adultes* 19 ans +,360,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
-Acides gras saturés,Femmes adultes* 19 ans +,4229,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
+Acides gras saturés,Femmes adultes* 19 ans +,5713,des,Confiserie - sucres et grignotines salées,,,,,1.9,0.1,1.7,2.2,g,10,0.6,,1
+Acides gras saturés,Femmes adultes* 19 ans +,1936,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,0.9,0.1,0.7,1,g,4.5,0.5,,2
+Acides gras saturés,Femmes adultes* 19 ans +,844,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,0.7,0.1,0.6,0.9,g,3.9,0.3,,2
+Acides gras saturés,Femmes adultes* 19 ans +,1411,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,0.3,0,0.2,0.3,g,1.4,0.1,,2
+Acides gras saturés,Femmes adultes* 19 ans +,4937,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.1,0,0,0.1,g,0.3,0.1,,2
+Acides gras saturés,Femmes adultes* 19 ans +,1238,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,0.8,0.1,0.6,0.9,g,4,0.5,,3
+Acides gras saturés,Femmes adultes* 19 ans +,685,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,0.1,0,0,0.1,g,0.3,0.1,,3
+Acides gras saturés,Femmes adultes* 19 ans +,229,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0,0,0,0,g,0.1,0,,3
+Acides gras saturés,Femmes adultes* 19 ans +,762,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.7,0.1,0.6,0.9,g,3.8,0.3,,3
+Acides gras saturés,Femmes adultes* 19 ans +,87,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0,0,,3
+Acides gras saturés,Femmes adultes* 19 ans +,1529,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.1,0,0,0.1,g,0.3,0.1,,3
+Acides gras saturés,Femmes adultes* 19 ans +,773,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0,0,,3
+Acides gras saturés,Femmes adultes* 19 ans +,360,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
+Acides gras saturés,Femmes adultes* 19 ans +,4229,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
 Acides gras saturés,Enfants 1 à 8 ans,122,des,Aliments pour bébés,,,,,0.1,0,0.1,0.2,g,0.6,0.1,,1
 Acides gras saturés,Enfants 1 à 8 ans,95,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0,g,0.1,0,,2
-Acides gras saturés,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0.1,0,0,0.1,g,0.5,0.1,,2
+Acides gras saturés,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparation pour nourrissons,,,0.1,0,0,0.1,g,0.5,0.1,,2
 Acides gras saturés,Enfants 1 à 8 ans,2443,des,Boissons (excluant laits),,,,,0,0,0,0.1,g,0.2,0,,1
 Acides gras saturés,Enfants 1 à 8 ans,20,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0,g,0,0,,2
 Acides gras saturés,Enfants 1 à 8 ans,141,des,Boissons (excluant laits),du,Café et thé,,,0,0,0,0,g,0,0,,2
@@ -3996,7 +3996,7 @@ Acides gras saturés,Enfants 1 à 8 ans,1032,des,Produits laitiers et Boissons �
 Acides gras saturés,Enfants 1 à 8 ans,1810,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,2,0.1,1.9,2.2,g,10.3,0.5,,3
 Acides gras saturés,Enfants 1 à 8 ans,1078,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,2,0.1,1.7,2.2,g,10,0.6,,3
 Acides gras saturés,Enfants 1 à 8 ans,854,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,0.4,0,0.3,0.4,g,1.8,0.2,,3
-Acides gras saturés,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0.2,0,0.2,0.3,g,1.3,0.2,,3
+Acides gras saturés,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,0.2,0,0.2,0.3,g,1.3,0.2,,3
 Acides gras saturés,Enfants 1 à 8 ans,128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0,0,0,0,g,0,0,,3
 Acides gras saturés,Enfants 1 à 8 ans,739,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0,0,0,0,g,0,0,,3
 Acides gras saturés,Enfants 1 à 8 ans,2270,des,Graisses et huiles,,,,,2.8,0.1,2.5,3,g,13.9,0.5,,1
@@ -4012,9 +4012,9 @@ Acides gras saturés,Enfants 1 à 8 ans,50,des,Poissons et fruits de mer,des,Mol
 Acides gras saturés,Enfants 1 à 8 ans,2428,des,Fruits et légumes,,,,,0.3,0,0.2,0.3,g,1.3,0.1,,1
 Acides gras saturés,Enfants 1 à 8 ans,2117,des,Fruits et légumes,des,Fruits,,,0.1,0,0.1,0.1,g,0.5,0.1,,2
 Acides gras saturés,Enfants 1 à 8 ans,2235,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,0.2,0,0.1,0.2,g,0.8,0.1,,2
-Acides gras saturés,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Bananes,0,0,0,0,g,0.2,0,,3
+Acides gras saturés,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Banane,0,0,0,0,g,0.2,0,,3
 Acides gras saturés,Enfants 1 à 8 ans,260,des,Fruits et légumes,des,Fruits,des,Autres fruits,0,0,0,0.1,g,0.2,0.1,,3
-Acides gras saturés,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pommes,0,0,0,0,g,0.1,0,,3
+Acides gras saturés,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pomme,0,0,0,0,g,0.1,0,,3
 Acides gras saturés,Enfants 1 à 8 ans,830,des,Fruits et légumes,des,Fruits,des,Baies,0,0,0,0,g,0,0,,3
 Acides gras saturés,Enfants 1 à 8 ans,47,des,Fruits et légumes,des,Fruits,des,Cerises,0,0,0,0,g,0,0,,3
 Acides gras saturés,Enfants 1 à 8 ans,421,des,Fruits et légumes,des,Fruits,des,Agrumes,0,0,0,0,g,0,0,,3
@@ -4031,7 +4031,7 @@ Acides gras saturés,Enfants 1 à 8 ans,875,des,Fruits et légumes,des,Légumes 
 Acides gras saturés,Enfants 1 à 8 ans,2475,des,Produits céréaliers,,,,,2,0.1,1.9,2.2,g,10.2,0.4,,1
 Acides gras saturés,Enfants 1 à 8 ans,2114,des,Produits céréaliers,des,Pains,,,1,0.1,0.9,1.1,g,4.9,0.3,,2
 Acides gras saturés,Enfants 1 à 8 ans,1282,des,Produits céréaliers,des,Céréales pour déjeuner,,,0.2,0,0.1,0.2,g,0.8,0.1,,2
-Acides gras saturés,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.7,0.1,0.6,0.8,g,3.3,0.3,,2
+Acides gras saturés,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,0.7,0.1,0.6,0.8,g,3.3,0.3,,2
 Acides gras saturés,Enfants 1 à 8 ans,2037,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,0.2,0,0.2,0.2,g,1.1,0.1,,2
 Acides gras saturés,Enfants 1 à 8 ans,805,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,0.4,0,0.3,0.5,g,1.9,0.2,,3
 Acides gras saturés,Enfants 1 à 8 ans,745,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.3,0,0.2,0.3,g,1.4,0.1,,3
@@ -4039,9 +4039,9 @@ Acides gras saturés,Enfants 1 à 8 ans,951,des,Produits céréaliers,des,Pains,
 Acides gras saturés,Enfants 1 à 8 ans,813,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,0.1,0,0.1,0.1,g,0.6,0,,3
 Acides gras saturés,Enfants 1 à 8 ans,728,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.1,0,0.1,0.1,g,0.5,0.1,,3
 Acides gras saturés,Enfants 1 à 8 ans,670,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.1,0,0,0.1,g,0.3,0,,3
-Acides gras saturés,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.2,g,0.7,0.1,,3
-Acides gras saturés,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0.1,0,,3
-Acides gras saturés,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0.1,0,,3
+Acides gras saturés,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.2,g,0.7,0.1,,3
+Acides gras saturés,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0.1,0,,3
+Acides gras saturés,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0.1,0,,3
 Acides gras saturés,Enfants 1 à 8 ans,834,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.1,0,0.1,0.1,g,0.6,0.1,,3
 Acides gras saturés,Enfants 1 à 8 ans,1461,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.1,0,0.1,0.1,g,0.3,0,,3
 Acides gras saturés,Enfants 1 à 8 ans,654,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0,0,0,0,g,0.1,0,,3
@@ -4071,23 +4071,23 @@ Acides gras saturés,Enfants 1 à 8 ans,2295,des,Soupes - sauces - Épices et au
 Acides gras saturés,Enfants 1 à 8 ans,761,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,F,F,,,g,F,F,F,2
 Acides gras saturés,Enfants 1 à 8 ans,532,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0,0,0,0.1,g,0.2,0,,2
 Acides gras saturés,Enfants 1 à 8 ans,2205,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0,0,0,0,g,0.1,0,,2
-Acides gras saturés,Enfants 1 à 8 ans,2106,des,Confiseries - sucres et grignotines salées,,,,,2.1,0.1,1.8,2.4,g,10.5,0.6,,1
-Acides gras saturés,Enfants 1 à 8 ans,1048,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,0.7,0.1,0.6,0.8,g,3.4,0.3,,2
-Acides gras saturés,Enfants 1 à 8 ans,497,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,0.8,0.1,0.6,1,g,4.1,0.4,,2
-Acides gras saturés,Enfants 1 à 8 ans,615,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0.2,0,0.2,0.3,g,1.2,0.1,,2
-Acides gras saturés,Enfants 1 à 8 ans,1642,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.4,0.1,0.2,0.5,g,1.8,0.3,E,2
-Acides gras saturés,Enfants 1 à 8 ans,548,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0.6,0.1,0.5,0.7,g,3,0.3,E,3
-Acides gras saturés,Enfants 1 à 8 ans,557,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0.1,0,0,0.1,g,0.3,0,,3
-Acides gras saturés,Enfants 1 à 8 ans,131,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0,0,0,0,g,0.2,0,,3
-Acides gras saturés,Enfants 1 à 8 ans,346,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.8,0.1,0.6,1,g,4.1,0.4,,3
-Acides gras saturés,Enfants 1 à 8 ans,184,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0,0,,3
-Acides gras saturés,Enfants 1 à 8 ans,720,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.4,0.1,0.2,0.5,g,1.8,0.3,E,3
-Acides gras saturés,Enfants 1 à 8 ans,257,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0,0,,3
-Acides gras saturés,Enfants 1 à 8 ans,1341,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
-Acides gras saturés,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,g,X,X,<10,3
+Acides gras saturés,Enfants 1 à 8 ans,2106,des,Confiserie - sucres et grignotines salées,,,,,2.1,0.1,1.8,2.4,g,10.5,0.6,,1
+Acides gras saturés,Enfants 1 à 8 ans,1048,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,0.7,0.1,0.6,0.8,g,3.4,0.3,,2
+Acides gras saturés,Enfants 1 à 8 ans,497,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,0.8,0.1,0.6,1,g,4.1,0.4,,2
+Acides gras saturés,Enfants 1 à 8 ans,615,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,0.2,0,0.2,0.3,g,1.2,0.1,,2
+Acides gras saturés,Enfants 1 à 8 ans,1642,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.4,0.1,0.2,0.5,g,1.8,0.3,E,2
+Acides gras saturés,Enfants 1 à 8 ans,548,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,0.6,0.1,0.5,0.7,g,3,0.3,E,3
+Acides gras saturés,Enfants 1 à 8 ans,557,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,0.1,0,0,0.1,g,0.3,0,,3
+Acides gras saturés,Enfants 1 à 8 ans,131,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0,0,0,0,g,0.2,0,,3
+Acides gras saturés,Enfants 1 à 8 ans,346,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.8,0.1,0.6,1,g,4.1,0.4,,3
+Acides gras saturés,Enfants 1 à 8 ans,184,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0,0,,3
+Acides gras saturés,Enfants 1 à 8 ans,720,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.4,0.1,0.2,0.5,g,1.8,0.3,E,3
+Acides gras saturés,Enfants 1 à 8 ans,257,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0,0,,3
+Acides gras saturés,Enfants 1 à 8 ans,1341,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
+Acides gras saturés,Enfants 1 à 8 ans,,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,g,X,X,<10,3
 Sodium,Population 1 an et +,186,des,Aliments pour bébés,,,,,0.3,0.1,0.1,0.5,mg,0,0,E,1
 Sodium,Population 1 an et +,154,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,F,F,,,mg,F,F,F,2
-Sodium,Population 1 an et +,51,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0.1,0,0.1,0.2,mg,0,0,,2
+Sodium,Population 1 an et +,51,des,Aliments pour bébés,des,Préparation pour nourrissons,,,0.1,0,0.1,0.2,mg,0,0,,2
 Sodium,Population 1 an et +,19574,des,Boissons (excluant laits),,,,,73.4,1.8,70,76.9,mg,2.7,0.1,,1
 Sodium,Population 1 an et +,3540,des,Boissons (excluant laits),de l',Alcool,,,4.7,0.2,4.2,5.1,mg,0.2,0,,2
 Sodium,Population 1 an et +,12127,des,Boissons (excluant laits),du,Café et thé,,,12.6,0.5,11.6,13.6,mg,0.5,0,,2
@@ -4110,7 +4110,7 @@ Sodium,Population 1 an et +,12441,des,Produits laitiers et Boissons à base de p
 Sodium,Population 1 an et +,6481,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,20.6,0.8,19,22.2,mg,0.8,0,,3
 Sodium,Population 1 an et +,5835,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,13.2,0.8,11.6,14.8,mg,0.5,0,,3
 Sodium,Population 1 an et +,6026,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,6.7,0.4,6,7.4,mg,0.3,0,,3
-Sodium,Population 1 an et +,4411,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,4.6,0.3,4,5.2,mg,0.2,0,,3
+Sodium,Population 1 an et +,4411,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,4.6,0.3,4,5.2,mg,0.2,0,,3
 Sodium,Population 1 an et +,814,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,5.4,0.5,4.5,6.3,mg,0.2,0,,3
 Sodium,Population 1 an et +,18258,des,Graisses et huiles,,,,,114.1,2.4,109.5,118.7,mg,4.2,0.1,,1
 Sodium,Population 1 an et +,944,des,Graisses et huiles,des,Graisses animales,,,1.7,0.4,0.9,2.6,mg,0.1,0,E,2
@@ -4125,8 +4125,8 @@ Sodium,Population 1 an et +,924,des,Poissons et fruits de mer,des,Mollusques et 
 Sodium,Population 1 an et +,18937,des,Fruits et légumes,,,,,190.1,4.9,180.3,199.8,mg,7.1,0.2,,1
 Sodium,Population 1 an et +,13689,des,Fruits et légumes,des,Fruits,,,2.7,0.1,2.6,2.9,mg,0.1,0,,2
 Sodium,Population 1 an et +,18039,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,187.3,5,177.6,197.1,mg,7,0.2,,2
-Sodium,Population 1 an et +,5026,des,Fruits et légumes,des,Fruits,des,Pommes,0.5,0,0.4,0.5,mg,0,0,,3
-Sodium,Population 1 an et +,5308,des,Fruits et légumes,des,Fruits,des,Bananes,0.3,0,0.3,0.3,mg,0,0,,3
+Sodium,Population 1 an et +,5026,des,Fruits et légumes,des,Fruits,des,Pomme,0.5,0,0.4,0.5,mg,0,0,,3
+Sodium,Population 1 an et +,5308,des,Fruits et légumes,des,Fruits,des,Banane,0.3,0,0.3,0.3,mg,0,0,,3
 Sodium,Population 1 an et +,4326,des,Fruits et légumes,des,Fruits,des,Baies,0.2,0,0.2,0.3,mg,0,0,,3
 Sodium,Population 1 an et +,513,des,Fruits et légumes,des,Fruits,des,Cerises,0,0,0,0,mg,0,0,,3
 Sodium,Population 1 an et +,3372,des,Fruits et légumes,des,Fruits,des,Agrumes,0.2,0,0.2,0.2,mg,0,0,,3
@@ -4144,7 +4144,7 @@ Sodium,Population 1 an et +,2923,des,Fruits et légumes,des,Légumes incluant po
 Sodium,Population 1 an et +,19327,des,Produits céréaliers,,,,,523.7,6.7,510.5,536.8,mg,19.5,0.2,,1
 Sodium,Population 1 an et +,16168,des,Produits céréaliers,des,Pains,,,428.7,6.1,416.7,440.8,mg,15.9,0.2,,2
 Sodium,Population 1 an et +,6966,des,Produits céréaliers,des,Céréales pour déjeuner,,,42.7,1.3,40.1,45.2,mg,1.6,0,,2
-Sodium,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,35.7,1.9,31.9,39.5,mg,1.3,0.1,,2
+Sodium,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,35.7,1.9,31.9,39.5,mg,1.3,0.1,,2
 Sodium,Population 1 an et +,14820,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,16.6,1.3,14.1,19.1,mg,0.6,0,,2
 Sodium,Population 1 an et +,8159,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,181.5,4.7,172.2,190.7,mg,6.7,0.2,,3
 Sodium,Population 1 an et +,6257,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,114,3.8,106.6,121.5,mg,4.2,0.1,,3
@@ -4152,10 +4152,10 @@ Sodium,Population 1 an et +,5962,des,Produits céréaliers,des,Pains,des,Pains e
 Sodium,Population 1 an et +,2918,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,22.7,1.2,20.4,25,mg,0.8,0,,3
 Sodium,Population 1 an et +,4760,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,25.9,1.2,23.7,28.2,mg,1,0,,3
 Sodium,Population 1 an et +,2573,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),16.8,0.8,15.1,18.4,mg,0.6,0,,3
-Sodium,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,7.5,0.4,6.6,8.4,mg,0.3,0,,3
-Sodium,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,1.1,0.2,0.7,1.5,mg,0,0,E,3
-Sodium,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.9,0.2,0.6,1.3,mg,0,0,E,3
-Sodium,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
+Sodium,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,7.5,0.4,6.6,8.4,mg,0.3,0,,3
+Sodium,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,1.1,0.2,0.7,1.5,mg,0,0,E,3
+Sodium,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.9,0.2,0.6,1.3,mg,0,0,E,3
+Sodium,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
 Sodium,Population 1 an et +,4543,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,14.4,1.2,12,16.8,mg,0.5,0,,3
 Sodium,Population 1 an et +,4598,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,1.9,0.4,1.2,2.6,mg,0.1,0,E,3
 Sodium,Population 1 an et +,11102,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.3,0,0.2,0.3,mg,0,0,,3
@@ -4185,23 +4185,23 @@ Sodium,Population 1 an et +,18345,des,Soupes - sauces - Épices et autres ingré
 Sodium,Population 1 an et +,7054,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,152.3,5.6,141.3,163.3,mg,5.7,0.2,,2
 Sodium,Population 1 an et +,4710,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,152.4,6.5,139.5,165.2,mg,5.7,0.2,,2
 Sodium,Population 1 an et +,17325,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,588.6,10.3,568.3,608.9,mg,21.9,0.3,,2
-Sodium,Population 1 an et +,16725,des,Confiseries - sucres et grignotines salées,,,,,79.7,2.6,74.7,84.8,mg,3,0.1,,1
-Sodium,Population 1 an et +,6211,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,12.7,1.1,10.5,15,mg,0.5,0,,2
-Sodium,Population 1 an et +,2912,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,11.5,0.5,10.5,12.5,mg,0.4,0,,2
-Sodium,Population 1 an et +,4652,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,51.5,2.4,46.9,56.2,mg,1.9,0.1,,2
-Sodium,Population 1 an et +,14214,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,4,0.3,3.5,4.5,mg,0.1,0,,2
-Sodium,Population 1 an et +,2559,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,5.4,1.1,3.2,7.6,mg,0.2,0,E,3
-Sodium,Population 1 an et +,3815,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,4,0.3,3.4,4.6,mg,0.1,0,,3
-Sodium,Population 1 an et +,703,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,3.3,0.3,2.7,3.8,mg,0.1,0,,3
-Sodium,Population 1 an et +,2447,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,10.8,0.5,9.8,11.8,mg,0.4,0,,3
-Sodium,Population 1 an et +,560,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0.7,0.1,0.5,0.8,mg,0,0,,3
-Sodium,Population 1 an et +,4750,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,3,0.3,2.5,3.5,mg,0.1,0,,3
-Sodium,Population 1 an et +,2044,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.6,0.1,0.5,0.7,mg,0,0,E,3
-Sodium,Population 1 an et +,715,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mg,0,0,,3
-Sodium,Population 1 an et +,12217,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0.3,0,0.3,0.3,mg,0,0,,3
+Sodium,Population 1 an et +,16725,des,Confiserie - sucres et grignotines salées,,,,,79.7,2.6,74.7,84.8,mg,3,0.1,,1
+Sodium,Population 1 an et +,6211,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,12.7,1.1,10.5,15,mg,0.5,0,,2
+Sodium,Population 1 an et +,2912,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,11.5,0.5,10.5,12.5,mg,0.4,0,,2
+Sodium,Population 1 an et +,4652,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,51.5,2.4,46.9,56.2,mg,1.9,0.1,,2
+Sodium,Population 1 an et +,14214,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,4,0.3,3.5,4.5,mg,0.1,0,,2
+Sodium,Population 1 an et +,2559,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,5.4,1.1,3.2,7.6,mg,0.2,0,E,3
+Sodium,Population 1 an et +,3815,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,4,0.3,3.4,4.6,mg,0.1,0,,3
+Sodium,Population 1 an et +,703,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,3.3,0.3,2.7,3.8,mg,0.1,0,,3
+Sodium,Population 1 an et +,2447,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,10.8,0.5,9.8,11.8,mg,0.4,0,,3
+Sodium,Population 1 an et +,560,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0.7,0.1,0.5,0.8,mg,0,0,,3
+Sodium,Population 1 an et +,4750,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,3,0.3,2.5,3.5,mg,0.1,0,,3
+Sodium,Population 1 an et +,2044,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.6,0.1,0.5,0.7,mg,0,0,E,3
+Sodium,Population 1 an et +,715,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mg,0,0,,3
+Sodium,Population 1 an et +,12217,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0.3,0,0.3,0.3,mg,0,0,,3
 Sodium,Hommes adultes 19 ans +,22,des,Aliments pour bébés,,,,,F,F,,,mg,F,F,F,1
 Sodium,Hommes adultes 19 ans +,21,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,F,F,,,mg,F,F,F,2
-Sodium,Hommes adultes 19 ans +,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,mg,X,X,<10,2
+Sodium,Hommes adultes 19 ans +,,des,Aliments pour bébés,des,Préparation pour nourrissons,,,X,X,,,mg,X,X,<10,2
 Sodium,Hommes adultes 19 ans +,6187,des,Boissons (excluant laits),,,,,91.5,3.8,83.9,99,mg,2.9,0.1,,1
 Sodium,Hommes adultes 19 ans +,1946,des,Boissons (excluant laits),de l',Alcool,,,8.5,0.5,7.5,9.6,mg,0.3,0,,2
 Sodium,Hommes adultes 19 ans +,5104,des,Boissons (excluant laits),du,Café et thé,,,16.3,1.1,14,18.5,mg,0.5,0,,2
@@ -4223,7 +4223,7 @@ Sodium,Hommes adultes 19 ans +,926,des,Produits laitiers et Boissons à base de 
 Sodium,Hommes adultes 19 ans +,3759,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,41.3,1.8,37.8,44.9,mg,1.3,0.1,,3
 Sodium,Hommes adultes 19 ans +,1819,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,20,1.3,17.4,22.6,mg,0.6,0,,3
 Sodium,Hommes adultes 19 ans +,1648,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,11.5,1.6,8.3,14.7,mg,0.4,0.1,,3
-Sodium,Hommes adultes 19 ans +,1727,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,6,0.7,4.6,7.4,mg,0.2,0,,3
+Sodium,Hommes adultes 19 ans +,1727,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,6,0.7,4.6,7.4,mg,0.2,0,,3
 Sodium,Hommes adultes 19 ans +,208,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,5.4,0.9,3.6,7.1,mg,0.2,0,E,3
 Sodium,Hommes adultes 19 ans +,1812,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,6.5,0.6,5.3,7.8,mg,0.2,0,,3
 Sodium,Hommes adultes 19 ans +,5767,des,Graisses et huiles,,,,,132,3.9,124.4,139.7,mg,4.2,0.1,,1
@@ -4239,8 +4239,8 @@ Sodium,Hommes adultes 19 ans +,343,des,Poissons et fruits de mer,des,Mollusques 
 Sodium,Hommes adultes 19 ans +,5930,des,Fruits et légumes,,,,,223.1,9.6,204.2,242,mg,7,0.3,,1
 Sodium,Hommes adultes 19 ans +,3876,des,Fruits et légumes,des,Fruits,,,2.5,0.1,2.2,2.7,mg,0.1,0,,2
 Sodium,Hommes adultes 19 ans +,5717,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,220.6,9.6,201.7,239.6,mg,6.9,0.3,,2
-Sodium,Hommes adultes 19 ans +,1350,des,Fruits et légumes,des,Fruits,des,Pommes,0.4,0,0.4,0.5,mg,0,0,,3
-Sodium,Hommes adultes 19 ans +,1590,des,Fruits et légumes,des,Fruits,des,Bananes,0.3,0,0.3,0.4,mg,0,0,,3
+Sodium,Hommes adultes 19 ans +,1350,des,Fruits et légumes,des,Fruits,des,Pomme,0.4,0,0.4,0.5,mg,0,0,,3
+Sodium,Hommes adultes 19 ans +,1590,des,Fruits et légumes,des,Fruits,des,Banane,0.3,0,0.3,0.4,mg,0,0,,3
 Sodium,Hommes adultes 19 ans +,1066,des,Fruits et légumes,des,Fruits,des,Baies,0.2,0,0.2,0.3,mg,0,0,,3
 Sodium,Hommes adultes 19 ans +,169,des,Fruits et légumes,des,Fruits,des,Cerises,0,0,0,0,mg,0,0,,3
 Sodium,Hommes adultes 19 ans +,1019,des,Fruits et légumes,des,Fruits,des,Agrumes,0.1,0,0.1,0.2,mg,0,0,,3
@@ -4258,7 +4258,7 @@ Sodium,Hommes adultes 19 ans +,5438,des,Fruits et légumes,des,Légumes incluant
 Sodium,Hommes adultes 19 ans +,6068,des,Produits céréaliers,,,,,587.9,12.3,563.7,612.1,mg,18.5,0.3,,1
 Sodium,Hommes adultes 19 ans +,5104,des,Produits céréaliers,des,Pains,,,499.9,11.8,476.7,523.1,mg,15.7,0.3,,2
 Sodium,Hommes adultes 19 ans +,1921,des,Produits céréaliers,des,Céréales pour déjeuner,,,40.3,2.4,35.6,45,mg,1.3,0.1,,2
-Sodium,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,34.3,3.3,27.9,40.7,mg,1.1,0.1,,2
+Sodium,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,34.3,3.3,27.9,40.7,mg,1.1,0.1,,2
 Sodium,Hommes adultes 19 ans +,4551,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,13.4,2.3,8.9,17.9,mg,0.4,0.1,E,2
 Sodium,Hommes adultes 19 ans +,2752,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,231,9.7,212.1,250,mg,7.3,0.3,,3
 Sodium,Hommes adultes 19 ans +,1980,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,126.1,5.9,114.5,137.7,mg,4,0.2,,3
@@ -4266,9 +4266,9 @@ Sodium,Hommes adultes 19 ans +,1885,des,Produits céréaliers,des,Pains,des,Autr
 Sodium,Hommes adultes 19 ans +,593,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,17.6,1.7,14.3,21,mg,0.6,0.1,,3
 Sodium,Hommes adultes 19 ans +,1481,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,28.5,2.2,24.2,32.9,mg,0.9,0.1,,3
 Sodium,Hommes adultes 19 ans +,523,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),11.8,1.2,9.3,14.2,mg,0.4,0,,3
-Sodium,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,8,0.9,6.1,9.8,mg,0.3,0,,3
-Sodium,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,F,F,,,mg,F,F,F,3
-Sodium,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,F,F,,,mg,F,F,F,3
+Sodium,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,8,0.9,6.1,9.8,mg,0.3,0,,3
+Sodium,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,F,F,,,mg,F,F,F,3
+Sodium,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,F,F,,,mg,F,F,F,3
 Sodium,Hommes adultes 19 ans +,1250,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,11.3,2.2,7,15.6,mg,0.4,0.1,E,3
 Sodium,Hommes adultes 19 ans +,1449,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,1.8,0.5,0.7,2.8,mg,0.1,0,E,3
 Sodium,Hommes adultes 19 ans +,3442,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.3,0,0.2,0.4,mg,0,0,,3
@@ -4298,23 +4298,23 @@ Sodium,Hommes adultes 19 ans +,5828,des,Soupes - sauces - Épices et autres ingr
 Sodium,Hommes adultes 19 ans +,2384,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,188.8,11.6,166,211.6,mg,5.9,0.3,,2
 Sodium,Hommes adultes 19 ans +,1511,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,171.9,11.6,149.1,194.7,mg,5.4,0.4,,2
 Sodium,Hommes adultes 19 ans +,5490,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,716.7,20.5,676.3,757,mg,22.6,0.5,,2
-Sodium,Hommes adultes 19 ans +,5232,des,Confiseries - sucres et grignotines salées,,,,,81.6,4.8,72.2,91,mg,2.6,0.1,,1
-Sodium,Hommes adultes 19 ans +,1527,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,12.6,2.8,7.1,18.1,mg,0.4,0.1,E,2
-Sodium,Hommes adultes 19 ans +,771,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,10.4,0.9,8.7,12.1,mg,0.3,0,,2
-Sodium,Hommes adultes 19 ans +,1268,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,55.1,4.3,46.8,63.5,mg,1.7,0.1,,2
-Sodium,Hommes adultes 19 ans +,4671,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,3.4,0.3,2.9,3.9,mg,0.1,0,,2
-Sodium,Hommes adultes 19 ans +,1023,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,3.7,0.4,3,4.5,mg,0.1,0,,3
-Sodium,Hommes adultes 19 ans +,170,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,2,0.3,1.4,2.6,mg,0.1,0,,3
-Sodium,Hommes adultes 19 ans +,497,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,F,F,,,mg,F,F,F,3
-Sodium,Hommes adultes 19 ans +,702,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,9.9,0.9,8.2,11.6,mg,0.3,0,,3
-Sodium,Hommes adultes 19 ans +,80,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,F,F,,,mg,F,F,F,3
-Sodium,Hommes adultes 19 ans +,1360,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,2.2,0.2,1.8,2.7,mg,0.1,0,,3
-Sodium,Hommes adultes 19 ans +,726,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.8,0.1,0.6,1.1,mg,0,0,,3
-Sodium,Hommes adultes 19 ans +,322,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mg,0,0,,3
-Sodium,Hommes adultes 19 ans +,4068,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0.3,0,0.3,0.4,mg,0,0,,3
+Sodium,Hommes adultes 19 ans +,5232,des,Confiserie - sucres et grignotines salées,,,,,81.6,4.8,72.2,91,mg,2.6,0.1,,1
+Sodium,Hommes adultes 19 ans +,1527,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,12.6,2.8,7.1,18.1,mg,0.4,0.1,E,2
+Sodium,Hommes adultes 19 ans +,771,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,10.4,0.9,8.7,12.1,mg,0.3,0,,2
+Sodium,Hommes adultes 19 ans +,1268,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,55.1,4.3,46.8,63.5,mg,1.7,0.1,,2
+Sodium,Hommes adultes 19 ans +,4671,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,3.4,0.3,2.9,3.9,mg,0.1,0,,2
+Sodium,Hommes adultes 19 ans +,1023,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,3.7,0.4,3,4.5,mg,0.1,0,,3
+Sodium,Hommes adultes 19 ans +,170,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,2,0.3,1.4,2.6,mg,0.1,0,,3
+Sodium,Hommes adultes 19 ans +,497,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,F,F,,,mg,F,F,F,3
+Sodium,Hommes adultes 19 ans +,702,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,9.9,0.9,8.2,11.6,mg,0.3,0,,3
+Sodium,Hommes adultes 19 ans +,80,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,F,F,,,mg,F,F,F,3
+Sodium,Hommes adultes 19 ans +,1360,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,2.2,0.2,1.8,2.7,mg,0.1,0,,3
+Sodium,Hommes adultes 19 ans +,726,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.8,0.1,0.6,1.1,mg,0,0,,3
+Sodium,Hommes adultes 19 ans +,322,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mg,0,0,,3
+Sodium,Hommes adultes 19 ans +,4068,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0.3,0,0.3,0.4,mg,0,0,,3
 Sodium,Femmes adultes* 19 ans +,21,des,Aliments pour bébés,,,,,0,0,0,0.1,mg,0,0,,1
 Sodium,Femmes adultes* 19 ans +,19,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0,mg,0,0,,2
-Sodium,Femmes adultes* 19 ans +,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,mg,X,X,<10,2
+Sodium,Femmes adultes* 19 ans +,,des,Aliments pour bébés,des,Préparation pour nourrissons,,,X,X,,,mg,X,X,<10,2
 Sodium,Femmes adultes* 19 ans +,6828,des,Boissons (excluant laits),,,,,66.1,2,62.2,70,mg,2.9,0.1,,1
 Sodium,Femmes adultes* 19 ans +,1439,des,Boissons (excluant laits),de l',Alcool,,,3.2,0.2,2.9,3.6,mg,0.1,0,,2
 Sodium,Femmes adultes* 19 ans +,5777,des,Boissons (excluant laits),du,Café et thé,,,13.3,0.5,12.2,14.4,mg,0.6,0,,2
@@ -4338,7 +4338,7 @@ Sodium,Femmes adultes* 19 ans +,2244,des,Produits laitiers et Boissons à base d
 Sodium,Femmes adultes* 19 ans +,358,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,5.8,0.7,4.5,7.2,mg,0.3,0,,3
 Sodium,Femmes adultes* 19 ans +,2211,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,7,0.5,6,8,mg,0.3,0,,3
 Sodium,Femmes adultes* 19 ans +,1928,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,7.5,1,5.5,9.5,mg,0.3,0,,3
-Sodium,Femmes adultes* 19 ans +,1769,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,4.3,0.3,3.7,4.9,mg,0.2,0,,3
+Sodium,Femmes adultes* 19 ans +,1769,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,4.3,0.3,3.7,4.9,mg,0.2,0,,3
 Sodium,Femmes adultes* 19 ans +,6356,des,Graisses et huiles,,,,,115.9,3.7,108.7,123.1,mg,5.1,0.2,,1
 Sodium,Femmes adultes* 19 ans +,369,des,Graisses et huiles,des,Graisses animales,,,F,F,,,mg,F,F,F,2
 Sodium,Femmes adultes* 19 ans +,1972,des,Graisses et huiles,du,Beurre,,,19.5,1.5,16.5,22.4,mg,0.9,0.1,,2
@@ -4352,8 +4352,8 @@ Sodium,Femmes adultes* 19 ans +,370,des,Poissons et fruits de mer,des,Mollusques
 Sodium,Femmes adultes* 19 ans +,6601,des,Fruits et légumes,,,,,169.3,7.4,154.8,183.9,mg,7.4,0.3,,1
 Sodium,Femmes adultes* 19 ans +,4951,des,Fruits et légumes,des,Fruits,,,2.8,0.1,2.6,3.1,mg,0.1,0,,2
 Sodium,Femmes adultes* 19 ans +,6313,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,166.5,7.4,152,181.1,mg,7.3,0.3,,2
-Sodium,Femmes adultes* 19 ans +,1574,des,Fruits et légumes,des,Fruits,des,Pommes,0.4,0,0.4,0.5,mg,0,0,,3
-Sodium,Femmes adultes* 19 ans +,1919,des,Fruits et légumes,des,Fruits,des,Bananes,0.3,0,0.2,0.3,mg,0,0,,3
+Sodium,Femmes adultes* 19 ans +,1574,des,Fruits et légumes,des,Fruits,des,Pomme,0.4,0,0.4,0.5,mg,0,0,,3
+Sodium,Femmes adultes* 19 ans +,1919,des,Fruits et légumes,des,Fruits,des,Banane,0.3,0,0.2,0.3,mg,0,0,,3
 Sodium,Femmes adultes* 19 ans +,1597,des,Fruits et légumes,des,Fruits,des,Baies,0.2,0,0.2,0.3,mg,0,0,,3
 Sodium,Femmes adultes* 19 ans +,215,des,Fruits et légumes,des,Fruits,des,Cerises,0,0,0,0,mg,0,0,,3
 Sodium,Femmes adultes* 19 ans +,1356,des,Fruits et légumes,des,Fruits,des,Agrumes,0.3,0.1,0.2,0.4,mg,0,0,E,3
@@ -4371,7 +4371,7 @@ Sodium,Femmes adultes* 19 ans +,662,des,Fruits et légumes,des,Légumes incluant
 Sodium,Femmes adultes* 19 ans +,6669,des,Produits céréaliers,,,,,437.7,8.7,420.5,454.9,mg,19.1,0.4,,1
 Sodium,Femmes adultes* 19 ans +,5520,des,Produits céréaliers,des,Pains,,,360.8,7.5,346,375.6,mg,15.8,0.3,,2
 Sodium,Femmes adultes* 19 ans +,2230,des,Produits céréaliers,des,Céréales pour déjeuner,,,32.9,1.7,29.5,36.3,mg,1.4,0.1,,2
-Sodium,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,31.3,3.4,24.6,37.9,mg,1.4,0.1,,2
+Sodium,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,31.3,3.4,24.6,37.9,mg,1.4,0.1,,2
 Sodium,Femmes adultes* 19 ans +,4893,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,12.7,1.9,8.9,16.5,mg,0.6,0.1,,2
 Sodium,Femmes adultes* 19 ans +,2551,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,141.7,5.7,130.6,152.8,mg,6.2,0.3,,3
 Sodium,Femmes adultes* 19 ans +,2239,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,107.2,4.3,98.9,115.6,mg,4.7,0.2,,3
@@ -4379,10 +4379,10 @@ Sodium,Femmes adultes* 19 ans +,1994,des,Produits céréaliers,des,Pains,des,Aut
 Sodium,Femmes adultes* 19 ans +,914,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,16.9,1.7,13.6,20.2,mg,0.7,0.1,,3
 Sodium,Femmes adultes* 19 ans +,1756,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,23.5,1.6,20.4,26.5,mg,1,0.1,,3
 Sodium,Femmes adultes* 19 ans +,555,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),9.4,0.9,7.7,11.1,mg,0.4,0,,3
-Sodium,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,4.3,0.5,3.4,5.3,mg,0.2,0,,3
-Sodium,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.6,0.2,0.3,1,mg,0,0,E,3
-Sodium,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.8,0.2,0.3,1.2,mg,0,0,E,3
-Sodium,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
+Sodium,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,4.3,0.5,3.4,5.3,mg,0.2,0,,3
+Sodium,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0.6,0.2,0.3,1,mg,0,0,E,3
+Sodium,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.8,0.2,0.3,1.2,mg,0,0,E,3
+Sodium,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
 Sodium,Femmes adultes* 19 ans +,1358,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,10.7,1.8,7.1,14.3,mg,0.5,0.1,E,3
 Sodium,Femmes adultes* 19 ans +,1522,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,1.8,0.6,0.6,3,mg,0.1,0,E,3
 Sodium,Femmes adultes* 19 ans +,3664,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.2,0,0.2,0.3,mg,0,0,,3
@@ -4412,23 +4412,23 @@ Sodium,Femmes adultes* 19 ans +,6338,des,Soupes - sauces - Épices et autres ing
 Sodium,Femmes adultes* 19 ans +,2243,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,133.1,7.4,118.6,147.6,mg,5.8,0.3,,2
 Sodium,Femmes adultes* 19 ans +,1853,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,159.9,10,140.2,179.6,mg,7,0.4,,2
 Sodium,Femmes adultes* 19 ans +,5984,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,501.2,14.6,472.5,529.8,mg,21.9,0.5,,2
-Sodium,Femmes adultes* 19 ans +,5713,des,Confiseries - sucres et grignotines salées,,,,,63.2,3.3,56.8,69.7,mg,2.8,0.1,,1
-Sodium,Femmes adultes* 19 ans +,1936,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,11.2,1,9.2,13.2,mg,0.5,0,,2
-Sodium,Femmes adultes* 19 ans +,844,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,9.9,0.8,8.4,11.5,mg,0.4,0,,2
-Sodium,Femmes adultes* 19 ans +,1411,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,38.3,3,32.4,44.2,mg,1.7,0.1,,2
-Sodium,Femmes adultes* 19 ans +,4937,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,3.8,0.6,2.7,4.9,mg,0.2,0,,2
-Sodium,Femmes adultes* 19 ans +,1238,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,4.4,0.7,3.1,5.8,mg,0.2,0,,3
-Sodium,Femmes adultes* 19 ans +,229,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,3.5,0.6,2.4,4.6,mg,0.2,0,E,3
-Sodium,Femmes adultes* 19 ans +,685,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,3.3,0.5,2.4,4.2,mg,0.1,0,,3
-Sodium,Femmes adultes* 19 ans +,762,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,9.7,0.8,8.1,11.3,mg,0.4,0,,3
-Sodium,Femmes adultes* 19 ans +,87,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0.3,0.1,0.1,0.4,mg,0,0,E,3
-Sodium,Femmes adultes* 19 ans +,1529,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,3,0.6,1.9,4.1,mg,0.1,0,E,3
-Sodium,Femmes adultes* 19 ans +,773,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.5,0,0.4,0.6,mg,0,0,,3
-Sodium,Femmes adultes* 19 ans +,360,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0.1,mg,0,0,,3
-Sodium,Femmes adultes* 19 ans +,4229,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0.3,0,0.2,0.3,mg,0,0,,3
+Sodium,Femmes adultes* 19 ans +,5713,des,Confiserie - sucres et grignotines salées,,,,,63.2,3.3,56.8,69.7,mg,2.8,0.1,,1
+Sodium,Femmes adultes* 19 ans +,1936,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,11.2,1,9.2,13.2,mg,0.5,0,,2
+Sodium,Femmes adultes* 19 ans +,844,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,9.9,0.8,8.4,11.5,mg,0.4,0,,2
+Sodium,Femmes adultes* 19 ans +,1411,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,38.3,3,32.4,44.2,mg,1.7,0.1,,2
+Sodium,Femmes adultes* 19 ans +,4937,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,3.8,0.6,2.7,4.9,mg,0.2,0,,2
+Sodium,Femmes adultes* 19 ans +,1238,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,4.4,0.7,3.1,5.8,mg,0.2,0,,3
+Sodium,Femmes adultes* 19 ans +,229,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,3.5,0.6,2.4,4.6,mg,0.2,0,E,3
+Sodium,Femmes adultes* 19 ans +,685,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,3.3,0.5,2.4,4.2,mg,0.1,0,,3
+Sodium,Femmes adultes* 19 ans +,762,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,9.7,0.8,8.1,11.3,mg,0.4,0,,3
+Sodium,Femmes adultes* 19 ans +,87,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0.3,0.1,0.1,0.4,mg,0,0,E,3
+Sodium,Femmes adultes* 19 ans +,1529,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,3,0.6,1.9,4.1,mg,0.1,0,E,3
+Sodium,Femmes adultes* 19 ans +,773,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.5,0,0.4,0.6,mg,0,0,,3
+Sodium,Femmes adultes* 19 ans +,360,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0.1,mg,0,0,,3
+Sodium,Femmes adultes* 19 ans +,4229,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0.3,0,0.2,0.3,mg,0,0,,3
 Sodium,Enfants 1 à 8 ans,122,des,Aliments pour bébés,,,,,2.2,0.6,1,3.4,mg,0.1,0,E,1
 Sodium,Enfants 1 à 8 ans,95,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,F,F,,,mg,F,F,F,2
-Sodium,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparations pour nourrissons,,,1.4,0.4,0.6,2.2,mg,0.1,0,E,2
+Sodium,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparation pour nourrissons,,,1.4,0.4,0.6,2.2,mg,0.1,0,E,2
 Sodium,Enfants 1 à 8 ans,2443,des,Boissons (excluant laits),,,,,31.1,1.7,27.8,34.5,mg,1.5,0.1,,1
 Sodium,Enfants 1 à 8 ans,20,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0.1,mg,0,0,,2
 Sodium,Enfants 1 à 8 ans,141,des,Boissons (excluant laits),du,Café et thé,,,1.2,0.3,0.6,1.8,mg,0.1,0,E,2
@@ -4452,7 +4452,7 @@ Sodium,Enfants 1 à 8 ans,1078,des,Produits laitiers et Boissons à base de plan
 Sodium,Enfants 1 à 8 ans,854,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,26.8,3,21,32.7,mg,1.3,0.1,,3
 Sodium,Enfants 1 à 8 ans,128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,4.7,0.8,3.2,6.3,mg,0.2,0,E,3
 Sodium,Enfants 1 à 8 ans,739,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,4,0.7,2.7,5.3,mg,0.2,0,E,3
-Sodium,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,2,0.4,1.1,2.9,mg,0.1,0,E,3
+Sodium,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,2,0.4,1.1,2.9,mg,0.1,0,E,3
 Sodium,Enfants 1 à 8 ans,2270,des,Graisses et huiles,,,,,55,2.7,49.7,60.3,mg,2.7,0.1,,1
 Sodium,Enfants 1 à 8 ans,83,des,Graisses et huiles,des,Graisses animales,,,F,F,,,mg,F,F,F,2
 Sodium,Enfants 1 à 8 ans,657,des,Graisses et huiles,du,Beurre,,,10.9,1,9,12.8,mg,0.5,0,,2
@@ -4467,8 +4467,8 @@ Sodium,Enfants 1 à 8 ans,2428,des,Fruits et légumes,,,,,141.6,8.7,124.6,158.6,
 Sodium,Enfants 1 à 8 ans,2117,des,Fruits et légumes,des,Fruits,,,3.5,0.3,3,4,mg,0.2,0,,2
 Sodium,Enfants 1 à 8 ans,2240,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,138.1,8.6,121.1,155.1,mg,6.7,0.4,,2
 Sodium,Enfants 1 à 8 ans,219,des,Fruits et légumes,des,Fruits,des,Melons,1.3,0.2,0.8,1.7,mg,0.1,0,,3
-Sodium,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pommes,0.7,0,0.6,0.8,mg,0,0,,3
-Sodium,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Bananes,0.3,0,0.3,0.3,mg,0,0,,3
+Sodium,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pomme,0.7,0,0.6,0.8,mg,0,0,,3
+Sodium,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Banane,0.3,0,0.3,0.3,mg,0,0,,3
 Sodium,Enfants 1 à 8 ans,830,des,Fruits et légumes,des,Fruits,des,Baies,0.3,0,0.2,0.3,mg,0,0,,3
 Sodium,Enfants 1 à 8 ans,47,des,Fruits et légumes,des,Fruits,des,Cerises,0,0,0,0,mg,0,0,,3
 Sodium,Enfants 1 à 8 ans,421,des,Fruits et légumes,des,Fruits,des,Agrumes,0.1,0,0.1,0.1,mg,0,0,,3
@@ -4485,7 +4485,7 @@ Sodium,Enfants 1 à 8 ans,242,des,Fruits et légumes,des,Légumes incluant pomme
 Sodium,Enfants 1 à 8 ans,2475,des,Produits céréaliers,,,,,494.1,12.1,470.3,517.9,mg,24.1,0.6,,1
 Sodium,Enfants 1 à 8 ans,2114,des,Produits céréaliers,des,Pains,,,356.9,11.5,334.3,379.6,mg,17.4,0.5,,2
 Sodium,Enfants 1 à 8 ans,1282,des,Produits céréaliers,des,Céréales pour déjeuner,,,63,2.9,57.3,68.7,mg,3.1,0.2,,2
-Sodium,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,46.4,3.3,39.9,52.9,mg,2.3,0.2,,2
+Sodium,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,46.4,3.3,39.9,52.9,mg,2.3,0.2,,2
 Sodium,Enfants 1 à 8 ans,2037,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,27.7,4,19.7,35.7,mg,1.4,0.2,,2
 Sodium,Enfants 1 à 8 ans,951,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,128.9,9.5,110.3,147.6,mg,6.3,0.5,,3
 Sodium,Enfants 1 à 8 ans,805,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,89.6,6.6,76.6,102.6,mg,4.4,0.3,,3
@@ -4493,9 +4493,9 @@ Sodium,Enfants 1 à 8 ans,813,des,Produits céréaliers,des,Pains,des,Pains et p
 Sodium,Enfants 1 à 8 ans,745,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,55.4,4.9,45.6,65.1,mg,2.7,0.2,,3
 Sodium,Enfants 1 à 8 ans,670,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),36,2.3,31.4,40.6,mg,1.8,0.1,,3
 Sodium,Enfants 1 à 8 ans,728,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,27,2.3,22.4,31.6,mg,1.3,0.1,,3
-Sodium,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,9.1,0.9,7.3,10.8,mg,0.4,0,,3
-Sodium,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,1.5,0.5,0.5,2.5,mg,0.1,0,E,3
-Sodium,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,F,F,,,mg,F,F,F,3
+Sodium,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,9.1,0.9,7.3,10.8,mg,0.4,0,,3
+Sodium,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,1.5,0.5,0.5,2.5,mg,0.1,0,E,3
+Sodium,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,F,F,,,mg,F,F,F,3
 Sodium,Enfants 1 à 8 ans,834,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,26.7,4,18.8,34.6,mg,1.3,0.2,,3
 Sodium,Enfants 1 à 8 ans,1461,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.1,0,0.1,0.2,mg,0,0,,3
 Sodium,Enfants 1 à 8 ans,654,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0.9,0.3,0.4,1.4,mg,0,0,E,3
@@ -4525,23 +4525,23 @@ Sodium,Enfants 1 à 8 ans,2285,des,Soupes - sauces - Épices et autres ingrédie
 Sodium,Enfants 1 à 8 ans,761,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,79.6,9.3,61.3,97.9,mg,3.9,0.4,,2
 Sodium,Enfants 1 à 8 ans,532,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,91.6,9.5,73.1,110.2,mg,4.5,0.5,,2
 Sodium,Enfants 1 à 8 ans,2187,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,371.2,13.8,344.1,398.4,mg,18.1,0.6,,2
-Sodium,Enfants 1 à 8 ans,2106,des,Confiseries - sucres et grignotines salées,,,,,70.9,4.3,62.4,79.3,mg,3.5,0.2,,1
-Sodium,Enfants 1 à 8 ans,1048,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,16.5,1.6,13.3,19.7,mg,0.8,0.1,,2
-Sodium,Enfants 1 à 8 ans,497,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,12.1,1.1,9.9,14.3,mg,0.6,0.1,,2
-Sodium,Enfants 1 à 8 ans,615,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,37.5,3.6,30.5,44.5,mg,1.8,0.2,,2
-Sodium,Enfants 1 à 8 ans,1642,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,4.8,0.6,3.5,6,mg,0.2,0,,2
-Sodium,Enfants 1 à 8 ans,557,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,7,0.9,5.2,8.8,mg,0.3,0,,3
-Sodium,Enfants 1 à 8 ans,131,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,6.9,1.3,4.3,9.5,mg,0.3,0.1,E,3
-Sodium,Enfants 1 à 8 ans,548,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,2.6,0.3,2,3.2,mg,0.1,0,,3
-Sodium,Enfants 1 à 8 ans,346,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,10.4,1.1,8.3,12.5,mg,0.5,0.1,,3
-Sodium,Enfants 1 à 8 ans,184,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,1.7,0.3,1.1,2.3,mg,0.1,0,E,3
-Sodium,Enfants 1 à 8 ans,720,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,4.2,0.6,3,5.4,mg,0.2,0,,3
-Sodium,Enfants 1 à 8 ans,257,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.5,0.1,0.3,0.6,mg,0,0,E,3
-Sodium,Enfants 1 à 8 ans,1341,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0.1,0,0.1,0.2,mg,0,0,,3
-Sodium,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,mg,X,X,<10,3
+Sodium,Enfants 1 à 8 ans,2106,des,Confiserie - sucres et grignotines salées,,,,,70.9,4.3,62.4,79.3,mg,3.5,0.2,,1
+Sodium,Enfants 1 à 8 ans,1048,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,16.5,1.6,13.3,19.7,mg,0.8,0.1,,2
+Sodium,Enfants 1 à 8 ans,497,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,12.1,1.1,9.9,14.3,mg,0.6,0.1,,2
+Sodium,Enfants 1 à 8 ans,615,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,37.5,3.6,30.5,44.5,mg,1.8,0.2,,2
+Sodium,Enfants 1 à 8 ans,1642,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,4.8,0.6,3.5,6,mg,0.2,0,,2
+Sodium,Enfants 1 à 8 ans,557,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,7,0.9,5.2,8.8,mg,0.3,0,,3
+Sodium,Enfants 1 à 8 ans,131,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,6.9,1.3,4.3,9.5,mg,0.3,0.1,E,3
+Sodium,Enfants 1 à 8 ans,548,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,2.6,0.3,2,3.2,mg,0.1,0,,3
+Sodium,Enfants 1 à 8 ans,346,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,10.4,1.1,8.3,12.5,mg,0.5,0.1,,3
+Sodium,Enfants 1 à 8 ans,184,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,1.7,0.3,1.1,2.3,mg,0.1,0,E,3
+Sodium,Enfants 1 à 8 ans,720,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,4.2,0.6,3,5.4,mg,0.2,0,,3
+Sodium,Enfants 1 à 8 ans,257,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.5,0.1,0.3,0.6,mg,0,0,E,3
+Sodium,Enfants 1 à 8 ans,1341,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0.1,0,0.1,0.2,mg,0,0,,3
+Sodium,Enfants 1 à 8 ans,,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,mg,X,X,<10,3
 Lipides totaux,Population 1 an et +,186,des,Aliments pour bébés,,,,,0,0,0,0.1,g,0.1,0,,1
 Lipides totaux,Population 1 an et +,154,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0,g,0,0,,2
-Lipides totaux,Population 1 an et +,51,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0,0,0,0,g,0,0,,2
+Lipides totaux,Population 1 an et +,51,des,Aliments pour bébés,des,Préparation pour nourrissons,,,0,0,0,0,g,0,0,,2
 Lipides totaux,Population 1 an et +,19574,des,Boissons (excluant laits),,,,,0.3,0,0.3,0.3,g,0.4,0,,1
 Lipides totaux,Population 1 an et +,3540,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0,g,0,0,,2
 Lipides totaux,Population 1 an et +,12127,des,Boissons (excluant laits),du,Café et thé,,,0.1,0,0.1,0.1,g,0.1,0,,2
@@ -4561,7 +4561,7 @@ Lipides totaux,Population 1 an et +,11627,des,Produits laitiers et Boissons à b
 Lipides totaux,Population 1 an et +,17005,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,4.7,0.1,4.5,4.9,g,6.8,0.1,,2
 Lipides totaux,Population 1 an et +,4392,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,,,0.5,0,0.4,0.5,g,0.7,0,,2
 Lipides totaux,Population 1 an et +,12441,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,1.9,0,1.8,2,g,2.8,0.1,,3
-Lipides totaux,Population 1 an et +,4411,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,1.2,0.1,1.1,1.4,g,1.8,0.1,,3
+Lipides totaux,Population 1 an et +,4411,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,1.2,0.1,1.1,1.4,g,1.8,0.1,,3
 Lipides totaux,Population 1 an et +,5835,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,1,0.1,0.9,1.1,g,1.4,0.1,,3
 Lipides totaux,Population 1 an et +,6481,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,0.4,0,0.4,0.5,g,0.6,0,,3
 Lipides totaux,Population 1 an et +,814,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0.1,0,0.1,0.1,g,0.2,0,,3
@@ -4580,8 +4580,8 @@ Lipides totaux,Population 1 an et +,18914,des,Fruits et légumes,,,,,2.2,0.1,2,2
 Lipides totaux,Population 1 an et +,13689,des,Fruits et légumes,des,Fruits,,,0.8,0,0.7,0.9,g,1.2,0.1,,2
 Lipides totaux,Population 1 an et +,17977,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,1.4,0,1.3,1.4,g,2,0.1,,2
 Lipides totaux,Population 1 an et +,2103,des,Fruits et légumes,des,Fruits,des,Autres fruits,0.5,0,0.4,0.6,g,0.7,0.1,,3
-Lipides totaux,Population 1 an et +,5026,des,Fruits et légumes,des,Fruits,des,Pommes,0.1,0,0.1,0.1,g,0.1,0,,3
-Lipides totaux,Population 1 an et +,5308,des,Fruits et légumes,des,Fruits,des,Bananes,0.1,0,0.1,0.1,g,0.1,0,,3
+Lipides totaux,Population 1 an et +,5026,des,Fruits et légumes,des,Fruits,des,Pomme,0.1,0,0.1,0.1,g,0.1,0,,3
+Lipides totaux,Population 1 an et +,5308,des,Fruits et légumes,des,Fruits,des,Banane,0.1,0,0.1,0.1,g,0.1,0,,3
 Lipides totaux,Population 1 an et +,4326,des,Fruits et légumes,des,Fruits,des,Baies,0.1,0,0.1,0.1,g,0.1,0,,3
 Lipides totaux,Population 1 an et +,513,des,Fruits et légumes,des,Fruits,des,Cerises,0,0,0,0,g,0,0,,3
 Lipides totaux,Population 1 an et +,3372,des,Fruits et légumes,des,Fruits,des,Agrumes,0,0,0,0,g,0,0,,3
@@ -4598,7 +4598,7 @@ Lipides totaux,Population 1 an et +,6318,des,Fruits et légumes,des,Légumes inc
 Lipides totaux,Population 1 an et +,19327,des,Produits céréaliers,,,,,7.4,0.1,7.2,7.7,g,10.8,0.2,,1
 Lipides totaux,Population 1 an et +,16168,des,Produits céréaliers,des,Pains,,,3.8,0.1,3.6,3.9,g,5.5,0.1,,2
 Lipides totaux,Population 1 an et +,6966,des,Produits céréaliers,des,Céréales pour déjeuner,,,0.7,0,0.7,0.8,g,1.1,0,,2
-Lipides totaux,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,1.7,0.1,1.5,1.8,g,2.4,0.1,,2
+Lipides totaux,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,1.7,0.1,1.5,1.8,g,2.4,0.1,,2
 Lipides totaux,Population 1 an et +,14820,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,1.3,0,1.2,1.3,g,1.8,0,,2
 Lipides totaux,Population 1 an et +,6257,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,1.4,0.1,1.3,1.5,g,2,0.1,,3
 Lipides totaux,Population 1 an et +,8159,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,1.2,0,1.1,1.3,g,1.8,0.1,,3
@@ -4606,10 +4606,10 @@ Lipides totaux,Population 1 an et +,5962,des,Produits céréaliers,des,Pains,des
 Lipides totaux,Population 1 an et +,2918,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.5,0,0.4,0.5,g,0.7,0,,3
 Lipides totaux,Population 1 an et +,4760,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.6,0,0.6,0.7,g,0.9,0,,3
 Lipides totaux,Population 1 an et +,2573,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.1,0,0.1,0.1,g,0.1,0,,3
-Lipides totaux,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.5,0,0.4,0.5,g,0.7,0,,3
-Lipides totaux,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0,0.1,g,0.1,0,,3
-Lipides totaux,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0.1,g,0.1,0,,3
-Lipides totaux,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
+Lipides totaux,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,0.5,0,0.4,0.5,g,0.7,0,,3
+Lipides totaux,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0,0.1,g,0.1,0,,3
+Lipides totaux,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0.1,g,0.1,0,,3
+Lipides totaux,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
 Lipides totaux,Population 1 an et +,11102,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.6,0,0.6,0.6,g,0.9,0,,3
 Lipides totaux,Population 1 an et +,4543,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.5,0,0.5,0.6,g,0.8,0,,3
 Lipides totaux,Population 1 an et +,4598,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0.2,0,0.1,0.2,g,0.2,0,,3
@@ -4639,23 +4639,23 @@ Lipides totaux,Population 1 an et +,18438,des,Soupes - sauces - Épices et autre
 Lipides totaux,Population 1 an et +,7054,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.4,0,0.4,0.5,g,0.6,0,,2
 Lipides totaux,Population 1 an et +,4710,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0.4,0,0.3,0.5,g,0.6,0,,2
 Lipides totaux,Population 1 an et +,17547,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.2,0,0.2,0.3,g,0.3,0,,2
-Lipides totaux,Population 1 an et +,16725,des,Confiseries - sucres et grignotines salées,,,,,5.6,0.2,5.3,5.9,g,8.1,0.2,,1
-Lipides totaux,Population 1 an et +,6211,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,1.5,0.1,1.3,1.6,g,2.2,0.1,,2
-Lipides totaux,Population 1 an et +,2912,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,1.4,0.1,1.2,1.5,g,2,0.1,,2
-Lipides totaux,Population 1 an et +,4652,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,2.5,0.1,2.3,2.8,g,3.7,0.2,,2
-Lipides totaux,Population 1 an et +,14214,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.2,0,0.1,0.2,g,0.3,0,,2
-Lipides totaux,Population 1 an et +,3815,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,1.2,0.1,1.1,1.3,g,1.8,0.1,,3
-Lipides totaux,Population 1 an et +,2559,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0.2,0,0.1,0.3,g,0.3,0.1,,3
-Lipides totaux,Population 1 an et +,703,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0.1,0,0.1,0.1,g,0.1,0,,3
-Lipides totaux,Population 1 an et +,2447,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,1.4,0.1,1.2,1.5,g,2,0.1,,3
-Lipides totaux,Population 1 an et +,560,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0,0,,3
-Lipides totaux,Population 1 an et +,4750,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.2,0,0.1,0.2,g,0.3,0,,3
-Lipides totaux,Population 1 an et +,2044,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0,0,,3
-Lipides totaux,Population 1 an et +,715,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
-Lipides totaux,Population 1 an et +,12217,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
+Lipides totaux,Population 1 an et +,16725,des,Confiserie - sucres et grignotines salées,,,,,5.6,0.2,5.3,5.9,g,8.1,0.2,,1
+Lipides totaux,Population 1 an et +,6211,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,1.5,0.1,1.3,1.6,g,2.2,0.1,,2
+Lipides totaux,Population 1 an et +,2912,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,1.4,0.1,1.2,1.5,g,2,0.1,,2
+Lipides totaux,Population 1 an et +,4652,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,2.5,0.1,2.3,2.8,g,3.7,0.2,,2
+Lipides totaux,Population 1 an et +,14214,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.2,0,0.1,0.2,g,0.3,0,,2
+Lipides totaux,Population 1 an et +,3815,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,1.2,0.1,1.1,1.3,g,1.8,0.1,,3
+Lipides totaux,Population 1 an et +,2559,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,0.2,0,0.1,0.3,g,0.3,0.1,,3
+Lipides totaux,Population 1 an et +,703,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0.1,0,0.1,0.1,g,0.1,0,,3
+Lipides totaux,Population 1 an et +,2447,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,1.4,0.1,1.2,1.5,g,2,0.1,,3
+Lipides totaux,Population 1 an et +,560,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0,0,,3
+Lipides totaux,Population 1 an et +,4750,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.2,0,0.1,0.2,g,0.3,0,,3
+Lipides totaux,Population 1 an et +,2044,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0,0,,3
+Lipides totaux,Population 1 an et +,715,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
+Lipides totaux,Population 1 an et +,12217,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
 Lipides totaux,Hommes adultes 19 ans +,22,des,Aliments pour bébés,,,,,0,0,0,0,g,0,0,,1
 Lipides totaux,Hommes adultes 19 ans +,21,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0,g,0,0,,2
-Lipides totaux,Hommes adultes 19 ans +,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,g,X,X,<10,2
+Lipides totaux,Hommes adultes 19 ans +,,des,Aliments pour bébés,des,Préparation pour nourrissons,,,X,X,,,g,X,X,<10,2
 Lipides totaux,Hommes adultes 19 ans +,6187,des,Boissons (excluant laits),,,,,0.3,0,0.3,0.4,g,0.4,0,,1
 Lipides totaux,Hommes adultes 19 ans +,1946,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0,g,0,0,,2
 Lipides totaux,Hommes adultes 19 ans +,5104,des,Boissons (excluant laits),du,Café et thé,,,0.1,0,0.1,0.1,g,0.1,0,,2
@@ -4675,7 +4675,7 @@ Lipides totaux,Hommes adultes 19 ans +,3514,des,Produits laitiers et Boissons à
 Lipides totaux,Hommes adultes 19 ans +,5221,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,4.6,0.2,4.3,5,g,5.7,0.2,,2
 Lipides totaux,Hommes adultes 19 ans +,926,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,,,0.4,0,0.3,0.5,g,0.5,0,,2
 Lipides totaux,Hommes adultes 19 ans +,3759,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,1.7,0.1,1.6,1.9,g,2.1,0.1,,3
-Lipides totaux,Hommes adultes 19 ans +,1727,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,1.5,0.1,1.3,1.8,g,1.9,0.1,,3
+Lipides totaux,Hommes adultes 19 ans +,1727,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,1.5,0.1,1.3,1.8,g,1.9,0.1,,3
 Lipides totaux,Hommes adultes 19 ans +,1648,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,0.9,0.1,0.6,1.1,g,1.1,0.1,,3
 Lipides totaux,Hommes adultes 19 ans +,1819,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,0.4,0,0.4,0.5,g,0.5,0,,3
 Lipides totaux,Hommes adultes 19 ans +,208,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0.1,0,0.1,0.1,g,0.1,0,,3
@@ -4694,8 +4694,8 @@ Lipides totaux,Hommes adultes 19 ans +,5918,des,Fruits et légumes,,,,,2.4,0.1,2
 Lipides totaux,Hommes adultes 19 ans +,3876,des,Fruits et légumes,des,Fruits,,,0.8,0.1,0.6,0.9,g,1,0.1,,2
 Lipides totaux,Hommes adultes 19 ans +,5694,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,1.6,0.1,1.5,1.8,g,2,0.1,,2
 Lipides totaux,Hommes adultes 19 ans +,603,des,Fruits et légumes,des,Fruits,des,Autres fruits,0.5,0.1,0.3,0.6,g,0.6,0.1,E,3
-Lipides totaux,Hommes adultes 19 ans +,1350,des,Fruits et légumes,des,Fruits,des,Pommes,0.1,0,0.1,0.1,g,0.1,0,,3
-Lipides totaux,Hommes adultes 19 ans +,1590,des,Fruits et légumes,des,Fruits,des,Bananes,0.1,0,0.1,0.1,g,0.1,0,,3
+Lipides totaux,Hommes adultes 19 ans +,1350,des,Fruits et légumes,des,Fruits,des,Pomme,0.1,0,0.1,0.1,g,0.1,0,,3
+Lipides totaux,Hommes adultes 19 ans +,1590,des,Fruits et légumes,des,Fruits,des,Banane,0.1,0,0.1,0.1,g,0.1,0,,3
 Lipides totaux,Hommes adultes 19 ans +,1066,des,Fruits et légumes,des,Fruits,des,Baies,0,0,0,0.1,g,0.1,0,,3
 Lipides totaux,Hommes adultes 19 ans +,169,des,Fruits et légumes,des,Fruits,des,Cerises,0,0,0,0,g,0,0,,3
 Lipides totaux,Hommes adultes 19 ans +,1019,des,Fruits et légumes,des,Fruits,des,Agrumes,0,0,0,0,g,0,0,,3
@@ -4712,7 +4712,7 @@ Lipides totaux,Hommes adultes 19 ans +,1991,des,Fruits et légumes,des,Légumes 
 Lipides totaux,Hommes adultes 19 ans +,6068,des,Produits céréaliers,,,,,8,0.2,7.6,8.4,g,9.9,0.2,,1
 Lipides totaux,Hommes adultes 19 ans +,5104,des,Produits céréaliers,des,Pains,,,4.2,0.2,3.9,4.5,g,5.2,0.2,,2
 Lipides totaux,Hommes adultes 19 ans +,1921,des,Produits céréaliers,des,Céréales pour déjeuner,,,0.8,0.1,0.7,0.9,g,1,0.1,,2
-Lipides totaux,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,1.6,0.1,1.4,1.9,g,2,0.1,,2
+Lipides totaux,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,1.6,0.1,1.4,1.9,g,2,0.1,,2
 Lipides totaux,Hommes adultes 19 ans +,4551,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,1.4,0,1.3,1.4,g,1.7,0.1,,2
 Lipides totaux,Hommes adultes 19 ans +,2752,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,1.6,0.1,1.4,1.8,g,2,0.1,,3
 Lipides totaux,Hommes adultes 19 ans +,1885,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,1.5,0.1,1.3,1.7,g,1.9,0.1,,3
@@ -4720,9 +4720,9 @@ Lipides totaux,Hommes adultes 19 ans +,1980,des,Produits céréaliers,des,Pains,
 Lipides totaux,Hommes adultes 19 ans +,593,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.3,0,0.2,0.3,g,0.4,0,,3
 Lipides totaux,Hommes adultes 19 ans +,1481,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.7,0.1,0.6,0.9,g,0.9,0.1,,3
 Lipides totaux,Hommes adultes 19 ans +,523,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.1,0,0,0.1,g,0.1,0,,3
-Lipides totaux,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.5,0.1,0.4,0.6,g,0.6,0.1,E,3
-Lipides totaux,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0,0.1,g,0.1,0,,3
-Lipides totaux,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0.1,g,0.1,0,,3
+Lipides totaux,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,0.5,0.1,0.4,0.6,g,0.6,0.1,E,3
+Lipides totaux,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0,0.1,g,0.1,0,,3
+Lipides totaux,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0.1,g,0.1,0,,3
 Lipides totaux,Hommes adultes 19 ans +,3442,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.7,0,0.6,0.7,g,0.9,0,,3
 Lipides totaux,Hommes adultes 19 ans +,1250,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.5,0,0.4,0.6,g,0.6,0,,3
 Lipides totaux,Hommes adultes 19 ans +,1449,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0.2,0,0.2,0.2,g,0.2,0,,3
@@ -4752,23 +4752,23 @@ Lipides totaux,Hommes adultes 19 ans +,5856,des,Soupes - sauces - Épices et aut
 Lipides totaux,Hommes adultes 19 ans +,2384,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.4,0,0.4,0.5,g,0.6,0.1,,2
 Lipides totaux,Hommes adultes 19 ans +,1511,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0.5,0.1,0.4,0.6,g,0.6,0.1,E,2
 Lipides totaux,Hommes adultes 19 ans +,5575,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.3,0,0.2,0.3,g,0.3,0,,2
-Lipides totaux,Hommes adultes 19 ans +,5232,des,Confiseries - sucres et grignotines salées,,,,,5.6,0.3,5,6.1,g,6.9,0.3,,1
-Lipides totaux,Hommes adultes 19 ans +,1527,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,1.4,0.1,1.1,1.6,g,1.7,0.2,,2
-Lipides totaux,Hommes adultes 19 ans +,771,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,1.3,0.1,1,1.5,g,1.6,0.1,,2
-Lipides totaux,Hommes adultes 19 ans +,1268,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,2.8,0.2,2.4,3.3,g,3.5,0.3,,2
-Lipides totaux,Hommes adultes 19 ans +,4671,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.1,0,0,0.1,g,0.1,0,,2
-Lipides totaux,Hommes adultes 19 ans +,1023,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,1.1,0.1,0.9,1.3,g,1.3,0.1,,3
-Lipides totaux,Hommes adultes 19 ans +,497,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0.3,0.1,0,0.5,g,0.3,0.1,E,3
-Lipides totaux,Hommes adultes 19 ans +,170,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0,0,0,0.1,g,0.1,0,,3
-Lipides totaux,Hommes adultes 19 ans +,702,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,1.3,0.1,1,1.5,g,1.6,0.1,,3
-Lipides totaux,Hommes adultes 19 ans +,80,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0,0,,3
-Lipides totaux,Hommes adultes 19 ans +,1360,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.1,0,0,0.1,g,0.1,0,,3
-Lipides totaux,Hommes adultes 19 ans +,726,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0,0,,3
-Lipides totaux,Hommes adultes 19 ans +,322,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
-Lipides totaux,Hommes adultes 19 ans +,4068,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
+Lipides totaux,Hommes adultes 19 ans +,5232,des,Confiserie - sucres et grignotines salées,,,,,5.6,0.3,5,6.1,g,6.9,0.3,,1
+Lipides totaux,Hommes adultes 19 ans +,1527,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,1.4,0.1,1.1,1.6,g,1.7,0.2,,2
+Lipides totaux,Hommes adultes 19 ans +,771,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,1.3,0.1,1,1.5,g,1.6,0.1,,2
+Lipides totaux,Hommes adultes 19 ans +,1268,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,2.8,0.2,2.4,3.3,g,3.5,0.3,,2
+Lipides totaux,Hommes adultes 19 ans +,4671,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.1,0,0,0.1,g,0.1,0,,2
+Lipides totaux,Hommes adultes 19 ans +,1023,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,1.1,0.1,0.9,1.3,g,1.3,0.1,,3
+Lipides totaux,Hommes adultes 19 ans +,497,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,0.3,0.1,0,0.5,g,0.3,0.1,E,3
+Lipides totaux,Hommes adultes 19 ans +,170,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0,0,0,0.1,g,0.1,0,,3
+Lipides totaux,Hommes adultes 19 ans +,702,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,1.3,0.1,1,1.5,g,1.6,0.1,,3
+Lipides totaux,Hommes adultes 19 ans +,80,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0,0,,3
+Lipides totaux,Hommes adultes 19 ans +,1360,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.1,0,0,0.1,g,0.1,0,,3
+Lipides totaux,Hommes adultes 19 ans +,726,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0,0,,3
+Lipides totaux,Hommes adultes 19 ans +,322,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
+Lipides totaux,Hommes adultes 19 ans +,4068,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
 Lipides totaux,Femmes adultes* 19 ans +,21,des,Aliments pour bébés,,,,,0,0,0,0,g,0,0,,1
 Lipides totaux,Femmes adultes* 19 ans +,19,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0,g,0,0,,2
-Lipides totaux,Femmes adultes* 19 ans +,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,g,X,X,<10,2
+Lipides totaux,Femmes adultes* 19 ans +,,des,Aliments pour bébés,des,Préparation pour nourrissons,,,X,X,,,g,X,X,<10,2
 Lipides totaux,Femmes adultes* 19 ans +,6828,des,Boissons (excluant laits),,,,,0.3,0,0.2,0.3,g,0.5,0.1,,1
 Lipides totaux,Femmes adultes* 19 ans +,1439,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0.1,g,0.1,0,,2
 Lipides totaux,Femmes adultes* 19 ans +,5777,des,Boissons (excluant laits),du,Café et thé,,,0.1,0,0,0.2,g,0.2,0.1,,2
@@ -4788,7 +4788,7 @@ Lipides totaux,Femmes adultes* 19 ans +,3758,des,Produits laitiers et Boissons �
 Lipides totaux,Femmes adultes* 19 ans +,5851,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,3.7,0.1,3.5,4,g,6.3,0.2,,2
 Lipides totaux,Femmes adultes* 19 ans +,1629,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,,,0.5,0,0.4,0.6,g,0.9,0.1,,2
 Lipides totaux,Femmes adultes* 19 ans +,4136,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,1.5,0.1,1.4,1.6,g,2.5,0.1,,3
-Lipides totaux,Femmes adultes* 19 ans +,1769,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,1.2,0.1,1.1,1.4,g,2.1,0.1,,3
+Lipides totaux,Femmes adultes* 19 ans +,1769,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,1.2,0.1,1.1,1.4,g,2.1,0.1,,3
 Lipides totaux,Femmes adultes* 19 ans +,1928,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,0.6,0.1,0.4,0.7,g,1,0.1,E,3
 Lipides totaux,Femmes adultes* 19 ans +,2244,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,0.3,0,0.3,0.3,g,0.5,0,,3
 Lipides totaux,Femmes adultes* 19 ans +,358,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0.1,0,0.1,0.2,g,0.2,0,,3
@@ -4807,8 +4807,8 @@ Lipides totaux,Femmes adultes* 19 ans +,6595,des,Fruits et légumes,,,,,2,0.1,1.
 Lipides totaux,Femmes adultes* 19 ans +,4951,des,Fruits et légumes,des,Fruits,,,0.9,0.1,0.7,1.1,g,1.5,0.1,,2
 Lipides totaux,Femmes adultes* 19 ans +,6291,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,1.1,0.1,1,1.2,g,1.9,0.1,,2
 Lipides totaux,Femmes adultes* 19 ans +,854,des,Fruits et légumes,des,Fruits,des,Autres fruits,0.6,0.1,0.4,0.8,g,1,0.1,E,3
-Lipides totaux,Femmes adultes* 19 ans +,1574,des,Fruits et légumes,des,Fruits,des,Pommes,0.1,0,0.1,0.1,g,0.1,0,,3
-Lipides totaux,Femmes adultes* 19 ans +,1919,des,Fruits et légumes,des,Fruits,des,Bananes,0.1,0,0.1,0.1,g,0.1,0,,3
+Lipides totaux,Femmes adultes* 19 ans +,1574,des,Fruits et légumes,des,Fruits,des,Pomme,0.1,0,0.1,0.1,g,0.1,0,,3
+Lipides totaux,Femmes adultes* 19 ans +,1919,des,Fruits et légumes,des,Fruits,des,Banane,0.1,0,0.1,0.1,g,0.1,0,,3
 Lipides totaux,Femmes adultes* 19 ans +,1597,des,Fruits et légumes,des,Fruits,des,Baies,0.1,0,0.1,0.1,g,0.1,0,,3
 Lipides totaux,Femmes adultes* 19 ans +,1356,des,Fruits et légumes,des,Fruits,des,Agrumes,0,0,0,0,g,0.1,0,,3
 Lipides totaux,Femmes adultes* 19 ans +,215,des,Fruits et légumes,des,Fruits,des,Cerises,0,0,0,0,g,0,0,,3
@@ -4825,7 +4825,7 @@ Lipides totaux,Femmes adultes* 19 ans +,2348,des,Fruits et légumes,des,Légumes
 Lipides totaux,Femmes adultes* 19 ans +,6669,des,Produits céréaliers,,,,,6,0.1,5.8,6.3,g,10.3,0.2,,1
 Lipides totaux,Femmes adultes* 19 ans +,5520,des,Produits céréaliers,des,Pains,,,3.1,0.1,2.9,3.3,g,5.3,0.2,,2
 Lipides totaux,Femmes adultes* 19 ans +,2230,des,Produits céréaliers,des,Céréales pour déjeuner,,,0.6,0,0.5,0.7,g,1.1,0.1,,2
-Lipides totaux,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,1.3,0.1,1.1,1.4,g,2.2,0.1,,2
+Lipides totaux,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,1.3,0.1,1.1,1.4,g,2.2,0.1,,2
 Lipides totaux,Femmes adultes* 19 ans +,4893,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,1,0,0.9,1.1,g,1.8,0.1,,2
 Lipides totaux,Femmes adultes* 19 ans +,1994,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,1.2,0.1,1,1.3,g,2,0.1,,3
 Lipides totaux,Femmes adultes* 19 ans +,2551,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,0.9,0,0.8,1,g,1.6,0.1,,3
@@ -4833,10 +4833,10 @@ Lipides totaux,Femmes adultes* 19 ans +,2239,des,Produits céréaliers,des,Pains
 Lipides totaux,Femmes adultes* 19 ans +,914,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.3,0,0.3,0.4,g,0.6,0.1,,3
 Lipides totaux,Femmes adultes* 19 ans +,1756,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.6,0,0.5,0.6,g,1,0.1,,3
 Lipides totaux,Femmes adultes* 19 ans +,555,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0,0,0,0.1,g,0.1,0,,3
-Lipides totaux,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.3,0,0.2,0.3,g,0.5,0,,3
-Lipides totaux,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0.1,g,0.1,0,,3
-Lipides totaux,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0.1,g,0.1,0,,3
-Lipides totaux,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
+Lipides totaux,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,0.3,0,0.2,0.3,g,0.5,0,,3
+Lipides totaux,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0.1,g,0.1,0,,3
+Lipides totaux,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0.1,g,0.1,0,,3
+Lipides totaux,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
 Lipides totaux,Femmes adultes* 19 ans +,3664,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.5,0,0.4,0.5,g,0.8,0,,3
 Lipides totaux,Femmes adultes* 19 ans +,1358,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.4,0,0.4,0.5,g,0.7,0.1,,3
 Lipides totaux,Femmes adultes* 19 ans +,1522,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0.1,0,0.1,0.2,g,0.2,0,,3
@@ -4866,23 +4866,23 @@ Lipides totaux,Femmes adultes* 19 ans +,6382,des,Soupes - sauces - Épices et au
 Lipides totaux,Femmes adultes* 19 ans +,2243,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.4,0,0.3,0.5,g,0.7,0.1,,2
 Lipides totaux,Femmes adultes* 19 ans +,1853,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0.4,0,0.3,0.5,g,0.7,0.1,,2
 Lipides totaux,Femmes adultes* 19 ans +,6077,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.2,0,0.2,0.3,g,0.4,0,,2
-Lipides totaux,Femmes adultes* 19 ans +,5713,des,Confiseries - sucres et grignotines salées,,,,,4.7,0.2,4.2,5.1,g,8,0.4,,1
-Lipides totaux,Femmes adultes* 19 ans +,1936,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,1.5,0.2,1.2,1.8,g,2.6,0.3,,2
-Lipides totaux,Femmes adultes* 19 ans +,844,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,1.2,0.1,1,1.4,g,2.1,0.2,,2
-Lipides totaux,Femmes adultes* 19 ans +,1411,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,1.9,0.1,1.6,2.1,g,3.2,0.2,,2
-Lipides totaux,Femmes adultes* 19 ans +,4937,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.1,0,0.1,0.1,g,0.2,0,,2
-Lipides totaux,Femmes adultes* 19 ans +,1238,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,1.3,0.1,1,1.5,g,2.2,0.2,,3
-Lipides totaux,Femmes adultes* 19 ans +,685,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0.2,0,0.1,0.3,g,0.3,0.1,,3
-Lipides totaux,Femmes adultes* 19 ans +,229,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0.1,0,0,0.1,g,0.1,0,,3
-Lipides totaux,Femmes adultes* 19 ans +,762,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,1.2,0.1,1,1.4,g,2.1,0.2,,3
-Lipides totaux,Femmes adultes* 19 ans +,87,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0,0,,3
-Lipides totaux,Femmes adultes* 19 ans +,1529,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.1,0,0,0.1,g,0.2,0,,3
-Lipides totaux,Femmes adultes* 19 ans +,773,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0,0,,3
-Lipides totaux,Femmes adultes* 19 ans +,360,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
-Lipides totaux,Femmes adultes* 19 ans +,4229,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
+Lipides totaux,Femmes adultes* 19 ans +,5713,des,Confiserie - sucres et grignotines salées,,,,,4.7,0.2,4.2,5.1,g,8,0.4,,1
+Lipides totaux,Femmes adultes* 19 ans +,1936,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,1.5,0.2,1.2,1.8,g,2.6,0.3,,2
+Lipides totaux,Femmes adultes* 19 ans +,844,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,1.2,0.1,1,1.4,g,2.1,0.2,,2
+Lipides totaux,Femmes adultes* 19 ans +,1411,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,1.9,0.1,1.6,2.1,g,3.2,0.2,,2
+Lipides totaux,Femmes adultes* 19 ans +,4937,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.1,0,0.1,0.1,g,0.2,0,,2
+Lipides totaux,Femmes adultes* 19 ans +,1238,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,1.3,0.1,1,1.5,g,2.2,0.2,,3
+Lipides totaux,Femmes adultes* 19 ans +,685,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,0.2,0,0.1,0.3,g,0.3,0.1,,3
+Lipides totaux,Femmes adultes* 19 ans +,229,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0.1,0,0,0.1,g,0.1,0,,3
+Lipides totaux,Femmes adultes* 19 ans +,762,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,1.2,0.1,1,1.4,g,2.1,0.2,,3
+Lipides totaux,Femmes adultes* 19 ans +,87,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0,0,,3
+Lipides totaux,Femmes adultes* 19 ans +,1529,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.1,0,0,0.1,g,0.2,0,,3
+Lipides totaux,Femmes adultes* 19 ans +,773,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0,0,,3
+Lipides totaux,Femmes adultes* 19 ans +,360,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
+Lipides totaux,Femmes adultes* 19 ans +,4229,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
 Lipides totaux,Enfants 1 à 8 ans,122,des,Aliments pour bébés,,,,,0.3,0.1,0.2,0.5,g,0.6,0.1,E,1
 Lipides totaux,Enfants 1 à 8 ans,95,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0.1,0,0,0.1,g,0.1,0,,2
-Lipides totaux,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0.3,0.1,0.1,0.4,g,0.5,0.1,E,2
+Lipides totaux,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparation pour nourrissons,,,0.3,0.1,0.1,0.4,g,0.5,0.1,E,2
 Lipides totaux,Enfants 1 à 8 ans,2443,des,Boissons (excluant laits),,,,,0.2,0,0.2,0.3,g,0.4,0,,1
 Lipides totaux,Enfants 1 à 8 ans,20,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0,g,0,0,,2
 Lipides totaux,Enfants 1 à 8 ans,141,des,Boissons (excluant laits),du,Café et thé,,,0,0,0,0,g,0,0,,2
@@ -4904,7 +4904,7 @@ Lipides totaux,Enfants 1 à 8 ans,1032,des,Produits laitiers et Boissons à base
 Lipides totaux,Enfants 1 à 8 ans,1078,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,3.5,0.2,3,3.9,g,6.5,0.4,,3
 Lipides totaux,Enfants 1 à 8 ans,1810,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,3.2,0.1,2.9,3.5,g,6.1,0.3,,3
 Lipides totaux,Enfants 1 à 8 ans,854,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,0.6,0.1,0.4,0.7,g,1.1,0.1,E,3
-Lipides totaux,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0.4,0.1,0.3,0.5,g,0.8,0.1,E,3
+Lipides totaux,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,0.4,0.1,0.3,0.5,g,0.8,0.1,E,3
 Lipides totaux,Enfants 1 à 8 ans,128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0.1,0,0.1,0.1,g,0.2,0,,3
 Lipides totaux,Enfants 1 à 8 ans,739,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0,0,0,0,g,0,0,,3
 Lipides totaux,Enfants 1 à 8 ans,2270,des,Graisses et huiles,,,,,11.5,0.4,10.8,12.2,g,21.7,0.6,,1
@@ -4921,8 +4921,8 @@ Lipides totaux,Enfants 1 à 8 ans,2428,des,Fruits et légumes,,,,,1.6,0.1,1.4,1.
 Lipides totaux,Enfants 1 à 8 ans,2117,des,Fruits et légumes,des,Fruits,,,0.6,0.1,0.5,0.8,g,1.2,0.1,E,2
 Lipides totaux,Enfants 1 à 8 ans,2235,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,0.9,0.1,0.8,1,g,1.7,0.1,,2
 Lipides totaux,Enfants 1 à 8 ans,260,des,Fruits et légumes,des,Fruits,des,Autres fruits,0.3,0.1,0.1,0.4,g,0.5,0.1,E,3
-Lipides totaux,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pommes,0.1,0,0.1,0.1,g,0.2,0,,3
-Lipides totaux,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Bananes,0.1,0,0.1,0.1,g,0.2,0,,3
+Lipides totaux,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pomme,0.1,0,0.1,0.1,g,0.2,0,,3
+Lipides totaux,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Banane,0.1,0,0.1,0.1,g,0.2,0,,3
 Lipides totaux,Enfants 1 à 8 ans,830,des,Fruits et légumes,des,Fruits,des,Baies,0.1,0,0.1,0.1,g,0.2,0,,3
 Lipides totaux,Enfants 1 à 8 ans,47,des,Fruits et légumes,des,Fruits,des,Cerises,0,0,0,0,g,0,0,,3
 Lipides totaux,Enfants 1 à 8 ans,421,des,Fruits et légumes,des,Fruits,des,Agrumes,0,0,0,0,g,0,0,,3
@@ -4939,7 +4939,7 @@ Lipides totaux,Enfants 1 à 8 ans,875,des,Fruits et légumes,des,Légumes inclua
 Lipides totaux,Enfants 1 à 8 ans,2475,des,Produits céréaliers,,,,,7.9,0.2,7.5,8.3,g,14.9,0.4,,1
 Lipides totaux,Enfants 1 à 8 ans,2114,des,Produits céréaliers,des,Pains,,,3.7,0.2,3.4,4.1,g,7,0.3,,2
 Lipides totaux,Enfants 1 à 8 ans,1282,des,Produits céréaliers,des,Céréales pour déjeuner,,,0.7,0,0.6,0.8,g,1.3,0.1,,2
-Lipides totaux,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,2.2,0.1,2,2.5,g,4.2,0.2,,2
+Lipides totaux,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,2.2,0.1,2,2.5,g,4.2,0.2,,2
 Lipides totaux,Enfants 1 à 8 ans,2037,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,1.3,0.1,1.1,1.4,g,2.4,0.1,,2
 Lipides totaux,Enfants 1 à 8 ans,745,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,1.3,0.1,1,1.5,g,2.4,0.2,,3
 Lipides totaux,Enfants 1 à 8 ans,805,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,1.1,0.1,0.9,1.3,g,2,0.2,,3
@@ -4947,9 +4947,9 @@ Lipides totaux,Enfants 1 à 8 ans,951,des,Produits céréaliers,des,Pains,des,Pa
 Lipides totaux,Enfants 1 à 8 ans,813,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,0.5,0,0.5,0.6,g,1,0.1,,3
 Lipides totaux,Enfants 1 à 8 ans,728,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.4,0,0.4,0.5,g,0.8,0.1,,3
 Lipides totaux,Enfants 1 à 8 ans,670,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.3,0,0.2,0.3,g,0.5,0,,3
-Lipides totaux,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.5,0,0.4,0.6,g,1,0.1,,3
-Lipides totaux,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0,0.1,g,0.2,0.1,,3
-Lipides totaux,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0.1,g,0.1,0,,3
+Lipides totaux,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,0.5,0,0.4,0.6,g,1,0.1,,3
+Lipides totaux,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0,0.1,g,0.2,0.1,,3
+Lipides totaux,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0.1,g,0.1,0,,3
 Lipides totaux,Enfants 1 à 8 ans,834,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.7,0.1,0.6,0.8,g,1.3,0.1,,3
 Lipides totaux,Enfants 1 à 8 ans,1461,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.4,0,0.4,0.5,g,0.8,0.1,,3
 Lipides totaux,Enfants 1 à 8 ans,654,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0.1,0,0.1,0.1,g,0.2,0,,3
@@ -4979,23 +4979,23 @@ Lipides totaux,Enfants 1 à 8 ans,2295,des,Soupes - sauces - Épices et autres i
 Lipides totaux,Enfants 1 à 8 ans,761,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.4,0.1,0.2,0.6,g,0.7,0.2,E,2
 Lipides totaux,Enfants 1 à 8 ans,532,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0.2,0,0.1,0.2,g,0.3,0,,2
 Lipides totaux,Enfants 1 à 8 ans,2205,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.1,0,0.1,0.1,g,0.2,0,,2
-Lipides totaux,Enfants 1 à 8 ans,2106,des,Confiseries - sucres et grignotines salées,,,,,4.6,0.3,4.1,5.2,g,8.8,0.5,,1
-Lipides totaux,Enfants 1 à 8 ans,1048,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,1.2,0.1,1,1.4,g,2.3,0.2,,2
-Lipides totaux,Enfants 1 à 8 ans,497,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,1.3,0.1,1.1,1.6,g,2.5,0.3,,2
-Lipides totaux,Enfants 1 à 8 ans,615,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,1.7,0.2,1.4,2,g,3.2,0.3,,2
-Lipides totaux,Enfants 1 à 8 ans,1642,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.4,0.1,0.3,0.5,g,0.7,0.1,E,2
-Lipides totaux,Enfants 1 à 8 ans,548,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,1,0.1,0.8,1.1,g,1.8,0.2,,3
-Lipides totaux,Enfants 1 à 8 ans,557,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0.2,0,0.1,0.2,g,0.3,0,,3
-Lipides totaux,Enfants 1 à 8 ans,131,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0.1,0,0.1,0.2,g,0.2,0,,3
-Lipides totaux,Enfants 1 à 8 ans,346,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,1.3,0.1,1,1.6,g,2.5,0.3,,3
-Lipides totaux,Enfants 1 à 8 ans,184,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0,0,,3
-Lipides totaux,Enfants 1 à 8 ans,720,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.4,0.1,0.3,0.5,g,0.7,0.1,E,3
-Lipides totaux,Enfants 1 à 8 ans,257,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0,0,,3
-Lipides totaux,Enfants 1 à 8 ans,1341,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
-Lipides totaux,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,g,X,X,<10,3
+Lipides totaux,Enfants 1 à 8 ans,2106,des,Confiserie - sucres et grignotines salées,,,,,4.6,0.3,4.1,5.2,g,8.8,0.5,,1
+Lipides totaux,Enfants 1 à 8 ans,1048,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,1.2,0.1,1,1.4,g,2.3,0.2,,2
+Lipides totaux,Enfants 1 à 8 ans,497,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,1.3,0.1,1.1,1.6,g,2.5,0.3,,2
+Lipides totaux,Enfants 1 à 8 ans,615,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,1.7,0.2,1.4,2,g,3.2,0.3,,2
+Lipides totaux,Enfants 1 à 8 ans,1642,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.4,0.1,0.3,0.5,g,0.7,0.1,E,2
+Lipides totaux,Enfants 1 à 8 ans,548,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,1,0.1,0.8,1.1,g,1.8,0.2,,3
+Lipides totaux,Enfants 1 à 8 ans,557,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,0.2,0,0.1,0.2,g,0.3,0,,3
+Lipides totaux,Enfants 1 à 8 ans,131,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0.1,0,0.1,0.2,g,0.2,0,,3
+Lipides totaux,Enfants 1 à 8 ans,346,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,1.3,0.1,1,1.6,g,2.5,0.3,,3
+Lipides totaux,Enfants 1 à 8 ans,184,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0,0,,3
+Lipides totaux,Enfants 1 à 8 ans,720,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.4,0.1,0.3,0.5,g,0.7,0.1,E,3
+Lipides totaux,Enfants 1 à 8 ans,257,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0,0,,3
+Lipides totaux,Enfants 1 à 8 ans,1341,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
+Lipides totaux,Enfants 1 à 8 ans,,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,g,X,X,<10,3
 Sucres totaux,Population 1 an et +,186,des,Aliments pour bébés,,,,,0.1,0,0,0.1,g,0.1,0,,1
 Sucres totaux,Population 1 an et +,154,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0.1,0,0,0.1,g,0.1,0,,2
-Sucres totaux,Population 1 an et +,51,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0,0,0,0,g,0,0,,2
+Sucres totaux,Population 1 an et +,51,des,Aliments pour bébés,des,Préparation pour nourrissons,,,0,0,0,0,g,0,0,,2
 Sucres totaux,Population 1 an et +,19574,des,Boissons (excluant laits),,,,,19.1,0.5,18.2,20,g,21,0.4,,1
 Sucres totaux,Population 1 an et +,3540,des,Boissons (excluant laits),de l',Alcool,,,0.5,0.1,0.4,0.6,g,0.5,0.1,E,2
 Sucres totaux,Population 1 an et +,12127,des,Boissons (excluant laits),du,Café et thé,,,1.3,0.2,0.9,1.7,g,1.4,0.2,,2
@@ -5017,7 +5017,7 @@ Sucres totaux,Population 1 an et +,4392,des,Produits laitiers et Boissons à bas
 Sucres totaux,Population 1 an et +,15629,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait nature,8.9,0.2,8.6,9.2,g,9.8,0.2,,3
 Sucres totaux,Population 1 an et +,932,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait aromatisé,1.1,0.1,0.9,1.3,g,1.2,0.1,,3
 Sucres totaux,Population 1 an et +,814,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0.5,0,0.4,0.6,g,0.6,0,,3
-Sucres totaux,Population 1 an et +,4411,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0.2,0,0.1,0.2,g,0.2,0,,3
+Sucres totaux,Population 1 an et +,4411,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,0.2,0,0.1,0.2,g,0.2,0,,3
 Sucres totaux,Population 1 an et +,3676,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,du,Yogourt aromatisé,2.3,0.1,2.1,2.5,g,2.5,0.1,,3
 Sucres totaux,Population 1 an et +,818,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,du,Yogourt nature,0.2,0,0.2,0.3,g,0.2,0,,3
 Sucres totaux,Population 1 an et +,18258,des,Graisses et huiles,,,,,0.5,0,0.4,0.5,g,0.5,0,,1
@@ -5033,8 +5033,8 @@ Sucres totaux,Population 1 an et +,924,des,Poissons et fruits de mer,des,Mollusq
 Sucres totaux,Population 1 an et +,18914,des,Fruits et légumes,,,,,21.6,0.3,21,22.3,g,23.8,0.4,,1
 Sucres totaux,Population 1 an et +,13689,des,Fruits et légumes,des,Fruits,,,16.5,0.3,15.9,17.1,g,18.1,0.3,,2
 Sucres totaux,Population 1 an et +,17977,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,5.2,0.1,5,5.3,g,5.7,0.1,,2
-Sucres totaux,Population 1 an et +,5026,des,Fruits et légumes,des,Fruits,des,Pommes,4.3,0.1,4,4.6,g,4.7,0.1,,3
-Sucres totaux,Population 1 an et +,5308,des,Fruits et légumes,des,Fruits,des,Bananes,3.6,0.1,3.4,3.8,g,3.9,0.1,,3
+Sucres totaux,Population 1 an et +,5026,des,Fruits et légumes,des,Fruits,des,Pomme,4.3,0.1,4,4.6,g,4.7,0.1,,3
+Sucres totaux,Population 1 an et +,5308,des,Fruits et légumes,des,Fruits,des,Banane,3.6,0.1,3.4,3.8,g,3.9,0.1,,3
 Sucres totaux,Population 1 an et +,3372,des,Fruits et légumes,des,Fruits,des,Agrumes,1.8,0.1,1.6,1.9,g,1.9,0.1,,3
 Sucres totaux,Population 1 an et +,2881,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,1.6,0.1,1.4,1.8,g,1.8,0.1,,3
 Sucres totaux,Population 1 an et +,4326,des,Fruits et légumes,des,Fruits,des,Baies,1.3,0.1,1.1,1.4,g,1.4,0.1,,3
@@ -5052,7 +5052,7 @@ Sucres totaux,Population 1 an et +,6318,des,Fruits et légumes,des,Légumes incl
 Sucres totaux,Population 1 an et +,19327,des,Produits céréaliers,,,,,9.6,0.1,9.3,9.9,g,10.6,0.1,,1
 Sucres totaux,Population 1 an et +,16168,des,Produits céréaliers,des,Pains,,,4.5,0.1,4.4,4.7,g,5,0.1,,2
 Sucres totaux,Population 1 an et +,6966,des,Produits céréaliers,des,Céréales pour déjeuner,,,2,0.1,1.8,2.1,g,2.1,0.1,,2
-Sucres totaux,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,2.7,0.1,2.5,2.9,g,2.9,0.1,,2
+Sucres totaux,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,2.7,0.1,2.5,2.9,g,2.9,0.1,,2
 Sucres totaux,Population 1 an et +,14820,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,0.4,0,0.4,0.5,g,0.5,0,,2
 Sucres totaux,Population 1 an et +,8159,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,2.2,0.1,2.1,2.3,g,2.4,0.1,,3
 Sucres totaux,Population 1 an et +,6257,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,1.3,0.1,1.2,1.4,g,1.5,0.1,,3
@@ -5060,10 +5060,10 @@ Sucres totaux,Population 1 an et +,5962,des,Produits céréaliers,des,Pains,des,
 Sucres totaux,Population 1 an et +,2918,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.1,0,0.1,0.2,g,0.1,0,,3
 Sucres totaux,Population 1 an et +,4760,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,1.1,0.1,1,1.2,g,1.2,0.1,,3
 Sucres totaux,Population 1 an et +,2573,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.8,0,0.7,0.9,g,0.9,0,,3
-Sucres totaux,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.9,0.1,0.8,1,g,1,0.1,,3
-Sucres totaux,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0.1,0.2,g,0.2,0,,3
-Sucres totaux,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.1,g,0.1,0,,3
-Sucres totaux,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
+Sucres totaux,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,0.9,0.1,0.8,1,g,1,0.1,,3
+Sucres totaux,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0.1,0.2,g,0.2,0,,3
+Sucres totaux,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.1,g,0.1,0,,3
+Sucres totaux,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
 Sucres totaux,Population 1 an et +,4543,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.3,0,0.2,0.3,g,0.3,0,,3
 Sucres totaux,Population 1 an et +,11102,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.1,0,0.1,0.2,g,0.2,0,,3
 Sucres totaux,Population 1 an et +,4598,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0,0,0,0,g,0,0,,3
@@ -5093,23 +5093,23 @@ Sucres totaux,Population 1 an et +,18438,des,Soupes - sauces - Épices et autres
 Sucres totaux,Population 1 an et +,7054,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,1.2,0.1,1.1,1.3,g,1.3,0.1,,2
 Sucres totaux,Population 1 an et +,4710,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0.4,0,0.3,0.4,g,0.4,0,,2
 Sucres totaux,Population 1 an et +,17547,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.4,0,0.3,0.4,g,0.4,0,,2
-Sucres totaux,Population 1 an et +,16725,des,Confiseries - sucres et grignotines salées,,,,,22.7,0.4,21.8,23.5,g,24.9,0.4,,1
-Sucres totaux,Population 1 an et +,6211,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,4.6,0.3,4.1,5.2,g,5.1,0.3,,2
-Sucres totaux,Population 1 an et +,2912,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,3.8,0.2,3.4,4.1,g,4.2,0.2,,2
-Sucres totaux,Population 1 an et +,4652,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0.3,0,0.2,0.3,g,0.3,0,,2
-Sucres totaux,Population 1 an et +,14214,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,14,0.3,13.4,14.6,g,15.4,0.3,,2
-Sucres totaux,Population 1 an et +,3815,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,2.2,0.1,1.9,2.5,g,2.4,0.1,,3
-Sucres totaux,Population 1 an et +,2559,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,2.1,0.2,1.6,2.6,g,2.3,0.3,,3
-Sucres totaux,Population 1 an et +,703,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0.4,0,0.3,0.4,g,0.4,0,,3
-Sucres totaux,Population 1 an et +,2447,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,2.9,0.1,2.6,3.2,g,3.2,0.1,,3
-Sucres totaux,Population 1 an et +,560,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0.9,0.1,0.7,1.1,g,1,0.1,,3
-Sucres totaux,Population 1 an et +,12217,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,8.9,0.2,8.4,9.3,g,9.7,0.2,,3
-Sucres totaux,Population 1 an et +,4750,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,4.1,0.2,3.8,4.4,g,4.5,0.2,,3
-Sucres totaux,Population 1 an et +,2044,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,1,0.1,0.9,1.2,g,1.1,0.1,,3
-Sucres totaux,Population 1 an et +,715,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
+Sucres totaux,Population 1 an et +,16725,des,Confiserie - sucres et grignotines salées,,,,,22.7,0.4,21.8,23.5,g,24.9,0.4,,1
+Sucres totaux,Population 1 an et +,6211,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,4.6,0.3,4.1,5.2,g,5.1,0.3,,2
+Sucres totaux,Population 1 an et +,2912,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,3.8,0.2,3.4,4.1,g,4.2,0.2,,2
+Sucres totaux,Population 1 an et +,4652,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,0.3,0,0.2,0.3,g,0.3,0,,2
+Sucres totaux,Population 1 an et +,14214,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,14,0.3,13.4,14.6,g,15.4,0.3,,2
+Sucres totaux,Population 1 an et +,3815,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,2.2,0.1,1.9,2.5,g,2.4,0.1,,3
+Sucres totaux,Population 1 an et +,2559,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,2.1,0.2,1.6,2.6,g,2.3,0.3,,3
+Sucres totaux,Population 1 an et +,703,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0.4,0,0.3,0.4,g,0.4,0,,3
+Sucres totaux,Population 1 an et +,2447,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,2.9,0.1,2.6,3.2,g,3.2,0.1,,3
+Sucres totaux,Population 1 an et +,560,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0.9,0.1,0.7,1.1,g,1,0.1,,3
+Sucres totaux,Population 1 an et +,12217,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,8.9,0.2,8.4,9.3,g,9.7,0.2,,3
+Sucres totaux,Population 1 an et +,4750,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,4.1,0.2,3.8,4.4,g,4.5,0.2,,3
+Sucres totaux,Population 1 an et +,2044,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,1,0.1,0.9,1.2,g,1.1,0.1,,3
+Sucres totaux,Population 1 an et +,715,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
 Sucres totaux,Hommes adultes 19 ans +,22,des,Aliments pour bébés,,,,,0,0,0,0.1,g,0,0,,1
 Sucres totaux,Hommes adultes 19 ans +,21,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0.1,g,0,0,,2
-Sucres totaux,Hommes adultes 19 ans +,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,g,X,X,<10,2
+Sucres totaux,Hommes adultes 19 ans +,,des,Aliments pour bébés,des,Préparation pour nourrissons,,,X,X,,,g,X,X,<10,2
 Sucres totaux,Hommes adultes 19 ans +,6187,des,Boissons (excluant laits),,,,,22.6,1,20.6,24.5,g,23.4,0.9,,1
 Sucres totaux,Hommes adultes 19 ans +,1946,des,Boissons (excluant laits),de l',Alcool,,,0.6,0.1,0.4,0.9,g,0.7,0.1,E,2
 Sucres totaux,Hommes adultes 19 ans +,5104,des,Boissons (excluant laits),du,Café et thé,,,1.8,0.5,0.9,2.7,g,1.9,0.5,E,2
@@ -5131,7 +5131,7 @@ Sucres totaux,Hommes adultes 19 ans +,926,des,Produits laitiers et Boissons à b
 Sucres totaux,Hommes adultes 19 ans +,4710,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait nature,8,0.3,7.5,8.5,g,8.3,0.3,,3
 Sucres totaux,Hommes adultes 19 ans +,188,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait aromatisé,1.2,0.2,0.8,1.5,g,1.2,0.2,E,3
 Sucres totaux,Hommes adultes 19 ans +,208,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0.5,0.1,0.3,0.7,g,0.5,0.1,E,3
-Sucres totaux,Hommes adultes 19 ans +,1727,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,F,F,,,g,F,F,F,3
+Sucres totaux,Hommes adultes 19 ans +,1727,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,F,F,,,g,F,F,F,3
 Sucres totaux,Hommes adultes 19 ans +,730,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,du,Yogourt aromatisé,1.7,0.2,1.4,2,g,1.8,0.2,,3
 Sucres totaux,Hommes adultes 19 ans +,219,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,du,Yogourt nature,0.2,0,0.1,0.2,g,0.2,0,,3
 Sucres totaux,Hommes adultes 19 ans +,5767,des,Graisses et huiles,,,,,0.5,0,0.5,0.6,g,0.5,0,,1
@@ -5147,8 +5147,8 @@ Sucres totaux,Hommes adultes 19 ans +,343,des,Poissons et fruits de mer,des,Moll
 Sucres totaux,Hommes adultes 19 ans +,5918,des,Fruits et légumes,,,,,21.9,0.6,20.8,23.1,g,22.8,0.6,,1
 Sucres totaux,Hommes adultes 19 ans +,3876,des,Fruits et légumes,des,Fruits,,,16.2,0.5,15.1,17.3,g,16.8,0.6,,2
 Sucres totaux,Hommes adultes 19 ans +,5694,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,5.7,0.1,5.5,6,g,5.9,0.2,,2
-Sucres totaux,Hommes adultes 19 ans +,1350,des,Fruits et légumes,des,Fruits,des,Pommes,4.2,0.3,3.7,4.7,g,4.4,0.3,,3
-Sucres totaux,Hommes adultes 19 ans +,1590,des,Fruits et légumes,des,Fruits,des,Bananes,4.1,0.2,3.7,4.5,g,4.3,0.2,,3
+Sucres totaux,Hommes adultes 19 ans +,1350,des,Fruits et légumes,des,Fruits,des,Pomme,4.2,0.3,3.7,4.7,g,4.4,0.3,,3
+Sucres totaux,Hommes adultes 19 ans +,1590,des,Fruits et légumes,des,Fruits,des,Banane,4.1,0.2,3.7,4.5,g,4.3,0.2,,3
 Sucres totaux,Hommes adultes 19 ans +,1019,des,Fruits et légumes,des,Fruits,des,Agrumes,1.7,0.1,1.4,1.9,g,1.7,0.1,,3
 Sucres totaux,Hommes adultes 19 ans +,782,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,1.4,0.1,1.1,1.6,g,1.4,0.1,,3
 Sucres totaux,Hommes adultes 19 ans +,1066,des,Fruits et légumes,des,Fruits,des,Baies,1.3,0.2,1,1.6,g,1.3,0.2,,3
@@ -5166,7 +5166,7 @@ Sucres totaux,Hommes adultes 19 ans +,1991,des,Fruits et légumes,des,Légumes i
 Sucres totaux,Hommes adultes 19 ans +,6068,des,Produits céréaliers,,,,,10.3,0.2,9.8,10.8,g,10.7,0.3,,1
 Sucres totaux,Hommes adultes 19 ans +,5104,des,Produits céréaliers,des,Pains,,,5.2,0.1,4.9,5.5,g,5.4,0.2,,2
 Sucres totaux,Hommes adultes 19 ans +,1921,des,Produits céréaliers,des,Céréales pour déjeuner,,,1.9,0.1,1.7,2.1,g,2,0.1,,2
-Sucres totaux,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,2.7,0.2,2.4,3.1,g,2.8,0.2,,2
+Sucres totaux,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,2.7,0.2,2.4,3.1,g,2.8,0.2,,2
 Sucres totaux,Hommes adultes 19 ans +,4551,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,0.5,0,0.4,0.5,g,0.5,0,,2
 Sucres totaux,Hommes adultes 19 ans +,2752,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,2.8,0.1,2.6,3,g,2.9,0.1,,3
 Sucres totaux,Hommes adultes 19 ans +,1885,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,1.4,0.1,1.2,1.6,g,1.5,0.1,,3
@@ -5174,9 +5174,9 @@ Sucres totaux,Hommes adultes 19 ans +,1980,des,Produits céréaliers,des,Pains,d
 Sucres totaux,Hommes adultes 19 ans +,593,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.1,0,0,0.1,g,0.1,0,,3
 Sucres totaux,Hommes adultes 19 ans +,1481,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,1.4,0.1,1.2,1.6,g,1.4,0.1,,3
 Sucres totaux,Hommes adultes 19 ans +,523,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.5,0.1,0.4,0.6,g,0.6,0.1,E,3
-Sucres totaux,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,1,0.1,0.8,1.2,g,1,0.1,,3
-Sucres totaux,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0.1,g,0.1,0,,3
-Sucres totaux,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,F,F,,,g,F,F,F,3
+Sucres totaux,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,1,0.1,0.8,1.2,g,1,0.1,,3
+Sucres totaux,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0.1,g,0.1,0,,3
+Sucres totaux,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,F,F,,,g,F,F,F,3
 Sucres totaux,Hommes adultes 19 ans +,1250,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.2,0,0.2,0.3,g,0.3,0,,3
 Sucres totaux,Hommes adultes 19 ans +,3442,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.2,0,0.2,0.2,g,0.2,0,,3
 Sucres totaux,Hommes adultes 19 ans +,1449,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0,0,0,0.1,g,0.1,0,,3
@@ -5206,23 +5206,23 @@ Sucres totaux,Hommes adultes 19 ans +,5856,des,Soupes - sauces - Épices et autr
 Sucres totaux,Hommes adultes 19 ans +,2384,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,1.5,0.1,1.2,1.7,g,1.5,0.1,,2
 Sucres totaux,Hommes adultes 19 ans +,1511,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0.4,0.1,0.3,0.5,g,0.4,0.1,E,2
 Sucres totaux,Hommes adultes 19 ans +,5575,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.6,0.1,0.4,0.7,g,0.6,0.1,E,2
-Sucres totaux,Hommes adultes 19 ans +,5232,des,Confiseries - sucres et grignotines salées,,,,,24,0.8,22.4,25.6,g,24.9,0.7,,1
-Sucres totaux,Hommes adultes 19 ans +,1527,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,4.1,0.6,3,5.2,g,4.2,0.6,,2
-Sucres totaux,Hommes adultes 19 ans +,771,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,3.3,0.3,2.7,3.9,g,3.4,0.3,,2
-Sucres totaux,Hommes adultes 19 ans +,1268,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0.2,0,0.1,0.3,g,0.2,0,,2
-Sucres totaux,Hommes adultes 19 ans +,4671,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,16.4,0.6,15.3,17.5,g,17,0.6,,2
-Sucres totaux,Hommes adultes 19 ans +,497,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,2,0.6,0.9,3.1,g,2.1,0.6,E,3
-Sucres totaux,Hommes adultes 19 ans +,1023,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,1.9,0.2,1.6,2.2,g,2,0.2,,3
-Sucres totaux,Hommes adultes 19 ans +,170,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0.2,0,0.2,0.3,g,0.2,0,,3
-Sucres totaux,Hommes adultes 19 ans +,702,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,2.6,0.2,2.2,3.1,g,2.7,0.2,,3
-Sucres totaux,Hommes adultes 19 ans +,80,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0.7,0.2,0.3,1.1,g,0.7,0.2,E,3
-Sucres totaux,Hommes adultes 19 ans +,4068,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,10.6,0.4,9.9,11.3,g,11,0.4,,3
-Sucres totaux,Hommes adultes 19 ans +,1360,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,4.5,0.3,3.9,5.1,g,4.7,0.3,,3
-Sucres totaux,Hommes adultes 19 ans +,726,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,1.3,0.2,0.9,1.7,g,1.3,0.2,,3
-Sucres totaux,Hommes adultes 19 ans +,322,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
+Sucres totaux,Hommes adultes 19 ans +,5232,des,Confiserie - sucres et grignotines salées,,,,,24,0.8,22.4,25.6,g,24.9,0.7,,1
+Sucres totaux,Hommes adultes 19 ans +,1527,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,4.1,0.6,3,5.2,g,4.2,0.6,,2
+Sucres totaux,Hommes adultes 19 ans +,771,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,3.3,0.3,2.7,3.9,g,3.4,0.3,,2
+Sucres totaux,Hommes adultes 19 ans +,1268,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,0.2,0,0.1,0.3,g,0.2,0,,2
+Sucres totaux,Hommes adultes 19 ans +,4671,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,16.4,0.6,15.3,17.5,g,17,0.6,,2
+Sucres totaux,Hommes adultes 19 ans +,497,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,2,0.6,0.9,3.1,g,2.1,0.6,E,3
+Sucres totaux,Hommes adultes 19 ans +,1023,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,1.9,0.2,1.6,2.2,g,2,0.2,,3
+Sucres totaux,Hommes adultes 19 ans +,170,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0.2,0,0.2,0.3,g,0.2,0,,3
+Sucres totaux,Hommes adultes 19 ans +,702,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,2.6,0.2,2.2,3.1,g,2.7,0.2,,3
+Sucres totaux,Hommes adultes 19 ans +,80,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0.7,0.2,0.3,1.1,g,0.7,0.2,E,3
+Sucres totaux,Hommes adultes 19 ans +,4068,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,10.6,0.4,9.9,11.3,g,11,0.4,,3
+Sucres totaux,Hommes adultes 19 ans +,1360,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,4.5,0.3,3.9,5.1,g,4.7,0.3,,3
+Sucres totaux,Hommes adultes 19 ans +,726,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,1.3,0.2,0.9,1.7,g,1.3,0.2,,3
+Sucres totaux,Hommes adultes 19 ans +,322,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
 Sucres totaux,Femmes adultes* 19 ans +,21,des,Aliments pour bébés,,,,,0,0,0,0.1,g,0,0,,1
 Sucres totaux,Femmes adultes* 19 ans +,19,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0.1,g,0,0,,2
-Sucres totaux,Femmes adultes* 19 ans +,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,g,X,X,<10,2
+Sucres totaux,Femmes adultes* 19 ans +,,des,Aliments pour bébés,des,Préparation pour nourrissons,,,X,X,,,g,X,X,<10,2
 Sucres totaux,Femmes adultes* 19 ans +,6828,des,Boissons (excluant laits),,,,,13.6,0.5,12.5,14.6,g,17.6,0.6,,1
 Sucres totaux,Femmes adultes* 19 ans +,1439,des,Boissons (excluant laits),de l',Alcool,,,0.6,0.1,0.4,0.8,g,0.7,0.1,E,2
 Sucres totaux,Femmes adultes* 19 ans +,5777,des,Boissons (excluant laits),du,Café et thé,,,0.8,0.2,0.5,1.2,g,1.1,0.2,E,2
@@ -5244,7 +5244,7 @@ Sucres totaux,Femmes adultes* 19 ans +,1629,des,Produits laitiers et Boissons à
 Sucres totaux,Femmes adultes* 19 ans +,5294,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait nature,7,0.2,6.5,7.4,g,9,0.3,,3
 Sucres totaux,Femmes adultes* 19 ans +,358,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0.5,0.1,0.4,0.7,g,0.7,0.1,E,3
 Sucres totaux,Femmes adultes* 19 ans +,105,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait aromatisé,0.3,0.1,0.2,0.4,g,0.4,0.1,E,3
-Sucres totaux,Femmes adultes* 19 ans +,1769,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0.1,0,0,0.2,g,0.2,0.1,,3
+Sucres totaux,Femmes adultes* 19 ans +,1769,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,0.1,0,0,0.2,g,0.2,0.1,,3
 Sucres totaux,Femmes adultes* 19 ans +,1295,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,du,Yogourt aromatisé,2.3,0.1,2,2.6,g,2.9,0.2,,3
 Sucres totaux,Femmes adultes* 19 ans +,372,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,du,Yogourt nature,0.3,0,0.2,0.4,g,0.4,0.1,,3
 Sucres totaux,Femmes adultes* 19 ans +,6356,des,Graisses et huiles,,,,,0.6,0,0.5,0.6,g,0.7,0,,1
@@ -5260,8 +5260,8 @@ Sucres totaux,Femmes adultes* 19 ans +,370,des,Poissons et fruits de mer,des,Mol
 Sucres totaux,Femmes adultes* 19 ans +,6595,des,Fruits et légumes,,,,,21.3,0.5,20.4,22.2,g,27.6,0.6,,1
 Sucres totaux,Femmes adultes* 19 ans +,4951,des,Fruits et légumes,des,Fruits,,,16.1,0.4,15.2,16.9,g,20.8,0.5,,2
 Sucres totaux,Femmes adultes* 19 ans +,6291,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,5.2,0.1,5,5.5,g,6.8,0.2,,2
-Sucres totaux,Femmes adultes* 19 ans +,1574,des,Fruits et légumes,des,Fruits,des,Pommes,3.7,0.2,3.3,4.1,g,4.8,0.3,,3
-Sucres totaux,Femmes adultes* 19 ans +,1919,des,Fruits et légumes,des,Fruits,des,Bananes,3.2,0.1,2.9,3.5,g,4.2,0.2,,3
+Sucres totaux,Femmes adultes* 19 ans +,1574,des,Fruits et légumes,des,Fruits,des,Pomme,3.7,0.2,3.3,4.1,g,4.8,0.3,,3
+Sucres totaux,Femmes adultes* 19 ans +,1919,des,Fruits et légumes,des,Fruits,des,Banane,3.2,0.1,2.9,3.5,g,4.2,0.2,,3
 Sucres totaux,Femmes adultes* 19 ans +,1356,des,Fruits et légumes,des,Fruits,des,Agrumes,2,0.1,1.7,2.2,g,2.6,0.2,,3
 Sucres totaux,Femmes adultes* 19 ans +,1006,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,1.7,0.2,1.3,2,g,2.2,0.2,,3
 Sucres totaux,Femmes adultes* 19 ans +,854,des,Fruits et légumes,des,Fruits,des,Autres fruits,1.5,0.1,1.2,1.8,g,1.9,0.2,,3
@@ -5279,7 +5279,7 @@ Sucres totaux,Femmes adultes* 19 ans +,2348,des,Fruits et légumes,des,Légumes 
 Sucres totaux,Femmes adultes* 19 ans +,6669,des,Produits céréaliers,,,,,7.3,0.2,7,7.7,g,9.5,0.2,,1
 Sucres totaux,Femmes adultes* 19 ans +,5520,des,Produits céréaliers,des,Pains,,,3.8,0.1,3.6,4,g,4.9,0.1,,2
 Sucres totaux,Femmes adultes* 19 ans +,2230,des,Produits céréaliers,des,Céréales pour déjeuner,,,1.3,0.1,1.2,1.5,g,1.7,0.1,,2
-Sucres totaux,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,1.8,0.1,1.6,2,g,2.4,0.1,,2
+Sucres totaux,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,1.8,0.1,1.6,2,g,2.4,0.1,,2
 Sucres totaux,Femmes adultes* 19 ans +,4893,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,0.4,0,0.3,0.4,g,0.5,0,,2
 Sucres totaux,Femmes adultes* 19 ans +,2551,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,1.8,0.1,1.6,1.9,g,2.3,0.1,,3
 Sucres totaux,Femmes adultes* 19 ans +,1994,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,1.1,0.1,1,1.2,g,1.4,0.1,,3
@@ -5287,10 +5287,10 @@ Sucres totaux,Femmes adultes* 19 ans +,2239,des,Produits céréaliers,des,Pains,
 Sucres totaux,Femmes adultes* 19 ans +,914,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.1,0,0.1,0.2,g,0.2,0,,3
 Sucres totaux,Femmes adultes* 19 ans +,1756,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.9,0.1,0.8,1,g,1.2,0.1,,3
 Sucres totaux,Femmes adultes* 19 ans +,555,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.4,0,0.3,0.5,g,0.6,0.1,,3
-Sucres totaux,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.5,0.1,0.4,0.6,g,0.7,0.1,E,3
-Sucres totaux,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0,0.1,g,0.1,0,,3
-Sucres totaux,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0.1,g,0.1,0,,3
-Sucres totaux,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
+Sucres totaux,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,0.5,0.1,0.4,0.6,g,0.7,0.1,E,3
+Sucres totaux,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0,0.1,g,0.1,0,,3
+Sucres totaux,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0.1,g,0.1,0,,3
+Sucres totaux,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
 Sucres totaux,Femmes adultes* 19 ans +,1358,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.2,0,0.2,0.2,g,0.3,0,,3
 Sucres totaux,Femmes adultes* 19 ans +,3664,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.1,0,0.1,0.1,g,0.2,0,,3
 Sucres totaux,Femmes adultes* 19 ans +,1522,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0,0,0,0,g,0.1,0,,3
@@ -5320,23 +5320,23 @@ Sucres totaux,Femmes adultes* 19 ans +,6382,des,Soupes - sauces - Épices et aut
 Sucres totaux,Femmes adultes* 19 ans +,2243,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.9,0.1,0.7,1,g,1.1,0.1,,2
 Sucres totaux,Femmes adultes* 19 ans +,1853,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0.4,0.1,0.3,0.5,g,0.5,0.1,E,2
 Sucres totaux,Femmes adultes* 19 ans +,6077,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.3,0,0.3,0.4,g,0.5,0,,2
-Sucres totaux,Femmes adultes* 19 ans +,5713,des,Confiseries - sucres et grignotines salées,,,,,20,0.6,18.8,21.3,g,26,0.7,,1
-Sucres totaux,Femmes adultes* 19 ans +,1936,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,4.7,0.5,3.7,5.6,g,6,0.6,,2
-Sucres totaux,Femmes adultes* 19 ans +,844,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,2.8,0.2,2.4,3.3,g,3.7,0.3,,2
-Sucres totaux,Femmes adultes* 19 ans +,1411,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0.3,0.1,0.1,0.4,g,0.4,0.1,E,2
-Sucres totaux,Femmes adultes* 19 ans +,4937,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,12.3,0.4,11.5,13.1,g,15.9,0.5,,2
-Sucres totaux,Femmes adultes* 19 ans +,1238,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,2.4,0.3,1.8,3,g,3.1,0.4,,3
-Sucres totaux,Femmes adultes* 19 ans +,685,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,1.9,0.3,1.3,2.4,g,2.4,0.3,,3
-Sucres totaux,Femmes adultes* 19 ans +,229,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0.4,0.1,0.3,0.5,g,0.5,0.1,E,3
-Sucres totaux,Femmes adultes* 19 ans +,762,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,2.6,0.2,2.2,3,g,3.3,0.3,,3
-Sucres totaux,Femmes adultes* 19 ans +,87,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0.3,0.1,0.2,0.4,g,0.3,0.1,E,3
-Sucres totaux,Femmes adultes* 19 ans +,4229,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,8.2,0.3,7.6,8.8,g,10.7,0.4,,3
-Sucres totaux,Femmes adultes* 19 ans +,1529,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,3.2,0.2,2.7,3.6,g,4.1,0.3,,3
-Sucres totaux,Femmes adultes* 19 ans +,773,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.8,0.1,0.7,0.9,g,1,0.1,,3
-Sucres totaux,Femmes adultes* 19 ans +,360,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0.1,0,0,0.1,g,0.1,0,,3
+Sucres totaux,Femmes adultes* 19 ans +,5713,des,Confiserie - sucres et grignotines salées,,,,,20,0.6,18.8,21.3,g,26,0.7,,1
+Sucres totaux,Femmes adultes* 19 ans +,1936,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,4.7,0.5,3.7,5.6,g,6,0.6,,2
+Sucres totaux,Femmes adultes* 19 ans +,844,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,2.8,0.2,2.4,3.3,g,3.7,0.3,,2
+Sucres totaux,Femmes adultes* 19 ans +,1411,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,0.3,0.1,0.1,0.4,g,0.4,0.1,E,2
+Sucres totaux,Femmes adultes* 19 ans +,4937,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,12.3,0.4,11.5,13.1,g,15.9,0.5,,2
+Sucres totaux,Femmes adultes* 19 ans +,1238,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,2.4,0.3,1.8,3,g,3.1,0.4,,3
+Sucres totaux,Femmes adultes* 19 ans +,685,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,1.9,0.3,1.3,2.4,g,2.4,0.3,,3
+Sucres totaux,Femmes adultes* 19 ans +,229,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0.4,0.1,0.3,0.5,g,0.5,0.1,E,3
+Sucres totaux,Femmes adultes* 19 ans +,762,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,2.6,0.2,2.2,3,g,3.3,0.3,,3
+Sucres totaux,Femmes adultes* 19 ans +,87,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0.3,0.1,0.2,0.4,g,0.3,0.1,E,3
+Sucres totaux,Femmes adultes* 19 ans +,4229,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,8.2,0.3,7.6,8.8,g,10.7,0.4,,3
+Sucres totaux,Femmes adultes* 19 ans +,1529,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,3.2,0.2,2.7,3.6,g,4.1,0.3,,3
+Sucres totaux,Femmes adultes* 19 ans +,773,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.8,0.1,0.7,0.9,g,1,0.1,,3
+Sucres totaux,Femmes adultes* 19 ans +,360,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0.1,0,0,0.1,g,0.1,0,,3
 Sucres totaux,Enfants 1 à 8 ans,122,des,Aliments pour bébés,,,,,0.4,0.1,0.2,0.5,g,0.4,0.1,E,1
 Sucres totaux,Enfants 1 à 8 ans,95,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0.4,0.1,0.2,0.5,g,0.4,0.1,E,2
-Sucres totaux,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0,0,0,0,g,0,0,,2
+Sucres totaux,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparation pour nourrissons,,,0,0,0,0,g,0,0,,2
 Sucres totaux,Enfants 1 à 8 ans,2443,des,Boissons (excluant laits),,,,,16.6,0.7,15.3,18,g,17.2,0.6,,1
 Sucres totaux,Enfants 1 à 8 ans,20,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0.1,g,0,0,,2
 Sucres totaux,Enfants 1 à 8 ans,141,des,Boissons (excluant laits),du,Café et thé,,,0.5,0.1,0.2,0.8,g,0.5,0.1,E,2
@@ -5358,7 +5358,7 @@ Sucres totaux,Enfants 1 à 8 ans,1032,des,Produits laitiers et Boissons à base 
 Sucres totaux,Enfants 1 à 8 ans,2242,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait nature,16,0.5,15,16.9,g,16.5,0.5,,3
 Sucres totaux,Enfants 1 à 8 ans,217,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait aromatisé,2,0.2,1.5,2.4,g,2,0.2,,3
 Sucres totaux,Enfants 1 à 8 ans,128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0.4,0.1,0.3,0.6,g,0.5,0.1,E,3
-Sucres totaux,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,F,F,,,g,F,F,F,3
+Sucres totaux,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,F,F,,,g,F,F,F,3
 Sucres totaux,Enfants 1 à 8 ans,948,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,du,Yogourt aromatisé,5,0.3,4.4,5.5,g,5.1,0.3,,3
 Sucres totaux,Enfants 1 à 8 ans,109,des,Produits laitiers et Boissons à base de plantes,des,Yogourts,du,Yogourt nature,0.2,0,0.1,0.2,g,0.2,0,,3
 Sucres totaux,Enfants 1 à 8 ans,2270,des,Graisses et huiles,,,,,0.1,0,0.1,0.2,g,0.1,0,,1
@@ -5374,8 +5374,8 @@ Sucres totaux,Enfants 1 à 8 ans,50,des,Poissons et fruits de mer,des,Mollusques
 Sucres totaux,Enfants 1 à 8 ans,2428,des,Fruits et légumes,,,,,22.7,0.7,21.3,24.1,g,23.5,0.7,,1
 Sucres totaux,Enfants 1 à 8 ans,2117,des,Fruits et légumes,des,Fruits,,,19.3,0.7,18,20.6,g,19.9,0.6,,2
 Sucres totaux,Enfants 1 à 8 ans,2235,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,3.4,0.1,3.2,3.7,g,3.5,0.1,,2
-Sucres totaux,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pommes,6.1,0.4,5.3,6.9,g,6.3,0.4,,3
-Sucres totaux,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Bananes,3.6,0.2,3.1,4,g,3.7,0.2,,3
+Sucres totaux,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pomme,6.1,0.4,5.3,6.9,g,6.3,0.4,,3
+Sucres totaux,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Banane,3.6,0.2,3.1,4,g,3.7,0.2,,3
 Sucres totaux,Enfants 1 à 8 ans,572,des,Fruits et légumes,des,Fruits,des,Raisins et raisins secs,2.5,0.4,1.8,3.2,g,2.6,0.4,,3
 Sucres totaux,Enfants 1 à 8 ans,830,des,Fruits et légumes,des,Fruits,des,Baies,1.6,0.2,1.3,2,g,1.7,0.2,,3
 Sucres totaux,Enfants 1 à 8 ans,421,des,Fruits et légumes,des,Fruits,des,Agrumes,1.6,0.1,1.4,1.9,g,1.7,0.1,,3
@@ -5393,7 +5393,7 @@ Sucres totaux,Enfants 1 à 8 ans,1032,des,Fruits et légumes,des,Légumes inclua
 Sucres totaux,Enfants 1 à 8 ans,2475,des,Produits céréaliers,,,,,10.9,0.3,10.2,11.6,g,11.2,0.4,,1
 Sucres totaux,Enfants 1 à 8 ans,2114,des,Produits céréaliers,des,Pains,,,3.9,0.2,3.5,4.4,g,4.1,0.2,,2
 Sucres totaux,Enfants 1 à 8 ans,1282,des,Produits céréaliers,des,Céréales pour déjeuner,,,2.6,0.1,2.3,2.9,g,2.7,0.2,,2
-Sucres totaux,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,3.8,0.2,3.4,4.3,g,3.9,0.2,,2
+Sucres totaux,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,3.8,0.2,3.4,4.3,g,3.9,0.2,,2
 Sucres totaux,Enfants 1 à 8 ans,2037,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,0.5,0,0.4,0.6,g,0.5,0,,2
 Sucres totaux,Enfants 1 à 8 ans,951,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,1.8,0.2,1.5,2.1,g,1.8,0.2,,3
 Sucres totaux,Enfants 1 à 8 ans,805,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,1.2,0.1,0.9,1.4,g,1.2,0.1,,3
@@ -5401,9 +5401,9 @@ Sucres totaux,Enfants 1 à 8 ans,813,des,Produits céréaliers,des,Pains,des,Pai
 Sucres totaux,Enfants 1 à 8 ans,745,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0.4,0,0.3,0.4,g,0.4,0,,3
 Sucres totaux,Enfants 1 à 8 ans,670,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),1.9,0.1,1.6,2.1,g,2,0.1,,3
 Sucres totaux,Enfants 1 à 8 ans,728,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.7,0.1,0.6,0.9,g,0.8,0.1,,3
-Sucres totaux,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,1.1,0.1,0.9,1.3,g,1.1,0.1,,3
-Sucres totaux,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.2,g,0.1,0,,3
-Sucres totaux,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,F,F,,,g,F,F,F,3
+Sucres totaux,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,1.1,0.1,0.9,1.3,g,1.1,0.1,,3
+Sucres totaux,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.2,g,0.1,0,,3
+Sucres totaux,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,F,F,,,g,F,F,F,3
 Sucres totaux,Enfants 1 à 8 ans,834,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.4,0,0.3,0.4,g,0.4,0,,3
 Sucres totaux,Enfants 1 à 8 ans,1461,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.1,0,0.1,0.1,g,0.1,0,,3
 Sucres totaux,Enfants 1 à 8 ans,654,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0,0,0,0,g,0,0,,3
@@ -5433,23 +5433,23 @@ Sucres totaux,Enfants 1 à 8 ans,2295,des,Soupes - sauces - Épices et autres in
 Sucres totaux,Enfants 1 à 8 ans,761,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.8,0.1,0.6,1,g,0.8,0.1,,2
 Sucres totaux,Enfants 1 à 8 ans,532,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0.2,0,0.1,0.3,g,0.2,0,,2
 Sucres totaux,Enfants 1 à 8 ans,2205,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.1,0,0.1,0.1,g,0.1,0,,2
-Sucres totaux,Enfants 1 à 8 ans,2106,des,Confiseries - sucres et grignotines salées,,,,,19.7,1,17.8,21.6,g,20.4,0.8,,1
-Sucres totaux,Enfants 1 à 8 ans,1048,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,4.6,0.3,4,5.3,g,4.8,0.3,,2
-Sucres totaux,Enfants 1 à 8 ans,497,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,5.2,0.5,4.2,6.3,g,5.4,0.5,,2
-Sucres totaux,Enfants 1 à 8 ans,615,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0.2,0,0.1,0.2,g,0.2,0,,2
-Sucres totaux,Enfants 1 à 8 ans,1642,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,9.7,0.6,8.4,11,g,10,0.6,,2
-Sucres totaux,Enfants 1 à 8 ans,557,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,2.1,0.2,1.7,2.5,g,2.2,0.2,,3
-Sucres totaux,Enfants 1 à 8 ans,548,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,1.8,0.2,1.4,2.1,g,1.8,0.2,,3
-Sucres totaux,Enfants 1 à 8 ans,131,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0.8,0.1,0.5,1,g,0.8,0.1,,3
-Sucres totaux,Enfants 1 à 8 ans,346,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,2.8,0.3,2.3,3.4,g,2.9,0.3,,3
-Sucres totaux,Enfants 1 à 8 ans,184,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,2.4,0.4,1.6,3.2,g,2.5,0.4,E,3
-Sucres totaux,Enfants 1 à 8 ans,720,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,4.5,0.4,3.7,5.3,g,4.6,0.4,,3
-Sucres totaux,Enfants 1 à 8 ans,1341,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,4.5,0.3,3.8,5.2,g,4.6,0.3,,3
-Sucres totaux,Enfants 1 à 8 ans,257,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.7,0.1,0.5,1,g,0.8,0.1,,3
-Sucres totaux,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,g,X,X,<10,3
+Sucres totaux,Enfants 1 à 8 ans,2106,des,Confiserie - sucres et grignotines salées,,,,,19.7,1,17.8,21.6,g,20.4,0.8,,1
+Sucres totaux,Enfants 1 à 8 ans,1048,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,4.6,0.3,4,5.3,g,4.8,0.3,,2
+Sucres totaux,Enfants 1 à 8 ans,497,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,5.2,0.5,4.2,6.3,g,5.4,0.5,,2
+Sucres totaux,Enfants 1 à 8 ans,615,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,0.2,0,0.1,0.2,g,0.2,0,,2
+Sucres totaux,Enfants 1 à 8 ans,1642,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,9.7,0.6,8.4,11,g,10,0.6,,2
+Sucres totaux,Enfants 1 à 8 ans,557,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,2.1,0.2,1.7,2.5,g,2.2,0.2,,3
+Sucres totaux,Enfants 1 à 8 ans,548,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,1.8,0.2,1.4,2.1,g,1.8,0.2,,3
+Sucres totaux,Enfants 1 à 8 ans,131,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0.8,0.1,0.5,1,g,0.8,0.1,,3
+Sucres totaux,Enfants 1 à 8 ans,346,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,2.8,0.3,2.3,3.4,g,2.9,0.3,,3
+Sucres totaux,Enfants 1 à 8 ans,184,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,2.4,0.4,1.6,3.2,g,2.5,0.4,E,3
+Sucres totaux,Enfants 1 à 8 ans,720,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,4.5,0.4,3.7,5.3,g,4.6,0.4,,3
+Sucres totaux,Enfants 1 à 8 ans,1341,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,4.5,0.3,3.8,5.2,g,4.6,0.3,,3
+Sucres totaux,Enfants 1 à 8 ans,257,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.7,0.1,0.5,1,g,0.8,0.1,,3
+Sucres totaux,Enfants 1 à 8 ans,,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,g,X,X,<10,3
 Vitamine D,Population 1 an et +,186,des,Aliments pour bébés,,,,,0,0,0,0,mcg,0,0,,1
 Vitamine D,Population 1 an et +,154,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Population 1 an et +,51,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Population 1 an et +,51,des,Aliments pour bébés,des,Préparation pour nourrissons,,,0,0,0,0,mcg,0,0,,2
 Vitamine D,Population 1 an et +,19574,des,Boissons (excluant laits),,,,,0,0,0,0.1,mcg,1,0.1,,1
 Vitamine D,Population 1 an et +,3540,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0,mcg,0,0,,2
 Vitamine D,Population 1 an et +,12127,des,Boissons (excluant laits),du,Café et thé,,,0,0,0,0,mcg,0,0,,2
@@ -5473,7 +5473,7 @@ Vitamine D,Population 1 an et +,6481,des,Produits laitiers et Boissons à base d
 Vitamine D,Population 1 an et +,5835,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,0.3,0,0.3,0.3,mcg,6,0.3,,3
 Vitamine D,Population 1 an et +,6026,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0.2,0,0.1,0.2,mcg,3.3,0.2,,3
 Vitamine D,Population 1 an et +,814,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0.1,0,0.1,0.1,mcg,1.7,0.1,,3
-Vitamine D,Population 1 an et +,4411,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0,0,0,0,mcg,0.7,0,,3
+Vitamine D,Population 1 an et +,4411,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,0,0,0,0,mcg,0.7,0,,3
 Vitamine D,Population 1 an et +,18258,des,Graisses et huiles,,,,,0.9,0,0.9,1,mcg,19.3,0.4,,1
 Vitamine D,Population 1 an et +,944,des,Graisses et huiles,des,Graisses animales,,,0,0,0,0,mcg,0.1,0,,2
 Vitamine D,Population 1 an et +,5492,des,Graisses et huiles,du,Beurre,,,0,0,0,0,mcg,0.4,0,,2
@@ -5487,8 +5487,8 @@ Vitamine D,Population 1 an et +,924,des,Poissons et fruits de mer,des,Mollusques
 Vitamine D,Population 1 an et +,18914,des,Fruits et légumes,,,,,0,0,0,0,mcg,0.2,0,,1
 Vitamine D,Population 1 an et +,13689,des,Fruits et légumes,des,Fruits,,,0,0,0,0,mcg,0,0,,2
 Vitamine D,Population 1 an et +,17977,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,0,0,0,0,mcg,0.2,0,,2
-Vitamine D,Population 1 an et +,5026,des,Fruits et légumes,des,Fruits,des,Pommes,0,0,0,0,mcg,0,0,,3
-Vitamine D,Population 1 an et +,5308,des,Fruits et légumes,des,Fruits,des,Bananes,0,0,0,0,mcg,0,0,,3
+Vitamine D,Population 1 an et +,5026,des,Fruits et légumes,des,Fruits,des,Pomme,0,0,0,0,mcg,0,0,,3
+Vitamine D,Population 1 an et +,5308,des,Fruits et légumes,des,Fruits,des,Banane,0,0,0,0,mcg,0,0,,3
 Vitamine D,Population 1 an et +,4326,des,Fruits et légumes,des,Fruits,des,Baies,0,0,0,0,mcg,0,0,,3
 Vitamine D,Population 1 an et +,513,des,Fruits et légumes,des,Fruits,des,Cerises,0,0,0,0,mcg,0,0,,3
 Vitamine D,Population 1 an et +,3372,des,Fruits et légumes,des,Fruits,des,Agrumes,0,0,0,0,mcg,0,0,,3
@@ -5506,7 +5506,7 @@ Vitamine D,Population 1 an et +,8457,des,Fruits et légumes,des,Légumes incluan
 Vitamine D,Population 1 an et +,19327,des,Produits céréaliers,,,,,0.2,0,0.2,0.2,mcg,4.4,0.1,,1
 Vitamine D,Population 1 an et +,16168,des,Produits céréaliers,des,Pains,,,0.1,0,0.1,0.1,mcg,2.8,0.1,,2
 Vitamine D,Population 1 an et +,6966,des,Produits céréaliers,des,Céréales pour déjeuner,,,0.1,0,0.1,0.1,mcg,1.4,0.1,,2
-Vitamine D,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Population 1 an et +,5437,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,0,0,0,0,mcg,0,0,,2
 Vitamine D,Population 1 an et +,14820,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,0,0,0,0,mcg,0.1,0,,2
 Vitamine D,Population 1 an et +,5962,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,0.1,0,0.1,0.1,mcg,1.4,0,,3
 Vitamine D,Population 1 an et +,8159,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,0.1,0,0.1,0.1,mcg,1.3,0,,3
@@ -5514,10 +5514,10 @@ Vitamine D,Population 1 an et +,6257,des,Produits céréaliers,des,Pains,des,Aut
 Vitamine D,Population 1 an et +,2918,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0,0,0,0,mcg,0,0,,3
 Vitamine D,Population 1 an et +,2573,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.1,0,0.1,0.1,mcg,1.2,0.1,,3
 Vitamine D,Population 1 an et +,4760,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0,0,0,0,mcg,0.2,0,,3
-Vitamine D,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mcg,0,0,,3
-Vitamine D,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mcg,0,0,,3
-Vitamine D,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0,0,0,0,mcg,0,0,,3
-Vitamine D,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mcg,X,X,<10,3
+Vitamine D,Population 1 an et +,161,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mcg,0,0,,3
+Vitamine D,Population 1 an et +,130,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mcg,0,0,,3
+Vitamine D,Population 1 an et +,1777,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,0,0,0,0,mcg,0,0,,3
+Vitamine D,Population 1 an et +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mcg,X,X,<10,3
 Vitamine D,Population 1 an et +,4543,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0,0,0,0,mcg,0.1,0,,3
 Vitamine D,Population 1 an et +,11102,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0,0,0,0,mcg,0,0,,3
 Vitamine D,Population 1 an et +,4598,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0,0,0,0,mcg,0,0,,3
@@ -5547,23 +5547,23 @@ Vitamine D,Population 1 an et +,18438,des,Soupes - sauces - Épices et autres in
 Vitamine D,Population 1 an et +,7054,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0,0,0,0,mcg,0.5,0,,2
 Vitamine D,Population 1 an et +,4710,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0,0,0,0,mcg,0.2,0,,2
 Vitamine D,Population 1 an et +,17547,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Population 1 an et +,16725,des,Confiseries - sucres et grignotines salées,,,,,0,0,0,0,mcg,0.6,0.1,,1
-Vitamine D,Population 1 an et +,6211,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Population 1 an et +,2912,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,0,0,0,0,mcg,0.5,0,,2
-Vitamine D,Population 1 an et +,4652,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Population 1 an et +,14214,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0,0,0,0,mcg,0.1,0.1,,2
-Vitamine D,Population 1 an et +,2559,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0,0,0,0,mcg,0,0,,3
-Vitamine D,Population 1 an et +,3815,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0,0,0,0,mcg,0,0,,3
-Vitamine D,Population 1 an et +,703,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0,0,0,0,mcg,0,0,,3
-Vitamine D,Population 1 an et +,2447,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0,0,0,0,mcg,0.5,0,,3
-Vitamine D,Population 1 an et +,560,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,mcg,0,0,,3
-Vitamine D,Population 1 an et +,4750,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0,0,0,0,mcg,0.1,0.1,,3
-Vitamine D,Population 1 an et +,2044,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,mcg,0,0,,3
-Vitamine D,Population 1 an et +,715,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mcg,0,0,,3
-Vitamine D,Population 1 an et +,12217,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,mcg,0,0,,3
+Vitamine D,Population 1 an et +,16725,des,Confiserie - sucres et grignotines salées,,,,,0,0,0,0,mcg,0.6,0.1,,1
+Vitamine D,Population 1 an et +,6211,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Population 1 an et +,2912,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,0,0,0,0,mcg,0.5,0,,2
+Vitamine D,Population 1 an et +,4652,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Population 1 an et +,14214,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0,0,0,0,mcg,0.1,0.1,,2
+Vitamine D,Population 1 an et +,2559,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,0,0,0,0,mcg,0,0,,3
+Vitamine D,Population 1 an et +,3815,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,0,0,0,0,mcg,0,0,,3
+Vitamine D,Population 1 an et +,703,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0,0,0,0,mcg,0,0,,3
+Vitamine D,Population 1 an et +,2447,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0,0,0,0,mcg,0.5,0,,3
+Vitamine D,Population 1 an et +,560,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,mcg,0,0,,3
+Vitamine D,Population 1 an et +,4750,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0,0,0,0,mcg,0.1,0.1,,3
+Vitamine D,Population 1 an et +,2044,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,mcg,0,0,,3
+Vitamine D,Population 1 an et +,715,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mcg,0,0,,3
+Vitamine D,Population 1 an et +,12217,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,mcg,0,0,,3
 Vitamine D,Hommes adultes 19 ans +,22,des,Aliments pour bébés,,,,,0,0,0,0,mcg,0,0,,1
 Vitamine D,Hommes adultes 19 ans +,21,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Hommes adultes 19 ans +,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,mcg,X,X,<10,2
+Vitamine D,Hommes adultes 19 ans +,,des,Aliments pour bébés,des,Préparation pour nourrissons,,,X,X,,,mcg,X,X,<10,2
 Vitamine D,Hommes adultes 19 ans +,6187,des,Boissons (excluant laits),,,,,0.1,0,0,0.1,mcg,1.1,0.2,,1
 Vitamine D,Hommes adultes 19 ans +,1946,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0,mcg,0,0,,2
 Vitamine D,Hommes adultes 19 ans +,5104,des,Boissons (excluant laits),du,Café et thé,,,0,0,0,0,mcg,0,0,,2
@@ -5587,7 +5587,7 @@ Vitamine D,Hommes adultes 19 ans +,1819,des,Produits laitiers et Boissons à bas
 Vitamine D,Hommes adultes 19 ans +,1648,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,0.2,0,0.2,0.3,mcg,4.6,0.5,,3
 Vitamine D,Hommes adultes 19 ans +,1812,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0.2,0,0.1,0.2,mcg,3,0.3,,3
 Vitamine D,Hommes adultes 19 ans +,208,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0.1,0,0.1,0.1,mcg,1.5,0.2,,3
-Vitamine D,Hommes adultes 19 ans +,1727,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0,0,0,0,mcg,0.8,0.1,,3
+Vitamine D,Hommes adultes 19 ans +,1727,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,0,0,0,0,mcg,0.8,0.1,,3
 Vitamine D,Hommes adultes 19 ans +,5767,des,Graisses et huiles,,,,,1.1,0,1.1,1.2,mcg,21.9,0.8,,1
 Vitamine D,Hommes adultes 19 ans +,333,des,Graisses et huiles,des,Graisses animales,,,0,0,0,0,mcg,0.1,0,,2
 Vitamine D,Hommes adultes 19 ans +,1787,des,Graisses et huiles,du,Beurre,,,0,0,0,0,mcg,0.4,0,,2
@@ -5601,8 +5601,8 @@ Vitamine D,Hommes adultes 19 ans +,343,des,Poissons et fruits de mer,des,Mollusq
 Vitamine D,Hommes adultes 19 ans +,5918,des,Fruits et légumes,,,,,0,0,0,0,mcg,0.2,0,,1
 Vitamine D,Hommes adultes 19 ans +,3876,des,Fruits et légumes,des,Fruits,,,0,0,0,0,mcg,0,0,,2
 Vitamine D,Hommes adultes 19 ans +,5694,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,0,0,0,0,mcg,0.2,0,,2
-Vitamine D,Hommes adultes 19 ans +,1350,des,Fruits et légumes,des,Fruits,des,Pommes,0,0,0,0,mcg,0,0,,3
-Vitamine D,Hommes adultes 19 ans +,1590,des,Fruits et légumes,des,Fruits,des,Bananes,0,0,0,0,mcg,0,0,,3
+Vitamine D,Hommes adultes 19 ans +,1350,des,Fruits et légumes,des,Fruits,des,Pomme,0,0,0,0,mcg,0,0,,3
+Vitamine D,Hommes adultes 19 ans +,1590,des,Fruits et légumes,des,Fruits,des,Banane,0,0,0,0,mcg,0,0,,3
 Vitamine D,Hommes adultes 19 ans +,1066,des,Fruits et légumes,des,Fruits,des,Baies,0,0,0,0,mcg,0,0,,3
 Vitamine D,Hommes adultes 19 ans +,169,des,Fruits et légumes,des,Fruits,des,Cerises,0,0,0,0,mcg,0,0,,3
 Vitamine D,Hommes adultes 19 ans +,1019,des,Fruits et légumes,des,Fruits,des,Agrumes,0,0,0,0,mcg,0,0,,3
@@ -5620,7 +5620,7 @@ Vitamine D,Hommes adultes 19 ans +,2838,des,Fruits et légumes,des,Légumes incl
 Vitamine D,Hommes adultes 19 ans +,6068,des,Produits céréaliers,,,,,0.2,0,0.2,0.2,mcg,4.3,0.2,,1
 Vitamine D,Hommes adultes 19 ans +,5104,des,Produits céréaliers,des,Pains,,,0.2,0,0.1,0.2,mcg,3,0.1,,2
 Vitamine D,Hommes adultes 19 ans +,1921,des,Produits céréaliers,des,Céréales pour déjeuner,,,0.1,0,0,0.1,mcg,1.1,0.1,,2
-Vitamine D,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Hommes adultes 19 ans +,1375,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,0,0,0,0,mcg,0,0,,2
 Vitamine D,Hommes adultes 19 ans +,4551,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,0,0,0,0,mcg,0.1,0,,2
 Vitamine D,Hommes adultes 19 ans +,2752,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,0.1,0,0.1,0.1,mcg,1.5,0.1,,3
 Vitamine D,Hommes adultes 19 ans +,1980,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,0.1,0,0.1,0.1,mcg,1.5,0.1,,3
@@ -5628,9 +5628,9 @@ Vitamine D,Hommes adultes 19 ans +,593,des,Produits céréaliers,des,Pains,des,C
 Vitamine D,Hommes adultes 19 ans +,1885,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,0,0,0,0,mcg,0,0,,3
 Vitamine D,Hommes adultes 19 ans +,523,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0,0,0,0.1,mcg,0.8,0.1,,3
 Vitamine D,Hommes adultes 19 ans +,1481,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0,0,0,0,mcg,0.3,0,,3
-Vitamine D,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mcg,0,0,,3
-Vitamine D,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mcg,0,0,,3
-Vitamine D,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0,0,0,0,mcg,0,0,,3
+Vitamine D,Hommes adultes 19 ans +,33,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mcg,0,0,,3
+Vitamine D,Hommes adultes 19 ans +,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mcg,0,0,,3
+Vitamine D,Hommes adultes 19 ans +,383,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,0,0,0,0,mcg,0,0,,3
 Vitamine D,Hommes adultes 19 ans +,1250,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0,0,0,0,mcg,0.1,0,,3
 Vitamine D,Hommes adultes 19 ans +,3442,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0,0,0,0,mcg,0,0,,3
 Vitamine D,Hommes adultes 19 ans +,1449,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0,0,0,0,mcg,0,0,,3
@@ -5660,23 +5660,23 @@ Vitamine D,Hommes adultes 19 ans +,5856,des,Soupes - sauces - Épices et autres 
 Vitamine D,Hommes adultes 19 ans +,2384,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0,0,0,0,mcg,0.3,0.1,,2
 Vitamine D,Hommes adultes 19 ans +,1511,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0,0,0,0,mcg,0.1,0,,2
 Vitamine D,Hommes adultes 19 ans +,5575,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Hommes adultes 19 ans +,5232,des,Confiseries - sucres et grignotines salées,,,,,0,0,0,0,mcg,0.5,0,,1
-Vitamine D,Hommes adultes 19 ans +,1527,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Hommes adultes 19 ans +,771,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,0,0,0,0,mcg,0.4,0,,2
-Vitamine D,Hommes adultes 19 ans +,1268,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Hommes adultes 19 ans +,4671,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Hommes adultes 19 ans +,497,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0,0,0,0,mcg,0,0,,3
-Vitamine D,Hommes adultes 19 ans +,1023,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0,0,0,0,mcg,0,0,,3
-Vitamine D,Hommes adultes 19 ans +,170,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0,0,0,0,mcg,0,0,,3
-Vitamine D,Hommes adultes 19 ans +,702,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0,0,0,0,mcg,0.4,0,,3
-Vitamine D,Hommes adultes 19 ans +,80,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,mcg,0,0,,3
-Vitamine D,Hommes adultes 19 ans +,726,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,mcg,0,0,,3
-Vitamine D,Hommes adultes 19 ans +,1360,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0,0,0,0,mcg,0,0,,3
-Vitamine D,Hommes adultes 19 ans +,322,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mcg,0,0,,3
-Vitamine D,Hommes adultes 19 ans +,4068,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,mcg,0,0,,3
+Vitamine D,Hommes adultes 19 ans +,5232,des,Confiserie - sucres et grignotines salées,,,,,0,0,0,0,mcg,0.5,0,,1
+Vitamine D,Hommes adultes 19 ans +,1527,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Hommes adultes 19 ans +,771,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,0,0,0,0,mcg,0.4,0,,2
+Vitamine D,Hommes adultes 19 ans +,1268,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Hommes adultes 19 ans +,4671,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Hommes adultes 19 ans +,497,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,0,0,0,0,mcg,0,0,,3
+Vitamine D,Hommes adultes 19 ans +,1023,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,0,0,0,0,mcg,0,0,,3
+Vitamine D,Hommes adultes 19 ans +,170,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0,0,0,0,mcg,0,0,,3
+Vitamine D,Hommes adultes 19 ans +,702,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0,0,0,0,mcg,0.4,0,,3
+Vitamine D,Hommes adultes 19 ans +,80,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,mcg,0,0,,3
+Vitamine D,Hommes adultes 19 ans +,726,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,mcg,0,0,,3
+Vitamine D,Hommes adultes 19 ans +,1360,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0,0,0,0,mcg,0,0,,3
+Vitamine D,Hommes adultes 19 ans +,322,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mcg,0,0,,3
+Vitamine D,Hommes adultes 19 ans +,4068,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,mcg,0,0,,3
 Vitamine D,Femmes adultes* 19 ans +,21,des,Aliments pour bébés,,,,,0,0,0,0,mcg,0,0,,1
 Vitamine D,Femmes adultes* 19 ans +,19,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Femmes adultes* 19 ans +,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,mcg,X,X,<10,2
+Vitamine D,Femmes adultes* 19 ans +,,des,Aliments pour bébés,des,Préparation pour nourrissons,,,X,X,,,mcg,X,X,<10,2
 Vitamine D,Femmes adultes* 19 ans +,6828,des,Boissons (excluant laits),,,,,0,0,0,0,mcg,0.6,0.1,,1
 Vitamine D,Femmes adultes* 19 ans +,1439,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0,mcg,0,0,,2
 Vitamine D,Femmes adultes* 19 ans +,5777,des,Boissons (excluant laits),du,Café et thé,,,0,0,0,0,mcg,0,0,,2
@@ -5700,7 +5700,7 @@ Vitamine D,Femmes adultes* 19 ans +,2244,des,Produits laitiers et Boissons à ba
 Vitamine D,Femmes adultes* 19 ans +,1928,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,0.2,0,0.1,0.2,mcg,4.2,0.6,,3
 Vitamine D,Femmes adultes* 19 ans +,2211,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0.2,0,0.1,0.2,mcg,4.1,0.3,,3
 Vitamine D,Femmes adultes* 19 ans +,358,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0.1,0,0.1,0.1,mcg,2.1,0.2,,3
-Vitamine D,Femmes adultes* 19 ans +,1769,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0,0,0,0,mcg,0.8,0.1,,3
+Vitamine D,Femmes adultes* 19 ans +,1769,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,0,0,0,0,mcg,0.8,0.1,,3
 Vitamine D,Femmes adultes* 19 ans +,6356,des,Graisses et huiles,,,,,0.8,0,0.8,0.9,mcg,20.1,0.7,,1
 Vitamine D,Femmes adultes* 19 ans +,369,des,Graisses et huiles,des,Graisses animales,,,0,0,0,0,mcg,0.2,0,,2
 Vitamine D,Femmes adultes* 19 ans +,1972,des,Graisses et huiles,du,Beurre,,,0,0,0,0,mcg,0.5,0,,2
@@ -5714,8 +5714,8 @@ Vitamine D,Femmes adultes* 19 ans +,370,des,Poissons et fruits de mer,des,Mollus
 Vitamine D,Femmes adultes* 19 ans +,6595,des,Fruits et légumes,,,,,0,0,0,0,mcg,0.3,0,,1
 Vitamine D,Femmes adultes* 19 ans +,4951,des,Fruits et légumes,des,Fruits,,,0,0,0,0,mcg,0,0,,2
 Vitamine D,Femmes adultes* 19 ans +,6291,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,0,0,0,0,mcg,0.3,0,,2
-Vitamine D,Femmes adultes* 19 ans +,1574,des,Fruits et légumes,des,Fruits,des,Pommes,0,0,0,0,mcg,0,0,,3
-Vitamine D,Femmes adultes* 19 ans +,1919,des,Fruits et légumes,des,Fruits,des,Bananes,0,0,0,0,mcg,0,0,,3
+Vitamine D,Femmes adultes* 19 ans +,1574,des,Fruits et légumes,des,Fruits,des,Pomme,0,0,0,0,mcg,0,0,,3
+Vitamine D,Femmes adultes* 19 ans +,1919,des,Fruits et légumes,des,Fruits,des,Banane,0,0,0,0,mcg,0,0,,3
 Vitamine D,Femmes adultes* 19 ans +,1597,des,Fruits et légumes,des,Fruits,des,Baies,0,0,0,0,mcg,0,0,,3
 Vitamine D,Femmes adultes* 19 ans +,215,des,Fruits et légumes,des,Fruits,des,Cerises,0,0,0,0,mcg,0,0,,3
 Vitamine D,Femmes adultes* 19 ans +,1356,des,Fruits et légumes,des,Fruits,des,Agrumes,0,0,0,0,mcg,0,0,,3
@@ -5733,7 +5733,7 @@ Vitamine D,Femmes adultes* 19 ans +,2959,des,Fruits et légumes,des,Légumes inc
 Vitamine D,Femmes adultes* 19 ans +,6669,des,Produits céréaliers,,,,,0.2,0,0.2,0.2,mcg,4.2,0.2,,1
 Vitamine D,Femmes adultes* 19 ans +,5520,des,Produits céréaliers,des,Pains,,,0.1,0,0.1,0.1,mcg,3,0.1,,2
 Vitamine D,Femmes adultes* 19 ans +,2230,des,Produits céréaliers,des,Céréales pour déjeuner,,,0,0,0,0.1,mcg,1.1,0.1,,2
-Vitamine D,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Femmes adultes* 19 ans +,1575,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,0,0,0,0,mcg,0,0,,2
 Vitamine D,Femmes adultes* 19 ans +,4893,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,0,0,0,0,mcg,0.1,0,,2
 Vitamine D,Femmes adultes* 19 ans +,2239,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,0.1,0,0.1,0.1,mcg,1.6,0.1,,3
 Vitamine D,Femmes adultes* 19 ans +,2551,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,0.1,0,0,0.1,mcg,1.3,0.1,,3
@@ -5741,10 +5741,10 @@ Vitamine D,Femmes adultes* 19 ans +,914,des,Produits céréaliers,des,Pains,des,
 Vitamine D,Femmes adultes* 19 ans +,1994,des,Produits céréaliers,des,Pains,des,Autres produits panifiés,0,0,0,0,mcg,0,0,,3
 Vitamine D,Femmes adultes* 19 ans +,555,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0,0,0,0,mcg,0.9,0.1,,3
 Vitamine D,Femmes adultes* 19 ans +,1756,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0,0,0,0,mcg,0.2,0,,3
-Vitamine D,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mcg,0,0,,3
-Vitamine D,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mcg,0,0,,3
-Vitamine D,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0,0,0,0,mcg,0,0,,3
-Vitamine D,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mcg,X,X,<10,3
+Vitamine D,Femmes adultes* 19 ans +,42,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mcg,0,0,,3
+Vitamine D,Femmes adultes* 19 ans +,30,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mcg,0,0,,3
+Vitamine D,Femmes adultes* 19 ans +,389,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,0,0,0,0,mcg,0,0,,3
+Vitamine D,Femmes adultes* 19 ans +,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mcg,X,X,<10,3
 Vitamine D,Femmes adultes* 19 ans +,1358,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0,0,0,0,mcg,0.1,0,,3
 Vitamine D,Femmes adultes* 19 ans +,3664,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0,0,0,0,mcg,0,0,,3
 Vitamine D,Femmes adultes* 19 ans +,1522,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0,0,0,0,mcg,0,0,,3
@@ -5774,23 +5774,23 @@ Vitamine D,Femmes adultes* 19 ans +,6382,des,Soupes - sauces - Épices et autres
 Vitamine D,Femmes adultes* 19 ans +,2243,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0,0,0,0,mcg,0.6,0.1,,2
 Vitamine D,Femmes adultes* 19 ans +,1853,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0,0,0,0,mcg,0.2,0,,2
 Vitamine D,Femmes adultes* 19 ans +,6077,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0,0,0,0,mcg,0.1,0.1,,2
-Vitamine D,Femmes adultes* 19 ans +,5713,des,Confiseries - sucres et grignotines salées,,,,,0,0,0,0,mcg,0.6,0,,1
-Vitamine D,Femmes adultes* 19 ans +,1936,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Femmes adultes* 19 ans +,844,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,0,0,0,0,mcg,0.5,0,,2
-Vitamine D,Femmes adultes* 19 ans +,1411,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Femmes adultes* 19 ans +,4937,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Femmes adultes* 19 ans +,685,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0,0,0,0,mcg,0,0,,3
-Vitamine D,Femmes adultes* 19 ans +,1238,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0,0,0,0,mcg,0,0,,3
-Vitamine D,Femmes adultes* 19 ans +,229,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0,0,0,0,mcg,0,0,,3
-Vitamine D,Femmes adultes* 19 ans +,762,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0,0,0,0,mcg,0.5,0,,3
-Vitamine D,Femmes adultes* 19 ans +,87,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,mcg,0,0,,3
-Vitamine D,Femmes adultes* 19 ans +,773,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,mcg,0,0,,3
-Vitamine D,Femmes adultes* 19 ans +,1529,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0,0,0,0,mcg,0,0,,3
-Vitamine D,Femmes adultes* 19 ans +,360,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mcg,0,0,,3
-Vitamine D,Femmes adultes* 19 ans +,4229,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,mcg,0,0,,3
+Vitamine D,Femmes adultes* 19 ans +,5713,des,Confiserie - sucres et grignotines salées,,,,,0,0,0,0,mcg,0.6,0,,1
+Vitamine D,Femmes adultes* 19 ans +,1936,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Femmes adultes* 19 ans +,844,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,0,0,0,0,mcg,0.5,0,,2
+Vitamine D,Femmes adultes* 19 ans +,1411,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Femmes adultes* 19 ans +,4937,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Femmes adultes* 19 ans +,685,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,0,0,0,0,mcg,0,0,,3
+Vitamine D,Femmes adultes* 19 ans +,1238,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,0,0,0,0,mcg,0,0,,3
+Vitamine D,Femmes adultes* 19 ans +,229,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0,0,0,0,mcg,0,0,,3
+Vitamine D,Femmes adultes* 19 ans +,762,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0,0,0,0,mcg,0.5,0,,3
+Vitamine D,Femmes adultes* 19 ans +,87,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,mcg,0,0,,3
+Vitamine D,Femmes adultes* 19 ans +,773,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,mcg,0,0,,3
+Vitamine D,Femmes adultes* 19 ans +,1529,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0,0,0,0,mcg,0,0,,3
+Vitamine D,Femmes adultes* 19 ans +,360,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mcg,0,0,,3
+Vitamine D,Femmes adultes* 19 ans +,4229,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,mcg,0,0,,3
 Vitamine D,Enfants 1 à 8 ans,122,des,Aliments pour bébés,,,,,0,0,0,0,mcg,0.2,0.1,,1
 Vitamine D,Enfants 1 à 8 ans,95,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparations pour nourrissons,,,0,0,0,0,mcg,0.2,0.1,,2
+Vitamine D,Enfants 1 à 8 ans,46,des,Aliments pour bébés,des,Préparation pour nourrissons,,,0,0,0,0,mcg,0.2,0.1,,2
 Vitamine D,Enfants 1 à 8 ans,2443,des,Boissons (excluant laits),,,,,0.1,0,0,0.1,mcg,1.3,0.2,,1
 Vitamine D,Enfants 1 à 8 ans,20,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0,mcg,0,0,,2
 Vitamine D,Enfants 1 à 8 ans,141,des,Boissons (excluant laits),du,Café et thé,,,0,0,0,0,mcg,0,0,,2
@@ -5814,7 +5814,7 @@ Vitamine D,Enfants 1 à 8 ans,1078,des,Produits laitiers et Boissons à base de 
 Vitamine D,Enfants 1 à 8 ans,854,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,0.6,0.1,0.4,0.7,mcg,10.2,1.1,E,3
 Vitamine D,Enfants 1 à 8 ans,739,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0.1,0,0.1,0.1,mcg,1.6,0.3,,3
 Vitamine D,Enfants 1 à 8 ans,128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0.1,0,0,0.1,mcg,1.3,0.2,,3
-Vitamine D,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0,0,0,0,mcg,0.3,0.1,,3
+Vitamine D,Enfants 1 à 8 ans,253,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,0,0,0,0,mcg,0.3,0.1,,3
 Vitamine D,Enfants 1 à 8 ans,2270,des,Graisses et huiles,,,,,0.7,0,0.6,0.7,mcg,11.7,0.6,,1
 Vitamine D,Enfants 1 à 8 ans,83,des,Graisses et huiles,des,Graisses animales,,,0,0,0,0,mcg,0.1,0,,2
 Vitamine D,Enfants 1 à 8 ans,657,des,Graisses et huiles,du,Beurre,,,0,0,0,0,mcg,0.2,0,,2
@@ -5828,8 +5828,8 @@ Vitamine D,Enfants 1 à 8 ans,50,des,Poissons et fruits de mer,des,Mollusques et
 Vitamine D,Enfants 1 à 8 ans,2428,des,Fruits et légumes,,,,,0,0,0,0,mcg,0.1,0,,1
 Vitamine D,Enfants 1 à 8 ans,2117,des,Fruits et légumes,des,Fruits,,,0,0,0,0,mcg,0,0,,2
 Vitamine D,Enfants 1 à 8 ans,2235,des,Fruits et légumes,des,Légumes incluant pommes de terre,,,0,0,0,0,mcg,0.1,0,,2
-Vitamine D,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pommes,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Bananes,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,978,des,Fruits et légumes,des,Fruits,des,Pomme,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,873,des,Fruits et légumes,des,Fruits,des,Banane,0,0,0,0,mcg,0,0,,3
 Vitamine D,Enfants 1 à 8 ans,830,des,Fruits et légumes,des,Fruits,des,Baies,0,0,0,0,mcg,0,0,,3
 Vitamine D,Enfants 1 à 8 ans,47,des,Fruits et légumes,des,Fruits,des,Cerises,0,0,0,0,mcg,0,0,,3
 Vitamine D,Enfants 1 à 8 ans,421,des,Fruits et légumes,des,Fruits,des,Agrumes,0,0,0,0,mcg,0,0,,3
@@ -5847,7 +5847,7 @@ Vitamine D,Enfants 1 à 8 ans,1032,des,Fruits et légumes,des,Légumes incluant 
 Vitamine D,Enfants 1 à 8 ans,2475,des,Produits céréaliers,,,,,0.2,0,0.2,0.3,mcg,4.4,0.2,,1
 Vitamine D,Enfants 1 à 8 ans,2114,des,Produits céréaliers,des,Pains,,,0.1,0,0.1,0.1,mcg,2,0.1,,2
 Vitamine D,Enfants 1 à 8 ans,1282,des,Produits céréaliers,des,Céréales pour déjeuner,,,0.1,0,0.1,0.1,mcg,2.3,0.2,,2
-Vitamine D,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Enfants 1 à 8 ans,970,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,0,0,0,0,mcg,0,0,,2
 Vitamine D,Enfants 1 à 8 ans,2037,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,0,0,0,0,mcg,0.1,0,,2
 Vitamine D,Enfants 1 à 8 ans,951,des,Produits céréaliers,des,Pains,des,Pains et petits pains blancs,0.1,0,0,0.1,mcg,1,0.1,,3
 Vitamine D,Enfants 1 à 8 ans,813,des,Produits céréaliers,des,Pains,des,Pains et petits pains à grains entiers et blé entier,0,0,0,0.1,mcg,0.9,0.1,,3
@@ -5855,9 +5855,9 @@ Vitamine D,Enfants 1 à 8 ans,805,des,Produits céréaliers,des,Pains,des,Autres
 Vitamine D,Enfants 1 à 8 ans,745,des,Produits céréaliers,des,Pains,des,Craquelins et biscottes,0,0,0,0,mcg,0,0,,3
 Vitamine D,Enfants 1 à 8 ans,670,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.1,0,0.1,0.1,mcg,2.2,0.2,,3
 Vitamine D,Enfants 1 à 8 ans,728,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0,0,0,0,mcg,0.1,0,,3
-Vitamine D,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,21,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,26,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,317,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,0,0,0,0,mcg,0,0,,3
 Vitamine D,Enfants 1 à 8 ans,834,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0,0,0,0,mcg,0.1,0,,3
 Vitamine D,Enfants 1 à 8 ans,1461,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0,0,0,0,mcg,0,0,,3
 Vitamine D,Enfants 1 à 8 ans,654,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,du,Riz,0,0,0,0,mcg,0,0,,3
@@ -5887,23 +5887,23 @@ Vitamine D,Enfants 1 à 8 ans,2295,des,Soupes - sauces - Épices et autres ingr�
 Vitamine D,Enfants 1 à 8 ans,761,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0,0,0,0,mcg,0.5,0.2,,2
 Vitamine D,Enfants 1 à 8 ans,532,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0,0,0,0,mcg,0.1,0,,2
 Vitamine D,Enfants 1 à 8 ans,2205,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Enfants 1 à 8 ans,2106,des,Confiseries - sucres et grignotines salées,,,,,0.1,0,0,0.1,mcg,1.2,0.5,,1
-Vitamine D,Enfants 1 à 8 ans,1048,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Enfants 1 à 8 ans,497,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,0,0,0,0,mcg,0.4,0,,2
-Vitamine D,Enfants 1 à 8 ans,615,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Enfants 1 à 8 ans,1642,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0,0,0,0.1,mcg,0.7,0.5,,2
-Vitamine D,Enfants 1 à 8 ans,557,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,548,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,131,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,346,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0,0,0,0,mcg,0.4,0,,3
-Vitamine D,Enfants 1 à 8 ans,184,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,720,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0,0,0,0.1,mcg,0.7,0.5,,3
-Vitamine D,Enfants 1 à 8 ans,257,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,1341,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,mcg,X,X,<10,3
+Vitamine D,Enfants 1 à 8 ans,2106,des,Confiserie - sucres et grignotines salées,,,,,0.1,0,0,0.1,mcg,1.2,0.5,,1
+Vitamine D,Enfants 1 à 8 ans,1048,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Enfants 1 à 8 ans,497,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,0,0,0,0,mcg,0.4,0,,2
+Vitamine D,Enfants 1 à 8 ans,615,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Enfants 1 à 8 ans,1642,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0,0,0,0.1,mcg,0.7,0.5,,2
+Vitamine D,Enfants 1 à 8 ans,557,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,548,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,131,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,346,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0,0,0,0,mcg,0.4,0,,3
+Vitamine D,Enfants 1 à 8 ans,184,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,720,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0,0,0,0.1,mcg,0.7,0.5,,3
+Vitamine D,Enfants 1 à 8 ans,257,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,1341,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,X,X,,,mcg,X,X,<10,3
 Énergie,Jeunes et adolescents* 9 à 18 ans  ,19,des,Aliments pour bébés,,,,,0.6,0.2,0.2,1,kcal,0,0,E,1
 Énergie,Jeunes et adolescents* 9 à 18 ans  ,17,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,F,F,,,kcal,F,F,F,2
-Énergie,Jeunes et adolescents* 9 à 18 ans  ,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,kcal,X,X,<10,2
+Énergie,Jeunes et adolescents* 9 à 18 ans  ,,des,Aliments pour bébés,des,Préparation pour nourrissons,,,X,X,,,kcal,X,X,<10,2
 Énergie,Jeunes et adolescents* 9 à 18 ans  ,3815,des,Boissons (excluant laits),,,,,151.7,4.7,142.5,160.8,kcal,7.4,0.2,,1
 Énergie,Jeunes et adolescents* 9 à 18 ans  ,93,des,Boissons (excluant laits),de l',Alcool,,,5,1.2,2.6,7.5,kcal,0.2,0.1,E,2
 Énergie,Jeunes et adolescents* 9 à 18 ans  ,890,des,Boissons (excluant laits),du,Café et thé,,,8.7,0.7,7.3,10.1,kcal,0.4,0,,2
@@ -5923,7 +5923,7 @@ Vitamine D,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,d
 Énergie,Jeunes et adolescents* 9 à 18 ans  ,3315,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,160.2,4.3,151.8,168.6,kcal,7.9,0.2,,2
 Énergie,Jeunes et adolescents* 9 à 18 ans  ,1440,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,40.7,2.9,35,46.4,kcal,2,0.1,,3
 Énergie,Jeunes et adolescents* 9 à 18 ans  ,2530,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,82.3,3.1,76.2,88.5,kcal,4,0.1,,3
-Énergie,Jeunes et adolescents* 9 à 18 ans  ,575,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,9.8,1,7.9,11.7,kcal,0.5,0,,3
+Énergie,Jeunes et adolescents* 9 à 18 ans  ,575,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,9.8,1,7.9,11.7,kcal,0.5,0,,3
 Énergie,Jeunes et adolescents* 9 à 18 ans  ,98,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,2.9,0.6,1.6,4.1,kcal,0.1,0,E,3
 Énergie,Jeunes et adolescents* 9 à 18 ans  ,1154,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,6.3,0.7,4.9,7.7,kcal,0.3,0,,3
 Énergie,Jeunes et adolescents* 9 à 18 ans  ,1072,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,18.2,1.7,14.9,21.5,kcal,0.9,0.1,,3
@@ -5940,8 +5940,8 @@ Vitamine D,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,d
 Énergie,Jeunes et adolescents* 9 à 18 ans  ,141,des,Poissons et fruits de mer,des,Mollusques et crustacés,,,2.1,0.4,1.3,3,kcal,0.1,0,E,2
 Énergie,Jeunes et adolescents* 9 à 18 ans  ,3672,des,Fruits et légumes,,,,,175.9,4,168.1,183.8,kcal,8.6,0.2,,1
 Énergie,Jeunes et adolescents* 9 à 18 ans  ,2498,des,Fruits et légumes,des,Fruits,,,88.6,3,82.8,94.5,kcal,4.3,0.1,,2
-Énergie,Jeunes et adolescents* 9 à 18 ans  ,1041,des,Fruits et légumes,des,Fruits,des,Pommes,26.7,1.3,24.2,29.2,kcal,1.3,0.1,,3
-Énergie,Jeunes et adolescents* 9 à 18 ans  ,823,des,Fruits et légumes,des,Fruits,des,Bananes,20.3,1.2,17.9,22.7,kcal,1,0.1,,3
+Énergie,Jeunes et adolescents* 9 à 18 ans  ,1041,des,Fruits et légumes,des,Fruits,des,Pomme,26.7,1.3,24.2,29.2,kcal,1.3,0.1,,3
+Énergie,Jeunes et adolescents* 9 à 18 ans  ,823,des,Fruits et légumes,des,Fruits,des,Banane,20.3,1.2,17.9,22.7,kcal,1,0.1,,3
 Énergie,Jeunes et adolescents* 9 à 18 ans  ,743,des,Fruits et légumes,des,Fruits,des,Baies,6.8,0.5,5.8,7.8,kcal,0.3,0,,3
 Énergie,Jeunes et adolescents* 9 à 18 ans  ,73,des,Fruits et légumes,des,Fruits,des,Cerises,0.7,0.2,0.3,1.1,kcal,0,0,E,3
 Énergie,Jeunes et adolescents* 9 à 18 ans  ,514,des,Fruits et légumes,des,Fruits,des,Agrumes,6.5,0.5,5.5,7.4,kcal,0.3,0,,3
@@ -5966,11 +5966,11 @@ Vitamine D,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,d
 Énergie,Jeunes et adolescents* 9 à 18 ans  ,1416,des,Produits céréaliers,des,Céréales pour déjeuner,,,62.6,3.1,56.5,68.7,kcal,3.1,0.1,,2
 Énergie,Jeunes et adolescents* 9 à 18 ans  ,794,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),31.1,2.3,26.5,35.7,kcal,1.5,0.1,,3
 Énergie,Jeunes et adolescents* 9 à 18 ans  ,700,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,31.5,2.1,27.4,35.6,kcal,1.5,0.1,,3
-Énergie,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,65.9,3.3,59.4,72.4,kcal,3.2,0.2,,2
-Énergie,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,2.7,0.6,1.6,3.9,kcal,0.1,0,E,3
-Énergie,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,1.9,0.5,1,2.9,kcal,0.1,0,E,3
-Énergie,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,26.4,2.3,21.9,30.8,kcal,1.3,0.1,,3
-Énergie,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,kcal,X,X,<10,3
+Énergie,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,65.9,3.3,59.4,72.4,kcal,3.2,0.2,,2
+Énergie,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,2.7,0.6,1.6,3.9,kcal,0.1,0,E,3
+Énergie,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,1.9,0.5,1,2.9,kcal,0.1,0,E,3
+Énergie,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,26.4,2.3,21.9,30.8,kcal,1.3,0.1,,3
+Énergie,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,kcal,X,X,<10,3
 Énergie,Jeunes et adolescents* 9 à 18 ans  ,3103,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,233.2,6.1,221.3,245.1,kcal,11.4,0.3,,2
 Énergie,Jeunes et adolescents* 9 à 18 ans  ,2364,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,106.4,4.9,96.9,116,kcal,5.2,0.2,,3
 Énergie,Jeunes et adolescents* 9 à 18 ans  ,1020,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,69,4.2,60.7,77.3,kcal,3.4,0.2,,3
@@ -6001,23 +6001,23 @@ Vitamine D,Enfants 1 à 8 ans,,des,Confiseries - sucres et grignotines salées,d
 Énergie,Jeunes et adolescents* 9 à 18 ans  ,1553,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,13.6,0.9,11.9,15.4,kcal,0.7,0,,2
 Énergie,Jeunes et adolescents* 9 à 18 ans  ,747,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,10.8,1,8.8,12.7,kcal,0.5,0,,2
 Énergie,Jeunes et adolescents* 9 à 18 ans  ,3417,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,4.1,0.2,3.6,4.6,kcal,0.2,0,,2
-Énergie,Jeunes et adolescents* 9 à 18 ans  ,3420,des,Confiseries - sucres et grignotines salées,,,,,269.9,9.8,250.7,289.1,kcal,13.2,0.4,,1
-Énergie,Jeunes et adolescents* 9 à 18 ans  ,1608,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,56.3,3.2,50.1,62.6,kcal,2.8,0.2,,2
-Énergie,Jeunes et adolescents* 9 à 18 ans  ,794,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,23.6,2.3,19,28.1,kcal,1.2,0.1,,3
-Énergie,Jeunes et adolescents* 9 à 18 ans  ,938,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,29.4,2.3,24.9,33.9,kcal,1.4,0.1,,3
-Énergie,Jeunes et adolescents* 9 à 18 ans  ,166,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,3.4,0.5,2.4,4.4,kcal,0.2,0,,3
-Énergie,Jeunes et adolescents* 9 à 18 ans  ,758,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,59.5,4.2,51.2,67.8,kcal,2.9,0.2,,2
-Énergie,Jeunes et adolescents* 9 à 18 ans  ,599,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,47.7,3.8,40.3,55.1,kcal,2.3,0.2,,3
-Énergie,Jeunes et adolescents* 9 à 18 ans  ,204,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,11.8,1.8,8.2,15.3,kcal,0.6,0.1,,3
-Énergie,Jeunes et adolescents* 9 à 18 ans  ,1279,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,84,7.3,69.8,98.3,kcal,4.1,0.3,,2
-Énergie,Jeunes et adolescents* 9 à 18 ans  ,2738,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,70.1,3.9,62.5,77.7,kcal,3.4,0.2,,2
-Énergie,Jeunes et adolescents* 9 à 18 ans  ,269,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,6.3,1.1,4.1,8.6,kcal,0.3,0.1,E,3
-Énergie,Jeunes et adolescents* 9 à 18 ans  ,1069,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,33.7,3.2,27.4,40,kcal,1.7,0.2,,3
-Énergie,Jeunes et adolescents* 9 à 18 ans  ,19,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,kcal,0,0,,3
-Énergie,Jeunes et adolescents* 9 à 18 ans  ,2377,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,30,1.4,27.3,32.8,kcal,1.5,0.1,,3
+Énergie,Jeunes et adolescents* 9 à 18 ans  ,3420,des,Confiserie - sucres et grignotines salées,,,,,269.9,9.8,250.7,289.1,kcal,13.2,0.4,,1
+Énergie,Jeunes et adolescents* 9 à 18 ans  ,1608,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,56.3,3.2,50.1,62.6,kcal,2.8,0.2,,2
+Énergie,Jeunes et adolescents* 9 à 18 ans  ,794,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,23.6,2.3,19,28.1,kcal,1.2,0.1,,3
+Énergie,Jeunes et adolescents* 9 à 18 ans  ,938,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,29.4,2.3,24.9,33.9,kcal,1.4,0.1,,3
+Énergie,Jeunes et adolescents* 9 à 18 ans  ,166,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,3.4,0.5,2.4,4.4,kcal,0.2,0,,3
+Énergie,Jeunes et adolescents* 9 à 18 ans  ,758,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,59.5,4.2,51.2,67.8,kcal,2.9,0.2,,2
+Énergie,Jeunes et adolescents* 9 à 18 ans  ,599,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,47.7,3.8,40.3,55.1,kcal,2.3,0.2,,3
+Énergie,Jeunes et adolescents* 9 à 18 ans  ,204,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,11.8,1.8,8.2,15.3,kcal,0.6,0.1,,3
+Énergie,Jeunes et adolescents* 9 à 18 ans  ,1279,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,84,7.3,69.8,98.3,kcal,4.1,0.3,,2
+Énergie,Jeunes et adolescents* 9 à 18 ans  ,2738,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,70.1,3.9,62.5,77.7,kcal,3.4,0.2,,2
+Énergie,Jeunes et adolescents* 9 à 18 ans  ,269,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,6.3,1.1,4.1,8.6,kcal,0.3,0.1,E,3
+Énergie,Jeunes et adolescents* 9 à 18 ans  ,1069,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,33.7,3.2,27.4,40,kcal,1.7,0.2,,3
+Énergie,Jeunes et adolescents* 9 à 18 ans  ,19,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,kcal,0,0,,3
+Énergie,Jeunes et adolescents* 9 à 18 ans  ,2377,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,30,1.4,27.3,32.8,kcal,1.5,0.1,,3
 Glucides,Jeunes et adolescents* 9 à 18 ans  ,19,des,Aliments pour bébés,,,,,0.1,0,0,0.2,g,0,0,,1
 Glucides,Jeunes et adolescents* 9 à 18 ans  ,17,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0.1,0,0,0.2,g,0,0,,2
-Glucides,Jeunes et adolescents* 9 à 18 ans  ,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,g,X,X,<10,2
+Glucides,Jeunes et adolescents* 9 à 18 ans  ,,des,Aliments pour bébés,des,Préparation pour nourrissons,,,X,X,,,g,X,X,<10,2
 Glucides,Jeunes et adolescents* 9 à 18 ans  ,3815,des,Boissons (excluant laits),,,,,36.5,1.1,34.3,38.7,g,13.6,0.4,,1
 Glucides,Jeunes et adolescents* 9 à 18 ans  ,93,des,Boissons (excluant laits),de l',Alcool,,,0.3,0.1,0.1,0.4,g,0.1,0,E,2
 Glucides,Jeunes et adolescents* 9 à 18 ans  ,890,des,Boissons (excluant laits),du,Café et thé,,,2.2,0.2,1.8,2.5,g,0.8,0.1,,2
@@ -6035,7 +6035,7 @@ Glucides,Jeunes et adolescents* 9 à 18 ans  ,3637,des,Boissons (excluant laits)
 Glucides,Jeunes et adolescents* 9 à 18 ans  ,3655,des,Produits laitiers et Boissons à base de plantes,,,,,21.2,0.6,20,22.3,g,7.9,0.2,,1
 Glucides,Jeunes et adolescents* 9 à 18 ans  ,2532,des,Produits laitiers et Boissons à base de plantes,des,Fromages,,,1.6,0.1,1.5,1.8,g,0.6,0,,2
 Glucides,Jeunes et adolescents* 9 à 18 ans  ,3315,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,17.2,0.5,16.1,18.3,g,6.4,0.2,,2
-Glucides,Jeunes et adolescents* 9 à 18 ans  ,575,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0.3,0.1,0.2,0.4,g,0.1,0,E,3
+Glucides,Jeunes et adolescents* 9 à 18 ans  ,575,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,0.3,0.1,0.2,0.4,g,0.1,0,E,3
 Glucides,Jeunes et adolescents* 9 à 18 ans  ,415,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait aromatisé,3.8,0.4,2.9,4.6,g,1.4,0.2,,3
 Glucides,Jeunes et adolescents* 9 à 18 ans  ,3128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait nature,12.6,0.4,11.9,13.3,g,4.7,0.1,,3
 Glucides,Jeunes et adolescents* 9 à 18 ans  ,98,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0.5,0.1,0.2,0.7,g,0.2,0,E,3
@@ -6054,8 +6054,8 @@ Glucides,Jeunes et adolescents* 9 à 18 ans  ,319,des,Poissons et fruits de mer,
 Glucides,Jeunes et adolescents* 9 à 18 ans  ,141,des,Poissons et fruits de mer,des,Mollusques et crustacés,,,0.1,0,0,0.1,g,0,0,,2
 Glucides,Jeunes et adolescents* 9 à 18 ans  ,3672,des,Fruits et légumes,,,,,40,0.9,38.2,41.8,g,14.9,0.3,,1
 Glucides,Jeunes et adolescents* 9 à 18 ans  ,2498,des,Fruits et légumes,des,Fruits,,,22.5,0.8,21,24,g,8.4,0.3,,2
-Glucides,Jeunes et adolescents* 9 à 18 ans  ,1041,des,Fruits et légumes,des,Fruits,des,Pommes,7.1,0.3,6.4,7.8,g,2.6,0.1,,3
-Glucides,Jeunes et adolescents* 9 à 18 ans  ,823,des,Fruits et légumes,des,Fruits,des,Bananes,5.2,0.3,4.6,5.8,g,1.9,0.1,,3
+Glucides,Jeunes et adolescents* 9 à 18 ans  ,1041,des,Fruits et légumes,des,Fruits,des,Pomme,7.1,0.3,6.4,7.8,g,2.6,0.1,,3
+Glucides,Jeunes et adolescents* 9 à 18 ans  ,823,des,Fruits et légumes,des,Fruits,des,Banane,5.2,0.3,4.6,5.8,g,1.9,0.1,,3
 Glucides,Jeunes et adolescents* 9 à 18 ans  ,743,des,Fruits et légumes,des,Fruits,des,Baies,1.7,0.1,1.4,1.9,g,0.6,0,,3
 Glucides,Jeunes et adolescents* 9 à 18 ans  ,73,des,Fruits et légumes,des,Fruits,des,Cerises,F,F,,,g,F,F,F,3
 Glucides,Jeunes et adolescents* 9 à 18 ans  ,514,des,Fruits et légumes,des,Fruits,des,Agrumes,1.6,0.1,1.4,1.9,g,0.6,0,,3
@@ -6080,11 +6080,11 @@ Glucides,Jeunes et adolescents* 9 à 18 ans  ,828,des,Produits céréaliers,des,
 Glucides,Jeunes et adolescents* 9 à 18 ans  ,1416,des,Produits céréaliers,des,Céréales pour déjeuner,,,12.7,0.6,11.5,13.9,g,4.7,0.2,,2
 Glucides,Jeunes et adolescents* 9 à 18 ans  ,794,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),6.7,0.5,5.7,7.6,g,2.5,0.2,,3
 Glucides,Jeunes et adolescents* 9 à 18 ans  ,700,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,6,0.4,5.3,6.8,g,2.3,0.1,,3
-Glucides,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,10.3,0.5,9.3,11.4,g,3.8,0.2,,2
-Glucides,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.4,0.1,0.2,0.6,g,0.2,0,E,3
-Glucides,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.3,0.1,0.2,0.5,g,0.1,0,E,3
-Glucides,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,4.4,0.4,3.7,5.2,g,1.6,0.1,,3
-Glucides,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
+Glucides,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,10.3,0.5,9.3,11.4,g,3.8,0.2,,2
+Glucides,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0.4,0.1,0.2,0.6,g,0.2,0,E,3
+Glucides,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.3,0.1,0.2,0.5,g,0.1,0,E,3
+Glucides,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,4.4,0.4,3.7,5.2,g,1.6,0.1,,3
+Glucides,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
 Glucides,Jeunes et adolescents* 9 à 18 ans  ,3103,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,46.2,1.2,43.8,48.5,g,17.2,0.4,,2
 Glucides,Jeunes et adolescents* 9 à 18 ans  ,2364,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,20.9,1,19,22.8,g,7.8,0.3,,3
 Glucides,Jeunes et adolescents* 9 à 18 ans  ,1020,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,12.8,0.8,11.2,14.3,g,4.8,0.3,,3
@@ -6115,23 +6115,23 @@ Glucides,Jeunes et adolescents* 9 à 18 ans  ,3619,des,Soupes - sauces - Épices
 Glucides,Jeunes et adolescents* 9 à 18 ans  ,1553,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,2.3,0.2,2,2.7,g,0.9,0.1,,2
 Glucides,Jeunes et adolescents* 9 à 18 ans  ,747,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,1.5,0.1,1.2,1.7,g,0.5,0.1,,2
 Glucides,Jeunes et adolescents* 9 à 18 ans  ,3417,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.7,0,0.6,0.8,g,0.3,0,,2
-Glucides,Jeunes et adolescents* 9 à 18 ans  ,3420,des,Confiseries - sucres et grignotines salées,,,,,44.5,1.4,41.7,47.3,g,16.6,0.5,,1
-Glucides,Jeunes et adolescents* 9 à 18 ans  ,1608,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,9.6,0.6,8.4,10.8,g,3.6,0.2,,2
-Glucides,Jeunes et adolescents* 9 à 18 ans  ,794,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,5.4,0.5,4.4,6.5,g,2,0.2,,3
-Glucides,Jeunes et adolescents* 9 à 18 ans  ,938,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,3.5,0.3,3,4.1,g,1.3,0.1,,3
-Glucides,Jeunes et adolescents* 9 à 18 ans  ,166,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0.6,0.1,0.4,0.8,g,0.2,0,E,3
-Glucides,Jeunes et adolescents* 9 à 18 ans  ,758,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,8.9,0.7,7.6,10.1,g,3.3,0.2,,2
-Glucides,Jeunes et adolescents* 9 à 18 ans  ,599,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,5.9,0.5,5,6.8,g,2.2,0.2,,3
-Glucides,Jeunes et adolescents* 9 à 18 ans  ,204,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,2.9,0.5,2,3.8,g,1.1,0.2,E,3
-Glucides,Jeunes et adolescents* 9 à 18 ans  ,1279,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,9.7,0.8,8.2,11.3,g,3.6,0.3,,2
-Glucides,Jeunes et adolescents* 9 à 18 ans  ,2738,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,16.4,0.7,14.9,17.8,g,6.1,0.3,,2
-Glucides,Jeunes et adolescents* 9 à 18 ans  ,269,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,1.6,0.3,1,2.1,g,0.6,0.1,E,3
-Glucides,Jeunes et adolescents* 9 à 18 ans  ,1069,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,7,0.5,6,8,g,2.6,0.2,,3
-Glucides,Jeunes et adolescents* 9 à 18 ans  ,19,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
-Glucides,Jeunes et adolescents* 9 à 18 ans  ,2377,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,7.8,0.4,7.1,8.5,g,2.9,0.1,,3
+Glucides,Jeunes et adolescents* 9 à 18 ans  ,3420,des,Confiserie - sucres et grignotines salées,,,,,44.5,1.4,41.7,47.3,g,16.6,0.5,,1
+Glucides,Jeunes et adolescents* 9 à 18 ans  ,1608,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,9.6,0.6,8.4,10.8,g,3.6,0.2,,2
+Glucides,Jeunes et adolescents* 9 à 18 ans  ,794,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,5.4,0.5,4.4,6.5,g,2,0.2,,3
+Glucides,Jeunes et adolescents* 9 à 18 ans  ,938,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,3.5,0.3,3,4.1,g,1.3,0.1,,3
+Glucides,Jeunes et adolescents* 9 à 18 ans  ,166,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0.6,0.1,0.4,0.8,g,0.2,0,E,3
+Glucides,Jeunes et adolescents* 9 à 18 ans  ,758,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,8.9,0.7,7.6,10.1,g,3.3,0.2,,2
+Glucides,Jeunes et adolescents* 9 à 18 ans  ,599,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,5.9,0.5,5,6.8,g,2.2,0.2,,3
+Glucides,Jeunes et adolescents* 9 à 18 ans  ,204,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,2.9,0.5,2,3.8,g,1.1,0.2,E,3
+Glucides,Jeunes et adolescents* 9 à 18 ans  ,1279,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,9.7,0.8,8.2,11.3,g,3.6,0.3,,2
+Glucides,Jeunes et adolescents* 9 à 18 ans  ,2738,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,16.4,0.7,14.9,17.8,g,6.1,0.3,,2
+Glucides,Jeunes et adolescents* 9 à 18 ans  ,269,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,1.6,0.3,1,2.1,g,0.6,0.1,E,3
+Glucides,Jeunes et adolescents* 9 à 18 ans  ,1069,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,7,0.5,6,8,g,2.6,0.2,,3
+Glucides,Jeunes et adolescents* 9 à 18 ans  ,19,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
+Glucides,Jeunes et adolescents* 9 à 18 ans  ,2377,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,7.8,0.4,7.1,8.5,g,2.9,0.1,,3
 Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,19,des,Aliments pour bébés,,,,,0,0,0,0,g,0.1,0,,1
 Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,17,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0,g,0.1,0,,2
-Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,g,X,X,<10,2
+Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,,des,Aliments pour bébés,des,Préparation pour nourrissons,,,X,X,,,g,X,X,<10,2
 Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,3815,des,Boissons (excluant laits),,,,,0.4,0,0.4,0.5,g,2.6,0.1,,1
 Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,93,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0,g,0,0,,2
 Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,890,des,Boissons (excluant laits),du,Café et thé,,,0,0,0,0,g,0,0,,2
@@ -6151,7 +6151,7 @@ Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,2532,des,Produits laiti
 Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,3315,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,0.2,0,0.2,0.2,g,1.2,0.1,,2
 Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,1440,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,0.1,0,0.1,0.1,g,0.6,0.1,,3
 Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,2530,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,0.1,0,0.1,0.1,g,0.5,0.1,,3
-Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,575,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,575,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,0,0,0,0,g,0,0,,3
 Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,98,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0,0,0,0,g,0.1,0,,3
 Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,1154,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0,0,0,0,g,0,0,,3
 Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,1072,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,0,0,0,0,g,0,0,,3
@@ -6168,8 +6168,8 @@ Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,319,des,Poissons et fru
 Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,141,des,Poissons et fruits de mer,des,Mollusques et crustacés,,,0,0,0,0,g,0,0,,2
 Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,3672,des,Fruits et légumes,,,,,5.7,0.1,5.4,5.9,g,34.7,0.6,,1
 Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,2498,des,Fruits et légumes,des,Fruits,,,2.8,0.1,2.6,3,g,17,0.5,,2
-Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,1041,des,Fruits et légumes,des,Fruits,des,Pommes,0.9,0,0.8,1,g,5.7,0.3,,3
-Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,823,des,Fruits et légumes,des,Fruits,des,Bananes,0.4,0,0.3,0.4,g,2.4,0.1,,3
+Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,1041,des,Fruits et légumes,des,Fruits,des,Pomme,0.9,0,0.8,1,g,5.7,0.3,,3
+Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,823,des,Fruits et légumes,des,Fruits,des,Banane,0.4,0,0.3,0.4,g,2.4,0.1,,3
 Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,743,des,Fruits et légumes,des,Fruits,des,Baies,0.4,0,0.3,0.5,g,2.6,0.3,,3
 Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,73,des,Fruits et légumes,des,Fruits,des,Cerises,0,0,0,0,g,0.1,0,,3
 Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,514,des,Fruits et légumes,des,Fruits,des,Agrumes,0.3,0,0.2,0.3,g,1.5,0.1,,3
@@ -6194,11 +6194,11 @@ Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,828,des,Produits céré
 Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,1416,des,Produits céréaliers,des,Céréales pour déjeuner,,,1.2,0.1,1.1,1.4,g,7.5,0.4,,2
 Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,794,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.4,0,0.4,0.5,g,2.6,0.2,,3
 Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,700,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.8,0.1,0.7,0.9,g,4.9,0.3,,3
-Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.5,0,0.5,0.6,g,3.3,0.2,,2
-Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0.1,0,,3
-Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.3,0,0.3,0.4,g,2.1,0.2,,3
-Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
+Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,0.5,0,0.5,0.6,g,3.3,0.2,,2
+Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0.1,0,,3
+Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,0.3,0,0.3,0.4,g,2.1,0.2,,3
+Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
 Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,3103,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,1.8,0.1,1.7,1.9,g,10.8,0.3,,2
 Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,2364,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.9,0,0.8,1,g,5.4,0.3,,3
 Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,1020,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.6,0,0.5,0.7,g,3.8,0.3,,3
@@ -6229,23 +6229,23 @@ Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,3619,des,Soupes - sauce
 Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,1553,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.2,0,0.2,0.2,g,1.1,0.1,,2
 Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,747,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0.1,0,0.1,0.2,g,0.8,0.1,,2
 Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,3417,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.2,0,0.2,0.3,g,1.5,0.1,,2
-Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,3420,des,Confiseries - sucres et grignotines salées,,,,,1.4,0.1,1.3,1.6,g,8.7,0.4,,1
-Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,1608,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,0.3,0,0.2,0.3,g,1.6,0.1,,2
-Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,794,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0,0,0,0,g,0.2,0,,3
-Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,938,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0.2,0,0.2,0.3,g,1.3,0.1,,3
-Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,166,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,758,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,0.2,0,0.1,0.2,g,1.1,0.1,,2
-Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,599,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.2,0,0.1,0.2,g,1,0.1,,3
-Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,204,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0.1,0,,3
-Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,1279,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0.8,0.1,0.7,0.9,g,4.9,0.3,,2
-Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,2738,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.2,0,0.1,0.2,g,1.1,0.2,,2
-Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,269,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0.2,0,,3
-Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,1069,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.2,0,0.1,0.2,g,0.9,0.2,,3
-Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,19,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,2377,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,3420,des,Confiserie - sucres et grignotines salées,,,,,1.4,0.1,1.3,1.6,g,8.7,0.4,,1
+Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,1608,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,0.3,0,0.2,0.3,g,1.6,0.1,,2
+Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,794,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,0,0,0,0,g,0.2,0,,3
+Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,938,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,0.2,0,0.2,0.3,g,1.3,0.1,,3
+Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,166,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,758,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,0.2,0,0.1,0.2,g,1.1,0.1,,2
+Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,599,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.2,0,0.1,0.2,g,1,0.1,,3
+Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,204,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0.1,0,,3
+Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,1279,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,0.8,0.1,0.7,0.9,g,4.9,0.3,,2
+Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,2738,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.2,0,0.1,0.2,g,1.1,0.2,,2
+Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,269,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0.2,0,,3
+Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,1069,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.2,0,0.1,0.2,g,0.9,0.2,,3
+Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,19,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans  ,2377,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
 Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,19,des,Aliments pour bébés,,,,,0.1,0,0,0.1,g,0,0,,1
 Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,17,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0.1,0,0,0.1,g,0,0,,2
-Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,g,X,X,<10,2
+Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,,des,Aliments pour bébés,des,Préparation pour nourrissons,,,X,X,,,g,X,X,<10,2
 Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,3815,des,Boissons (excluant laits),,,,,29.5,1,27.6,31.5,g,25.4,0.6,,1
 Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,93,des,Boissons (excluant laits),de l',Alcool,,,0.1,0,0,0.2,g,0.1,0,,2
 Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,890,des,Boissons (excluant laits),du,Café et thé,,,2,0.2,1.7,2.4,g,1.7,0.2,,2
@@ -6263,7 +6263,7 @@ Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,3637,des,Boissons (excluant l
 Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,3655,des,Produits laitiers et Boissons à base de plantes,,,,,19.5,0.5,18.5,20.5,g,16.7,0.4,,1
 Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,2532,des,Produits laitiers et Boissons à base de plantes,des,Fromages,,,0.6,0,0.5,0.6,g,0.5,0,,2
 Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,3315,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,16.7,0.5,15.8,17.7,g,14.4,0.4,,2
-Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,575,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,F,F,,,g,F,F,F,3
+Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,575,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,F,F,,,g,F,F,F,3
 Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,415,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait aromatisé,3,0.3,2.3,3.7,g,2.6,0.3,,3
 Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,3128,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait nature,13.2,0.4,12.5,13.9,g,11.4,0.3,,3
 Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,98,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0.4,0.1,0.2,0.6,g,0.3,0.1,E,3
@@ -6282,8 +6282,8 @@ Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,319,des,Poissons et fruits de
 Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,141,des,Poissons et fruits de mer,des,Mollusques et crustacés,,,0,0,0,0,g,0,0,,2
 Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,3672,des,Fruits et légumes,,,,,20.1,0.6,19,21.2,g,17.3,0.5,,1
 Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,2498,des,Fruits et légumes,des,Fruits,,,15.9,0.5,14.8,16.9,g,13.7,0.5,,2
-Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,1041,des,Fruits et légumes,des,Fruits,des,Pommes,5.4,0.3,4.9,5.9,g,4.6,0.2,,3
-Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,823,des,Fruits et légumes,des,Fruits,des,Bananes,2.8,0.2,2.5,3.1,g,2.4,0.1,,3
+Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,1041,des,Fruits et légumes,des,Fruits,des,Pomme,5.4,0.3,4.9,5.9,g,4.6,0.2,,3
+Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,823,des,Fruits et légumes,des,Fruits,des,Banane,2.8,0.2,2.5,3.1,g,2.4,0.1,,3
 Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,743,des,Fruits et légumes,des,Fruits,des,Baies,1.1,0.1,0.9,1.2,g,0.9,0.1,,3
 Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,73,des,Fruits et légumes,des,Fruits,des,Cerises,0.1,0,0.1,0.2,g,0.1,0,,3
 Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,514,des,Fruits et légumes,des,Fruits,des,Agrumes,1.3,0.1,1.1,1.5,g,1.1,0.1,,3
@@ -6308,11 +6308,11 @@ Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,828,des,Produits céréaliers
 Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,1416,des,Produits céréaliers,des,Céréales pour déjeuner,,,3.4,0.2,3,3.8,g,2.9,0.2,,2
 Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,794,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),2.3,0.2,1.9,2.7,g,2,0.2,,3
 Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,700,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,1.1,0.1,0.9,1.3,g,0.9,0.1,,3
-Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,4.6,0.2,4.1,5.1,g,4,0.2,,2
-Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,F,F,,,g,F,F,F,3
-Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0.1,0.2,g,0.1,0,,3
-Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,2,0.2,1.6,2.3,g,1.7,0.1,,3
-Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
+Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,4.6,0.2,4.1,5.1,g,4,0.2,,2
+Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,F,F,,,g,F,F,F,3
+Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0.1,0.2,g,0.1,0,,3
+Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,2,0.2,1.6,2.3,g,1.7,0.1,,3
+Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
 Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,3103,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,0.6,0,0.6,0.7,g,0.5,0,,2
 Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,2364,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.2,0,0.2,0.2,g,0.2,0,,3
 Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,1020,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.4,0,0.3,0.5,g,0.3,0,,3
@@ -6343,23 +6343,23 @@ Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,3619,des,Soupes - sauces - É
 Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,1553,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,1.5,0.1,1.3,1.7,g,1.3,0.1,,2
 Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,747,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0.2,0,0.1,0.3,g,0.2,0,,2
 Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,3417,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.2,0,0.1,0.2,g,0.1,0,,2
-Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,3420,des,Confiseries - sucres et grignotines salées,,,,,29.5,1,27.5,31.4,g,25.3,0.7,,1
-Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,1608,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,6.8,0.4,5.9,7.7,g,5.9,0.4,,2
-Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,794,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,3.4,0.4,2.7,4.2,g,3,0.3,,3
-Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,938,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,2.9,0.3,2.4,3.4,g,2.5,0.2,,3
-Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,166,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0.5,0.1,0.3,0.6,g,0.4,0.1,E,3
-Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,758,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,7.9,0.6,6.6,9.1,g,6.8,0.5,,2
-Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,599,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,5.1,0.4,4.3,5.9,g,4.4,0.3,,3
-Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,204,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,2.8,0.5,1.9,3.7,g,2.4,0.4,E,3
-Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,1279,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0.3,0,0.3,0.4,g,0.3,0,,2
-Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,2738,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,14.4,0.6,13.2,15.7,g,12.4,0.5,,2
-Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,269,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,1.1,0.2,0.7,1.5,g,1,0.2,E,3
-Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,1069,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,5.6,0.4,4.7,6.4,g,4.8,0.3,,3
-Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,19,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
-Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,2377,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,7.7,0.4,7,8.4,g,6.7,0.3,,3
+Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,3420,des,Confiserie - sucres et grignotines salées,,,,,29.5,1,27.5,31.4,g,25.3,0.7,,1
+Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,1608,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,6.8,0.4,5.9,7.7,g,5.9,0.4,,2
+Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,794,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,3.4,0.4,2.7,4.2,g,3,0.3,,3
+Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,938,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,2.9,0.3,2.4,3.4,g,2.5,0.2,,3
+Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,166,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0.5,0.1,0.3,0.6,g,0.4,0.1,E,3
+Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,758,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,7.9,0.6,6.6,9.1,g,6.8,0.5,,2
+Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,599,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,5.1,0.4,4.3,5.9,g,4.4,0.3,,3
+Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,204,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,2.8,0.5,1.9,3.7,g,2.4,0.4,E,3
+Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,1279,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,0.3,0,0.3,0.4,g,0.3,0,,2
+Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,2738,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,14.4,0.6,13.2,15.7,g,12.4,0.5,,2
+Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,269,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,1.1,0.2,0.7,1.5,g,1,0.2,E,3
+Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,1069,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,5.6,0.4,4.7,6.4,g,4.8,0.3,,3
+Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,19,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
+Sucres totaux,Jeunes et adolescents* 9 à 18 ans  ,2377,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,7.7,0.4,7,8.4,g,6.7,0.3,,3
 Protéine,Jeunes et adolescents* 9 à 18 ans  ,19,des,Aliments pour bébés,,,,,0,0,0,0,g,0,0,,1
 Protéine,Jeunes et adolescents* 9 à 18 ans  ,17,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0,g,0,0,,2
-Protéine,Jeunes et adolescents* 9 à 18 ans  ,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,g,X,X,<10,2
+Protéine,Jeunes et adolescents* 9 à 18 ans  ,,des,Aliments pour bébés,des,Préparation pour nourrissons,,,X,X,,,g,X,X,<10,2
 Protéine,Jeunes et adolescents* 9 à 18 ans  ,3815,des,Boissons (excluant laits),,,,,0.8,0,0.8,0.9,g,1.1,0,,1
 Protéine,Jeunes et adolescents* 9 à 18 ans  ,93,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0,g,0,0,,2
 Protéine,Jeunes et adolescents* 9 à 18 ans  ,890,des,Boissons (excluant laits),du,Café et thé,,,0,0,0,0,g,0,0,,2
@@ -6379,7 +6379,7 @@ Protéine,Jeunes et adolescents* 9 à 18 ans  ,2532,des,Produits laitiers et Boi
 Protéine,Jeunes et adolescents* 9 à 18 ans  ,3315,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,9.8,0.3,9.3,10.3,g,12.4,0.3,,2
 Protéine,Jeunes et adolescents* 9 à 18 ans  ,1440,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,2.8,0.2,2.4,3.2,g,3.5,0.2,,3
 Protéine,Jeunes et adolescents* 9 à 18 ans  ,2530,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,5.2,0.2,4.8,5.6,g,6.6,0.2,,3
-Protéine,Jeunes et adolescents* 9 à 18 ans  ,575,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0.2,0,0.1,0.2,g,0.2,0,,3
+Protéine,Jeunes et adolescents* 9 à 18 ans  ,575,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,0.2,0,0.1,0.2,g,0.2,0,,3
 Protéine,Jeunes et adolescents* 9 à 18 ans  ,98,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0.1,0,0,0.1,g,0.1,0,,3
 Protéine,Jeunes et adolescents* 9 à 18 ans  ,1154,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0.6,0.1,0.5,0.8,g,0.8,0.1,E,3
 Protéine,Jeunes et adolescents* 9 à 18 ans  ,1072,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,0.9,0.1,0.8,1.1,g,1.2,0.1,,3
@@ -6396,8 +6396,8 @@ Protéine,Jeunes et adolescents* 9 à 18 ans  ,319,des,Poissons et fruits de mer
 Protéine,Jeunes et adolescents* 9 à 18 ans  ,141,des,Poissons et fruits de mer,des,Mollusques et crustacés,,,0.4,0.1,0.2,0.6,g,0.5,0.1,E,2
 Protéine,Jeunes et adolescents* 9 à 18 ans  ,3672,des,Fruits et légumes,,,,,3.6,0.1,3.4,3.8,g,4.5,0.1,,1
 Protéine,Jeunes et adolescents* 9 à 18 ans  ,2498,des,Fruits et légumes,des,Fruits,,,1,0,0.9,1.1,g,1.2,0,,2
-Protéine,Jeunes et adolescents* 9 à 18 ans  ,1041,des,Fruits et légumes,des,Fruits,des,Pommes,0.1,0,0.1,0.1,g,0.2,0,,3
-Protéine,Jeunes et adolescents* 9 à 18 ans  ,823,des,Fruits et légumes,des,Fruits,des,Bananes,0.2,0,0.2,0.3,g,0.3,0,,3
+Protéine,Jeunes et adolescents* 9 à 18 ans  ,1041,des,Fruits et légumes,des,Fruits,des,Pomme,0.1,0,0.1,0.1,g,0.2,0,,3
+Protéine,Jeunes et adolescents* 9 à 18 ans  ,823,des,Fruits et légumes,des,Fruits,des,Banane,0.2,0,0.2,0.3,g,0.3,0,,3
 Protéine,Jeunes et adolescents* 9 à 18 ans  ,743,des,Fruits et légumes,des,Fruits,des,Baies,0.1,0,0.1,0.1,g,0.1,0,,3
 Protéine,Jeunes et adolescents* 9 à 18 ans  ,73,des,Fruits et légumes,des,Fruits,des,Cerises,0,0,0,0,g,0,0,,3
 Protéine,Jeunes et adolescents* 9 à 18 ans  ,514,des,Fruits et légumes,des,Fruits,des,Agrumes,0.1,0,0.1,0.1,g,0.2,0,,3
@@ -6422,11 +6422,11 @@ Protéine,Jeunes et adolescents* 9 à 18 ans  ,828,des,Produits céréaliers,des
 Protéine,Jeunes et adolescents* 9 à 18 ans  ,1416,des,Produits céréaliers,des,Céréales pour déjeuner,,,1.4,0.1,1.3,1.6,g,1.8,0.1,,2
 Protéine,Jeunes et adolescents* 9 à 18 ans  ,794,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.5,0,0.5,0.6,g,0.7,0.1,,3
 Protéine,Jeunes et adolescents* 9 à 18 ans  ,700,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.9,0.1,0.8,1,g,1.1,0.1,,3
-Protéine,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.8,0,0.8,0.9,g,1.1,0.1,,2
-Protéine,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0,0,,3
-Protéine,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
-Protéine,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.4,0,0.3,0.4,g,0.5,0,,3
-Protéine,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
+Protéine,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,0.8,0,0.8,0.9,g,1.1,0.1,,2
+Protéine,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0,0,,3
+Protéine,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0,0,,3
+Protéine,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,0.4,0,0.3,0.4,g,0.5,0,,3
+Protéine,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
 Protéine,Jeunes et adolescents* 9 à 18 ans  ,3103,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,7.2,0.2,6.8,7.6,g,9.1,0.2,,2
 Protéine,Jeunes et adolescents* 9 à 18 ans  ,2364,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,3.5,0.2,3.2,3.8,g,4.4,0.2,,3
 Protéine,Jeunes et adolescents* 9 à 18 ans  ,1020,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,2.5,0.2,2.2,2.8,g,3.1,0.2,,3
@@ -6457,23 +6457,23 @@ Protéine,Jeunes et adolescents* 9 à 18 ans  ,3619,des,Soupes - sauces - Épice
 Protéine,Jeunes et adolescents* 9 à 18 ans  ,1553,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.3,0,0.3,0.4,g,0.4,0,,2
 Protéine,Jeunes et adolescents* 9 à 18 ans  ,747,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0.4,0,0.3,0.5,g,0.5,0,,2
 Protéine,Jeunes et adolescents* 9 à 18 ans  ,3417,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.2,0,0.2,0.2,g,0.3,0,,2
-Protéine,Jeunes et adolescents* 9 à 18 ans  ,3420,des,Confiseries - sucres et grignotines salées,,,,,2.7,0.1,2.5,3,g,3.4,0.2,,1
-Protéine,Jeunes et adolescents* 9 à 18 ans  ,1608,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,0.5,0,0.4,0.5,g,0.6,0,,2
-Protéine,Jeunes et adolescents* 9 à 18 ans  ,794,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0,0,0,0.1,g,0.1,0,,3
-Protéine,Jeunes et adolescents* 9 à 18 ans  ,938,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0.4,0,0.3,0.5,g,0.5,0,,3
-Protéine,Jeunes et adolescents* 9 à 18 ans  ,166,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0,0,0,0.1,g,0.1,0,,3
-Protéine,Jeunes et adolescents* 9 à 18 ans  ,758,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,0.9,0.1,0.8,1.1,g,1.2,0.1,,2
-Protéine,Jeunes et adolescents* 9 à 18 ans  ,599,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.9,0.1,0.8,1,g,1.1,0.1,,3
-Protéine,Jeunes et adolescents* 9 à 18 ans  ,204,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0.1,g,0.1,0,,3
-Protéine,Jeunes et adolescents* 9 à 18 ans  ,1279,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,1.2,0.1,1,1.3,g,1.5,0.1,,2
-Protéine,Jeunes et adolescents* 9 à 18 ans  ,2738,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.2,0,0.1,0.2,g,0.2,0,,2
-Protéine,Jeunes et adolescents* 9 à 18 ans  ,269,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0,0,,3
-Protéine,Jeunes et adolescents* 9 à 18 ans  ,1069,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.1,0,0.1,0.2,g,0.2,0,,3
-Protéine,Jeunes et adolescents* 9 à 18 ans  ,19,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
-Protéine,Jeunes et adolescents* 9 à 18 ans  ,2377,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
+Protéine,Jeunes et adolescents* 9 à 18 ans  ,3420,des,Confiserie - sucres et grignotines salées,,,,,2.7,0.1,2.5,3,g,3.4,0.2,,1
+Protéine,Jeunes et adolescents* 9 à 18 ans  ,1608,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,0.5,0,0.4,0.5,g,0.6,0,,2
+Protéine,Jeunes et adolescents* 9 à 18 ans  ,794,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,0,0,0,0.1,g,0.1,0,,3
+Protéine,Jeunes et adolescents* 9 à 18 ans  ,938,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,0.4,0,0.3,0.5,g,0.5,0,,3
+Protéine,Jeunes et adolescents* 9 à 18 ans  ,166,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0,0,0,0.1,g,0.1,0,,3
+Protéine,Jeunes et adolescents* 9 à 18 ans  ,758,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,0.9,0.1,0.8,1.1,g,1.2,0.1,,2
+Protéine,Jeunes et adolescents* 9 à 18 ans  ,599,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.9,0.1,0.8,1,g,1.1,0.1,,3
+Protéine,Jeunes et adolescents* 9 à 18 ans  ,204,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0.1,g,0.1,0,,3
+Protéine,Jeunes et adolescents* 9 à 18 ans  ,1279,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,1.2,0.1,1,1.3,g,1.5,0.1,,2
+Protéine,Jeunes et adolescents* 9 à 18 ans  ,2738,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.2,0,0.1,0.2,g,0.2,0,,2
+Protéine,Jeunes et adolescents* 9 à 18 ans  ,269,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0,0,,3
+Protéine,Jeunes et adolescents* 9 à 18 ans  ,1069,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.1,0,0.1,0.2,g,0.2,0,,3
+Protéine,Jeunes et adolescents* 9 à 18 ans  ,19,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
+Protéine,Jeunes et adolescents* 9 à 18 ans  ,2377,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
 Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,19,des,Aliments pour bébés,,,,,0,0,0,0,g,0,0,,1
 Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,17,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0,g,0,0,,2
-Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,g,X,X,<10,2
+Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,,des,Aliments pour bébés,des,Préparation pour nourrissons,,,X,X,,,g,X,X,<10,2
 Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,3815,des,Boissons (excluant laits),,,,,0.3,0,0.3,0.3,g,0.4,0,,1
 Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,93,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0,g,0,0,,2
 Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,890,des,Boissons (excluant laits),du,Café et thé,,,0,0,0,0,g,0,0,,2
@@ -6493,7 +6493,7 @@ Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,2532,des,Produits laitiers e
 Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,3315,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,5.9,0.2,5.6,6.2,g,8,0.2,,2
 Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,1440,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,0.8,0.1,0.7,0.9,g,1.1,0.1,,3
 Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,2530,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,3.1,0.1,2.9,3.4,g,4.2,0.2,,3
-Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,575,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0.9,0.1,0.7,1.1,g,1.2,0.1,,3
+Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,575,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,0.9,0.1,0.7,1.1,g,1.2,0.1,,3
 Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,98,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0.1,0,0,0.1,g,0.1,0,,3
 Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,1154,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0,0,0,0,g,0,0,,3
 Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,1072,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,1,0.1,0.8,1.1,g,1.3,0.1,,3
@@ -6510,8 +6510,8 @@ Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,319,des,Poissons et fruits d
 Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,141,des,Poissons et fruits de mer,des,Mollusques et crustacés,,,0,0,0,0,g,0,0,,2
 Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,3672,des,Fruits et légumes,,,,,1.9,0.1,1.7,2.1,g,2.6,0.1,,1
 Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,2498,des,Fruits et légumes,des,Fruits,,,0.5,0,0.4,0.5,g,0.6,0,,2
-Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,1041,des,Fruits et légumes,des,Fruits,des,Pommes,0.1,0,0.1,0.1,g,0.1,0,,3
-Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,823,des,Fruits et légumes,des,Fruits,des,Bananes,0.1,0,0.1,0.1,g,0.1,0,,3
+Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,1041,des,Fruits et légumes,des,Fruits,des,Pomme,0.1,0,0.1,0.1,g,0.1,0,,3
+Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,823,des,Fruits et légumes,des,Fruits,des,Banane,0.1,0,0.1,0.1,g,0.1,0,,3
 Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,743,des,Fruits et légumes,des,Fruits,des,Baies,0.1,0,0,0.1,g,0.1,0,,3
 Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,73,des,Fruits et légumes,des,Fruits,des,Cerises,0,0,0,0,g,0,0,,3
 Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,514,des,Fruits et légumes,des,Fruits,des,Agrumes,0,0,0,0,g,0,0,,3
@@ -6536,11 +6536,11 @@ Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,828,des,Produits céréalier
 Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,1416,des,Produits céréaliers,des,Céréales pour déjeuner,,,0.8,0,0.7,0.9,g,1.1,0.1,,2
 Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,794,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.3,0,0.2,0.3,g,0.4,0,,3
 Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,700,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.5,0,0.4,0.6,g,0.7,0.1,,3
-Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,2.7,0.1,2.4,2.9,g,3.6,0.2,,2
-Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0.1,0.2,g,0.1,0,,3
-Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.1,g,0.1,0,,3
-Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,1,0.1,0.8,1.2,g,1.4,0.1,,3
-Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
+Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,2.7,0.1,2.4,2.9,g,3.6,0.2,,2
+Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0.1,0,0.1,0.2,g,0.1,0,,3
+Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.1,g,0.1,0,,3
+Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,1,0.1,0.8,1.2,g,1.4,0.1,,3
+Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
 Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,3103,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,1.7,0.1,1.6,1.8,g,2.3,0.1,,2
 Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,2364,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.7,0,0.7,0.8,g,1,0,,3
 Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,1020,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.8,0.1,0.7,0.9,g,1.1,0.1,,3
@@ -6571,23 +6571,23 @@ Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,3619,des,Soupes - sauces - �
 Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,1553,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.4,0.1,0.3,0.5,g,0.6,0.1,E,2
 Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,747,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0.4,0,0.3,0.4,g,0.5,0.1,,2
 Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,3417,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.1,0,0.1,0.2,g,0.2,0,,2
-Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,3420,des,Confiseries - sucres et grignotines salées,,,,,9.5,0.5,8.5,10.5,g,12.9,0.6,,1
-Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,1608,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,1.9,0.1,1.7,2.1,g,2.6,0.2,,2
-Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,794,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0.2,0,0.1,0.3,g,0.3,0,,3
-Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,938,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,1.6,0.1,1.4,1.8,g,2.2,0.2,,3
-Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,166,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0.1,0,0.1,0.1,g,0.1,0,,3
-Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,758,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,2.3,0.2,2,2.7,g,3.2,0.3,,2
-Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,599,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,2.3,0.2,1.9,2.7,g,3.1,0.3,,3
-Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,204,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0,0,,3
-Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,1279,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,4.7,0.4,3.8,5.5,g,6.3,0.6,,2
-Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,2738,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.6,0.2,0.3,1,g,0.9,0.2,E,2
-Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,269,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0,0,,3
-Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,1069,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.6,0.2,0.3,1,g,0.9,0.2,E,3
-Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,19,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
-Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,2377,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
+Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,3420,des,Confiserie - sucres et grignotines salées,,,,,9.5,0.5,8.5,10.5,g,12.9,0.6,,1
+Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,1608,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,1.9,0.1,1.7,2.1,g,2.6,0.2,,2
+Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,794,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,0.2,0,0.1,0.3,g,0.3,0,,3
+Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,938,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,1.6,0.1,1.4,1.8,g,2.2,0.2,,3
+Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,166,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0.1,0,0.1,0.1,g,0.1,0,,3
+Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,758,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,2.3,0.2,2,2.7,g,3.2,0.3,,2
+Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,599,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,2.3,0.2,1.9,2.7,g,3.1,0.3,,3
+Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,204,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0,0,,3
+Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,1279,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,4.7,0.4,3.8,5.5,g,6.3,0.6,,2
+Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,2738,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.6,0.2,0.3,1,g,0.9,0.2,E,2
+Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,269,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0,0,,3
+Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,1069,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.6,0.2,0.3,1,g,0.9,0.2,E,3
+Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,19,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
+Lipides totaux,Jeunes et adolescents* 9 à 18 ans  ,2377,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
 Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,19,des,Aliments pour bébés,,,,,0,0,0,0,g,0,0,,1
 Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,17,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0,g,0,0,,2
-Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,g,X,X,<10,2
+Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,,des,Aliments pour bébés,des,Préparation pour nourrissons,,,X,X,,,g,X,X,<10,2
 Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,3815,des,Boissons (excluant laits),,,,,0.1,0,0.1,0.1,g,0.3,0,,1
 Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,93,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0,g,0,0,,2
 Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,890,des,Boissons (excluant laits),du,Café et thé,,,0,0,0,0,g,0,0,,2
@@ -6607,7 +6607,7 @@ Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,2532,des,Produits lait
 Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,3315,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,3.6,0.1,3.4,3.8,g,14,0.4,,2
 Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,1440,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,0.5,0,0.5,0.6,g,2,0.1,,3
 Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,2530,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,2,0.1,1.8,2.1,g,7.7,0.3,,3
-Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,575,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0.5,0.1,0.4,0.7,g,2.1,0.2,E,3
+Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,575,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,0.5,0.1,0.4,0.7,g,2.1,0.2,E,3
 Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,98,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0,0,0,0,g,0,0,,3
 Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,1154,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0,0,0,0,g,0,0,,3
 Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,1072,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,0.6,0.1,0.5,0.7,g,2.1,0.2,E,3
@@ -6624,8 +6624,8 @@ Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,319,des,Poissons et fr
 Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,141,des,Poissons et fruits de mer,des,Mollusques et crustacés,,,0,0,0,0,g,0,0,,2
 Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,3672,des,Fruits et légumes,,,,,0.3,0,0.3,0.4,g,1.3,0.1,,1
 Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,2498,des,Fruits et légumes,des,Fruits,,,0.1,0,0.1,0.1,g,0.3,0,,2
-Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,1041,des,Fruits et légumes,des,Fruits,des,Pommes,0,0,0,0,g,0.1,0,,3
-Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,823,des,Fruits et légumes,des,Fruits,des,Bananes,0,0,0,0,g,0.1,0,,3
+Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,1041,des,Fruits et légumes,des,Fruits,des,Pomme,0,0,0,0,g,0.1,0,,3
+Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,823,des,Fruits et légumes,des,Fruits,des,Banane,0,0,0,0,g,0.1,0,,3
 Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,743,des,Fruits et légumes,des,Fruits,des,Baies,0,0,0,0,g,0,0,,3
 Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,73,des,Fruits et légumes,des,Fruits,des,Cerises,0,0,0,0,g,0,0,,3
 Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,514,des,Fruits et légumes,des,Fruits,des,Agrumes,0,0,0,0,g,0,0,,3
@@ -6650,11 +6650,11 @@ Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,828,des,Produits cér�
 Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,1416,des,Produits céréaliers,des,Céréales pour déjeuner,,,0.2,0,0.2,0.3,g,0.9,0.1,,2
 Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,794,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.1,0,0.1,0.1,g,0.2,0,,3
 Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,700,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.2,0,0.1,0.2,g,0.7,0.1,,3
-Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.8,0,0.7,0.9,g,3.1,0.2,,2
-Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0.1,0,,3
-Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0.1,0,,3
-Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.3,0,0.2,0.3,g,1,0.1,,3
-Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
+Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,0.8,0,0.7,0.9,g,3.1,0.2,,2
+Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,g,0.1,0,,3
+Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,g,0.1,0,,3
+Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,0.3,0,0.2,0.3,g,1,0.1,,3
+Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,g,X,X,<10,3
 Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,3103,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,0.3,0,0.3,0.3,g,1.1,0,,2
 Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,2364,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.1,0,0.1,0.1,g,0.4,0,,3
 Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,1020,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.1,0,0.1,0.2,g,0.5,0,,3
@@ -6685,23 +6685,23 @@ Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,3619,des,Soupes - sauc
 Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,1553,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.2,0,0.1,0.3,g,0.7,0.2,,2
 Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,747,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0.1,0,0.1,0.2,g,0.5,0.1,,2
 Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,3417,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0,0,0,0,g,0.1,0,,2
-Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,3420,des,Confiseries - sucres et grignotines salées,,,,,3.8,0.2,3.3,4.2,g,14.5,0.7,,1
-Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,1608,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,1.1,0.1,0.9,1.2,g,4.2,0.3,,2
-Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,794,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0.1,0,0.1,0.1,g,0.4,0.1,,3
-Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,938,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,1,0.1,0.8,1.1,g,3.7,0.3,,3
-Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,166,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0,0,0,0,g,0.1,0,,3
-Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,758,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,1.4,0.1,1.2,1.6,g,5.4,0.4,,2
-Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,599,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,1.4,0.1,1.2,1.6,g,5.4,0.4,,3
-Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,204,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0,0,,3
-Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,1279,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0.7,0.1,0.6,0.8,g,2.6,0.2,,2
-Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,2738,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.6,0.2,0.3,0.9,g,2.3,0.6,E,2
-Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,269,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0,0,,3
-Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,1069,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.6,0.2,0.3,0.9,g,2.3,0.6,E,3
-Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,19,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
-Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,2377,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
+Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,3420,des,Confiserie - sucres et grignotines salées,,,,,3.8,0.2,3.3,4.2,g,14.5,0.7,,1
+Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,1608,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,1.1,0.1,0.9,1.2,g,4.2,0.3,,2
+Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,794,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,0.1,0,0.1,0.1,g,0.4,0.1,,3
+Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,938,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,1,0.1,0.8,1.1,g,3.7,0.3,,3
+Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,166,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0,0,0,0,g,0.1,0,,3
+Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,758,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,1.4,0.1,1.2,1.6,g,5.4,0.4,,2
+Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,599,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,1.4,0.1,1.2,1.6,g,5.4,0.4,,3
+Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,204,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,g,0,0,,3
+Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,1279,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,0.7,0.1,0.6,0.8,g,2.6,0.2,,2
+Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,2738,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.6,0.2,0.3,0.9,g,2.3,0.6,E,2
+Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,269,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,g,0,0,,3
+Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,1069,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.6,0.2,0.3,0.9,g,2.3,0.6,E,3
+Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,19,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,g,0,0,,3
+Acides gras saturés,Jeunes et adolescents* 9 à 18 ans  ,2377,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,g,0,0,,3
 Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,19,des,Aliments pour bébés,,,,,0,0,0,0,mcg,0,0,,1
 Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,17,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,mcg,X,X,<10,2
+Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,,des,Aliments pour bébés,des,Préparation pour nourrissons,,,X,X,,,mcg,X,X,<10,2
 Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,3815,des,Boissons (excluant laits),,,,,0.1,0,0.1,0.1,mcg,1.3,0.2,,1
 Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,93,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0,mcg,0,0,,2
 Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,890,des,Boissons (excluant laits),du,Café et thé,,,0,0,0,0,mcg,0,0,,2
@@ -6721,7 +6721,7 @@ Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,2532,des,Produits laitiers et Bo
 Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,3315,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,3,0.1,2.8,3.1,mcg,52.7,1.1,,2
 Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,1440,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,0.8,0.1,0.7,0.9,mcg,14.8,0.9,,3
 Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,2530,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,1.6,0.1,1.5,1.7,mcg,28,1,,3
-Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,575,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0,0,0,0,mcg,0.4,0.1,,3
+Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,575,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,0,0,0,0,mcg,0.4,0.1,,3
 Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,98,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0.1,0,0,0.1,mcg,1,0.2,,3
 Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,1154,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0.2,0,0.1,0.2,mcg,3.2,0.4,,3
 Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,1072,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,0.3,0,0.2,0.3,mcg,5.2,0.5,,3
@@ -6738,8 +6738,8 @@ Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,319,des,Poissons et fruits de me
 Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,141,des,Poissons et fruits de mer,des,Mollusques et crustacés,,,0,0,0,0,mcg,0,0,,2
 Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,3672,des,Fruits et légumes,,,,,0,0,0,0,mcg,0.1,0,,1
 Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,2498,des,Fruits et légumes,des,Fruits,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,1041,des,Fruits et légumes,des,Fruits,des,Pommes,0,0,0,0,mcg,0,0,,3
-Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,823,des,Fruits et légumes,des,Fruits,des,Bananes,0,0,0,0,mcg,0,0,,3
+Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,1041,des,Fruits et légumes,des,Fruits,des,Pomme,0,0,0,0,mcg,0,0,,3
+Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,823,des,Fruits et légumes,des,Fruits,des,Banane,0,0,0,0,mcg,0,0,,3
 Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,743,des,Fruits et légumes,des,Fruits,des,Baies,0,0,0,0,mcg,0,0,,3
 Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,73,des,Fruits et légumes,des,Fruits,des,Cerises,0,0,0,0,mcg,0,0,,3
 Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,514,des,Fruits et légumes,des,Fruits,des,Agrumes,0,0,0,0,mcg,0,0,,3
@@ -6764,11 +6764,11 @@ Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,828,des,Produits céréaliers,de
 Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,1416,des,Produits céréaliers,des,Céréales pour déjeuner,,,0.2,0,0.1,0.2,mcg,2.7,0.3,,2
 Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,794,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),0.1,0,0.1,0.2,mcg,2.5,0.3,,3
 Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,700,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0,0,0,0,mcg,0.2,0,,3
-Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mcg,0,0,,3
-Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mcg,0,0,,3
-Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0,0,0,0,mcg,0,0,,3
-Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mcg,X,X,<10,3
+Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mcg,0,0,,3
+Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mcg,0,0,,3
+Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,0,0,0,0,mcg,0,0,,3
+Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mcg,X,X,<10,3
 Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,3103,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,0,0,0,0,mcg,0.1,0,,2
 Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,2364,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0,0,0,0,mcg,0,0,,3
 Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,1020,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0,0,0,0,mcg,0.1,0,,3
@@ -6799,23 +6799,23 @@ Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,3619,des,Soupes - sauces - Épic
 Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,1553,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0,0,0,0,mcg,0.5,0.1,,2
 Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,747,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0,0,0,0,mcg,0.2,0,,2
 Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,3417,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,3420,des,Confiseries - sucres et grignotines salées,,,,,0,0,0,0.1,mcg,0.9,0.1,,1
-Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,1608,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,794,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0,0,0,0,mcg,0,0,,3
-Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,938,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0,0,0,0,mcg,0,0,,3
-Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,166,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0,0,0,0,mcg,0,0,,3
-Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,758,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,0,0,0,0,mcg,0.7,0.1,,2
-Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,599,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0,0,0,0,mcg,0.7,0.1,,3
-Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,204,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,mcg,0,0,,3
-Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,1279,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0,0,0,0,mcg,0,0,,2
-Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,2738,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0,0,0,0,mcg,0.1,0,,2
-Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,269,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,mcg,0,0,,3
-Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,1069,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0,0,0,0,mcg,0.1,0,,3
-Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,19,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mcg,0,0,,3
-Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,2377,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,mcg,0,0,,3
+Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,3420,des,Confiserie - sucres et grignotines salées,,,,,0,0,0,0.1,mcg,0.9,0.1,,1
+Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,1608,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,794,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,0,0,0,0,mcg,0,0,,3
+Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,938,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,0,0,0,0,mcg,0,0,,3
+Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,166,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0,0,0,0,mcg,0,0,,3
+Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,758,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,0,0,0,0,mcg,0.7,0.1,,2
+Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,599,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0,0,0,0,mcg,0.7,0.1,,3
+Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,204,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,mcg,0,0,,3
+Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,1279,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,0,0,0,0,mcg,0,0,,2
+Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,2738,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0,0,0,0,mcg,0.1,0,,2
+Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,269,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,mcg,0,0,,3
+Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,1069,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0,0,0,0,mcg,0.1,0,,3
+Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,19,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mcg,0,0,,3
+Vitamine D,Jeunes et adolescents* 9 à 18 ans  ,2377,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,mcg,0,0,,3
 Folate,Jeunes et adolescents* 9 à 18 ans  ,19,des,Aliments pour bébés,,,,,0.1,0,0,0.1,mcg (ÉFA),0,0,,1
 Folate,Jeunes et adolescents* 9 à 18 ans  ,17,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0.1,0,0,0.1,mcg (ÉFA),0,0,,2
-Folate,Jeunes et adolescents* 9 à 18 ans  ,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,mcg (ÉFA),X,X,<10,2
+Folate,Jeunes et adolescents* 9 à 18 ans  ,,des,Aliments pour bébés,des,Préparation pour nourrissons,,,X,X,,,mcg (ÉFA),X,X,<10,2
 Folate,Jeunes et adolescents* 9 à 18 ans  ,3815,des,Boissons (excluant laits),,,,,18.4,0.8,16.7,20,mcg (ÉFA),4.2,0.2,,1
 Folate,Jeunes et adolescents* 9 à 18 ans  ,93,des,Boissons (excluant laits),de l',Alcool,,,0.3,0.1,0.2,0.5,mcg (ÉFA),0.1,0,E,2
 Folate,Jeunes et adolescents* 9 à 18 ans  ,890,des,Boissons (excluant laits),du,Café et thé,,,1.4,0.1,1.1,1.7,mcg (ÉFA),0.3,0,,2
@@ -6835,7 +6835,7 @@ Folate,Jeunes et adolescents* 9 à 18 ans  ,2532,des,Produits laitiers et Boisso
 Folate,Jeunes et adolescents* 9 à 18 ans  ,3315,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,15.1,0.4,14.3,15.9,mcg (ÉFA),3.5,0.1,,2
 Folate,Jeunes et adolescents* 9 à 18 ans  ,1440,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,4.2,0.3,3.6,4.7,mcg (ÉFA),1,0.1,,3
 Folate,Jeunes et adolescents* 9 à 18 ans  ,2530,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,7.5,0.3,6.9,8.1,mcg (ÉFA),1.7,0.1,,3
-Folate,Jeunes et adolescents* 9 à 18 ans  ,575,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0.3,0,0.2,0.3,mcg (ÉFA),0.1,0,,3
+Folate,Jeunes et adolescents* 9 à 18 ans  ,575,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,0.3,0,0.2,0.3,mcg (ÉFA),0.1,0,,3
 Folate,Jeunes et adolescents* 9 à 18 ans  ,98,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0.8,0.2,0.5,1.2,mcg (ÉFA),0.2,0,E,3
 Folate,Jeunes et adolescents* 9 à 18 ans  ,1154,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0.9,0.1,0.7,1.1,mcg (ÉFA),0.2,0,,3
 Folate,Jeunes et adolescents* 9 à 18 ans  ,1072,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,1.5,0.1,1.2,1.7,mcg (ÉFA),0.3,0,,3
@@ -6852,8 +6852,8 @@ Folate,Jeunes et adolescents* 9 à 18 ans  ,319,des,Poissons et fruits de mer,de
 Folate,Jeunes et adolescents* 9 à 18 ans  ,141,des,Poissons et fruits de mer,des,Mollusques et crustacés,,,F,F,,,mcg (ÉFA),F,F,F,2
 Folate,Jeunes et adolescents* 9 à 18 ans  ,3672,des,Fruits et légumes,,,,,58.3,1.5,55.3,61.3,mcg (ÉFA),13.4,0.4,,1
 Folate,Jeunes et adolescents* 9 à 18 ans  ,2498,des,Fruits et légumes,des,Fruits,,,17.8,0.7,16.4,19.1,mcg (ÉFA),4.1,0.2,,2
-Folate,Jeunes et adolescents* 9 à 18 ans  ,1041,des,Fruits et légumes,des,Fruits,des,Pommes,1.5,0.1,1.3,1.6,mcg (ÉFA),0.3,0,,3
-Folate,Jeunes et adolescents* 9 à 18 ans  ,823,des,Fruits et légumes,des,Fruits,des,Bananes,4.5,0.3,4,5.1,mcg (ÉFA),1,0.1,,3
+Folate,Jeunes et adolescents* 9 à 18 ans  ,1041,des,Fruits et légumes,des,Fruits,des,Pomme,1.5,0.1,1.3,1.6,mcg (ÉFA),0.3,0,,3
+Folate,Jeunes et adolescents* 9 à 18 ans  ,823,des,Fruits et légumes,des,Fruits,des,Banane,4.5,0.3,4,5.1,mcg (ÉFA),1,0.1,,3
 Folate,Jeunes et adolescents* 9 à 18 ans  ,743,des,Fruits et légumes,des,Fruits,des,Baies,2.6,0.2,2.2,3,mcg (ÉFA),0.6,0,,3
 Folate,Jeunes et adolescents* 9 à 18 ans  ,73,des,Fruits et légumes,des,Fruits,des,Cerises,0,0,0,0.1,mcg (ÉFA),0,0,,3
 Folate,Jeunes et adolescents* 9 à 18 ans  ,514,des,Fruits et légumes,des,Fruits,des,Agrumes,3.5,0.3,3,4,mcg (ÉFA),0.8,0.1,,3
@@ -6878,11 +6878,11 @@ Folate,Jeunes et adolescents* 9 à 18 ans  ,828,des,Produits céréaliers,des,Pa
 Folate,Jeunes et adolescents* 9 à 18 ans  ,1416,des,Produits céréaliers,des,Céréales pour déjeuner,,,22.1,1.3,19.6,24.6,mcg (ÉFA),5.1,0.3,,2
 Folate,Jeunes et adolescents* 9 à 18 ans  ,794,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),13.2,1,11.1,15.2,mcg (ÉFA),3,0.2,,3
 Folate,Jeunes et adolescents* 9 à 18 ans  ,700,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,8.9,0.7,7.5,10.3,mcg (ÉFA),2.1,0.2,,3
-Folate,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,9.3,0.5,8.4,10.3,mcg (ÉFA),2.2,0.1,,2
-Folate,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.5,0.1,0.3,0.7,mcg (ÉFA),0.1,0,E,3
-Folate,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.4,0.1,0.2,0.5,mcg (ÉFA),0.1,0,E,3
-Folate,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.8,0.1,0.7,0.9,mcg (ÉFA),0.2,0,,3
-Folate,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mcg (ÉFA),X,X,<10,3
+Folate,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,9.3,0.5,8.4,10.3,mcg (ÉFA),2.2,0.1,,2
+Folate,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0.5,0.1,0.3,0.7,mcg (ÉFA),0.1,0,E,3
+Folate,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.4,0.1,0.2,0.5,mcg (ÉFA),0.1,0,E,3
+Folate,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,0.8,0.1,0.7,0.9,mcg (ÉFA),0.2,0,,3
+Folate,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mcg (ÉFA),X,X,<10,3
 Folate,Jeunes et adolescents* 9 à 18 ans  ,3103,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,123.1,4.1,115.1,131,mcg (ÉFA),28.4,0.8,,2
 Folate,Jeunes et adolescents* 9 à 18 ans  ,2364,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,65.1,3.1,59,71.2,mcg (ÉFA),15,0.7,,3
 Folate,Jeunes et adolescents* 9 à 18 ans  ,1020,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,54.6,3.3,48,61.1,mcg (ÉFA),12.6,0.7,,3
@@ -6913,23 +6913,23 @@ Folate,Jeunes et adolescents* 9 à 18 ans  ,3619,des,Soupes - sauces - Épices e
 Folate,Jeunes et adolescents* 9 à 18 ans  ,1553,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,1,0.1,0.9,1.1,mcg (ÉFA),0.2,0,,2
 Folate,Jeunes et adolescents* 9 à 18 ans  ,747,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,3.4,0.4,2.7,4.1,mcg (ÉFA),0.8,0.1,,2
 Folate,Jeunes et adolescents* 9 à 18 ans  ,3417,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,6.1,0.4,5.2,6.9,mcg (ÉFA),1.4,0.1,,2
-Folate,Jeunes et adolescents* 9 à 18 ans  ,3420,des,Confiseries - sucres et grignotines salées,,,,,9.1,0.7,7.8,10.4,mcg (ÉFA),2.1,0.2,,1
-Folate,Jeunes et adolescents* 9 à 18 ans  ,1608,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,1.1,0.1,0.9,1.3,mcg (ÉFA),0.3,0,,2
-Folate,Jeunes et adolescents* 9 à 18 ans  ,794,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0.1,0,0.1,0.2,mcg (ÉFA),0,0,,3
-Folate,Jeunes et adolescents* 9 à 18 ans  ,938,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0.9,0.1,0.7,1.1,mcg (ÉFA),0.2,0,,3
-Folate,Jeunes et adolescents* 9 à 18 ans  ,166,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0.1,0,0,0.1,mcg (ÉFA),0,0,,3
-Folate,Jeunes et adolescents* 9 à 18 ans  ,758,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,2,0.2,1.7,2.3,mcg (ÉFA),0.5,0,,2
-Folate,Jeunes et adolescents* 9 à 18 ans  ,599,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,1.9,0.2,1.6,2.2,mcg (ÉFA),0.4,0,,3
-Folate,Jeunes et adolescents* 9 à 18 ans  ,204,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0.1,0,0,0.1,mcg (ÉFA),0,0,,3
-Folate,Jeunes et adolescents* 9 à 18 ans  ,1279,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,5.1,0.6,3.9,6.3,mcg (ÉFA),1.2,0.1,,2
-Folate,Jeunes et adolescents* 9 à 18 ans  ,2738,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.9,0.2,0.6,1.3,mcg (ÉFA),0.2,0,E,2
-Folate,Jeunes et adolescents* 9 à 18 ans  ,269,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.2,0,0.1,0.3,mcg (ÉFA),0.1,0,,3
-Folate,Jeunes et adolescents* 9 à 18 ans  ,1069,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.7,0.2,0.4,1,mcg (ÉFA),0.2,0,E,3
-Folate,Jeunes et adolescents* 9 à 18 ans  ,19,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mcg (ÉFA),0,0,,3
-Folate,Jeunes et adolescents* 9 à 18 ans  ,2377,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,mcg (ÉFA),0,0,,3
+Folate,Jeunes et adolescents* 9 à 18 ans  ,3420,des,Confiserie - sucres et grignotines salées,,,,,9.1,0.7,7.8,10.4,mcg (ÉFA),2.1,0.2,,1
+Folate,Jeunes et adolescents* 9 à 18 ans  ,1608,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,1.1,0.1,0.9,1.3,mcg (ÉFA),0.3,0,,2
+Folate,Jeunes et adolescents* 9 à 18 ans  ,794,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,0.1,0,0.1,0.2,mcg (ÉFA),0,0,,3
+Folate,Jeunes et adolescents* 9 à 18 ans  ,938,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,0.9,0.1,0.7,1.1,mcg (ÉFA),0.2,0,,3
+Folate,Jeunes et adolescents* 9 à 18 ans  ,166,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0.1,0,0,0.1,mcg (ÉFA),0,0,,3
+Folate,Jeunes et adolescents* 9 à 18 ans  ,758,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,2,0.2,1.7,2.3,mcg (ÉFA),0.5,0,,2
+Folate,Jeunes et adolescents* 9 à 18 ans  ,599,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,1.9,0.2,1.6,2.2,mcg (ÉFA),0.4,0,,3
+Folate,Jeunes et adolescents* 9 à 18 ans  ,204,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0.1,0,0,0.1,mcg (ÉFA),0,0,,3
+Folate,Jeunes et adolescents* 9 à 18 ans  ,1279,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,5.1,0.6,3.9,6.3,mcg (ÉFA),1.2,0.1,,2
+Folate,Jeunes et adolescents* 9 à 18 ans  ,2738,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.9,0.2,0.6,1.3,mcg (ÉFA),0.2,0,E,2
+Folate,Jeunes et adolescents* 9 à 18 ans  ,269,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.2,0,0.1,0.3,mcg (ÉFA),0.1,0,,3
+Folate,Jeunes et adolescents* 9 à 18 ans  ,1069,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.7,0.2,0.4,1,mcg (ÉFA),0.2,0,E,3
+Folate,Jeunes et adolescents* 9 à 18 ans  ,19,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mcg (ÉFA),0,0,,3
+Folate,Jeunes et adolescents* 9 à 18 ans  ,2377,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,mcg (ÉFA),0,0,,3
 Calcium,Jeunes et adolescents* 9 à 18 ans  ,19,des,Aliments pour bébés,,,,,F,F,,,mg,F,F,F,1
 Calcium,Jeunes et adolescents* 9 à 18 ans  ,17,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,F,F,,,mg,F,F,F,2
-Calcium,Jeunes et adolescents* 9 à 18 ans  ,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,mg,X,X,<10,2
+Calcium,Jeunes et adolescents* 9 à 18 ans  ,,des,Aliments pour bébés,des,Préparation pour nourrissons,,,X,X,,,mg,X,X,<10,2
 Calcium,Jeunes et adolescents* 9 à 18 ans  ,3815,des,Boissons (excluant laits),,,,,57.4,2.6,52.3,62.5,mg,5.8,0.3,,1
 Calcium,Jeunes et adolescents* 9 à 18 ans  ,93,des,Boissons (excluant laits),de l',Alcool,,,0.3,0.1,0.2,0.5,mg,0,0,E,2
 Calcium,Jeunes et adolescents* 9 à 18 ans  ,890,des,Boissons (excluant laits),du,Café et thé,,,1.3,0.1,1.2,1.5,mg,0.1,0,,2
@@ -6949,7 +6949,7 @@ Calcium,Jeunes et adolescents* 9 à 18 ans  ,2532,des,Produits laitiers et Boiss
 Calcium,Jeunes et adolescents* 9 à 18 ans  ,3315,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,362.1,9.4,343.7,380.5,mg,36.8,0.6,,2
 Calcium,Jeunes et adolescents* 9 à 18 ans  ,1440,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,103,6.7,89.8,116.2,mg,10.5,0.6,,3
 Calcium,Jeunes et adolescents* 9 à 18 ans  ,2530,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,189.5,7.1,175.5,203.5,mg,19.2,0.6,,3
-Calcium,Jeunes et adolescents* 9 à 18 ans  ,575,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,5.4,0.6,4.1,6.6,mg,0.5,0.1,,3
+Calcium,Jeunes et adolescents* 9 à 18 ans  ,575,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,5.4,0.6,4.1,6.6,mg,0.5,0.1,,3
 Calcium,Jeunes et adolescents* 9 à 18 ans  ,98,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,8.6,2,4.7,12.6,mg,0.9,0.2,E,3
 Calcium,Jeunes et adolescents* 9 à 18 ans  ,1154,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,22.2,2.5,17.2,27.2,mg,2.3,0.3,,3
 Calcium,Jeunes et adolescents* 9 à 18 ans  ,1072,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,33.4,3,27.4,39.4,mg,3.4,0.3,,3
@@ -6966,8 +6966,8 @@ Calcium,Jeunes et adolescents* 9 à 18 ans  ,319,des,Poissons et fruits de mer,d
 Calcium,Jeunes et adolescents* 9 à 18 ans  ,141,des,Poissons et fruits de mer,des,Mollusques et crustacés,,,1.5,0.3,0.9,2.1,mg,0.2,0,E,2
 Calcium,Jeunes et adolescents* 9 à 18 ans  ,3672,des,Fruits et légumes,,,,,52.2,1.2,49.8,54.5,mg,5.3,0.1,,1
 Calcium,Jeunes et adolescents* 9 à 18 ans  ,2498,des,Fruits et légumes,des,Fruits,,,16.1,0.6,14.9,17.3,mg,1.6,0.1,,2
-Calcium,Jeunes et adolescents* 9 à 18 ans  ,1041,des,Fruits et légumes,des,Fruits,des,Pommes,3,0.1,2.7,3.3,mg,0.3,0,,3
-Calcium,Jeunes et adolescents* 9 à 18 ans  ,823,des,Fruits et légumes,des,Fruits,des,Bananes,1.1,0.1,1,1.3,mg,0.1,0,,3
+Calcium,Jeunes et adolescents* 9 à 18 ans  ,1041,des,Fruits et légumes,des,Fruits,des,Pomme,3,0.1,2.7,3.3,mg,0.3,0,,3
+Calcium,Jeunes et adolescents* 9 à 18 ans  ,823,des,Fruits et légumes,des,Fruits,des,Banane,1.1,0.1,1,1.3,mg,0.1,0,,3
 Calcium,Jeunes et adolescents* 9 à 18 ans  ,743,des,Fruits et légumes,des,Fruits,des,Baies,2.1,0.2,1.7,2.5,mg,0.2,0,,3
 Calcium,Jeunes et adolescents* 9 à 18 ans  ,73,des,Fruits et légumes,des,Fruits,des,Cerises,0.1,0,0.1,0.2,mg,0,0,,3
 Calcium,Jeunes et adolescents* 9 à 18 ans  ,514,des,Fruits et légumes,des,Fruits,des,Agrumes,4.9,0.4,4.2,5.6,mg,0.5,0,,3
@@ -6992,11 +6992,11 @@ Calcium,Jeunes et adolescents* 9 à 18 ans  ,828,des,Produits céréaliers,des,P
 Calcium,Jeunes et adolescents* 9 à 18 ans  ,1416,des,Produits céréaliers,des,Céréales pour déjeuner,,,23.6,1.8,20.1,27,mg,2.4,0.2,,2
 Calcium,Jeunes et adolescents* 9 à 18 ans  ,794,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),14.2,1.4,11.4,16.9,mg,1.4,0.1,,3
 Calcium,Jeunes et adolescents* 9 à 18 ans  ,700,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,9.4,0.8,7.7,11.1,mg,1,0.1,,3
-Calcium,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,8.9,0.6,7.7,10.1,mg,0.9,0.1,,2
-Calcium,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0.2,0,0.1,0.3,mg,0,0,,3
-Calcium,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.1,mg,0,0,,3
-Calcium,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,6.1,0.5,5,7.1,mg,0.6,0.1,,3
-Calcium,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
+Calcium,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,8.9,0.6,7.7,10.1,mg,0.9,0.1,,2
+Calcium,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0.2,0,0.1,0.3,mg,0,0,,3
+Calcium,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.1,0,0,0.1,mg,0,0,,3
+Calcium,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,6.1,0.5,5,7.1,mg,0.6,0.1,,3
+Calcium,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
 Calcium,Jeunes et adolescents* 9 à 18 ans  ,3103,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,16.6,0.8,15,18.2,mg,1.7,0.1,,2
 Calcium,Jeunes et adolescents* 9 à 18 ans  ,2364,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,4.6,0.2,4.2,5,mg,0.5,0,,3
 Calcium,Jeunes et adolescents* 9 à 18 ans  ,1020,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,7.5,0.8,6,9.1,mg,0.8,0.1,,3
@@ -7027,23 +7027,23 @@ Calcium,Jeunes et adolescents* 9 à 18 ans  ,3619,des,Soupes - sauces - Épices 
 Calcium,Jeunes et adolescents* 9 à 18 ans  ,1553,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,4.6,0.3,3.9,5.2,mg,0.5,0,,2
 Calcium,Jeunes et adolescents* 9 à 18 ans  ,747,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,2.2,0.2,1.7,2.7,mg,0.2,0,,2
 Calcium,Jeunes et adolescents* 9 à 18 ans  ,3417,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,20.4,1.2,18.1,22.7,mg,2.1,0.1,,2
-Calcium,Jeunes et adolescents* 9 à 18 ans  ,3420,des,Confiseries - sucres et grignotines salées,,,,,54.1,2.6,49,59.2,mg,5.5,0.3,,1
-Calcium,Jeunes et adolescents* 9 à 18 ans  ,1608,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,9,0.7,7.6,10.3,mg,0.9,0.1,,2
-Calcium,Jeunes et adolescents* 9 à 18 ans  ,794,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0.9,0.2,0.5,1.2,mg,0.1,0,E,3
-Calcium,Jeunes et adolescents* 9 à 18 ans  ,938,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,7.1,0.7,5.8,8.3,mg,0.7,0.1,,3
-Calcium,Jeunes et adolescents* 9 à 18 ans  ,166,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,1.1,0.2,0.7,1.4,mg,0.1,0,E,3
-Calcium,Jeunes et adolescents* 9 à 18 ans  ,758,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,30.6,2.4,25.9,35.2,mg,3.1,0.2,,2
-Calcium,Jeunes et adolescents* 9 à 18 ans  ,599,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,30,2.4,25.4,34.7,mg,3,0.2,,3
-Calcium,Jeunes et adolescents* 9 à 18 ans  ,204,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0.6,0.2,0.3,0.8,mg,0.1,0,E,3
-Calcium,Jeunes et adolescents* 9 à 18 ans  ,1279,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,8.8,0.8,7.1,10.4,mg,0.9,0.1,,2
-Calcium,Jeunes et adolescents* 9 à 18 ans  ,2738,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,5.8,0.7,4.4,7.1,mg,0.6,0.1,,2
-Calcium,Jeunes et adolescents* 9 à 18 ans  ,269,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.4,0.1,0.3,0.6,mg,0,0,E,3
-Calcium,Jeunes et adolescents* 9 à 18 ans  ,1069,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,4.7,0.7,3.4,6,mg,0.5,0.1,,3
-Calcium,Jeunes et adolescents* 9 à 18 ans  ,19,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mg,0,0,,3
-Calcium,Jeunes et adolescents* 9 à 18 ans  ,2377,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0.6,0.1,0.5,0.8,mg,0.1,0,E,3
+Calcium,Jeunes et adolescents* 9 à 18 ans  ,3420,des,Confiserie - sucres et grignotines salées,,,,,54.1,2.6,49,59.2,mg,5.5,0.3,,1
+Calcium,Jeunes et adolescents* 9 à 18 ans  ,1608,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,9,0.7,7.6,10.3,mg,0.9,0.1,,2
+Calcium,Jeunes et adolescents* 9 à 18 ans  ,794,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,0.9,0.2,0.5,1.2,mg,0.1,0,E,3
+Calcium,Jeunes et adolescents* 9 à 18 ans  ,938,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,7.1,0.7,5.8,8.3,mg,0.7,0.1,,3
+Calcium,Jeunes et adolescents* 9 à 18 ans  ,166,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,1.1,0.2,0.7,1.4,mg,0.1,0,E,3
+Calcium,Jeunes et adolescents* 9 à 18 ans  ,758,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,30.6,2.4,25.9,35.2,mg,3.1,0.2,,2
+Calcium,Jeunes et adolescents* 9 à 18 ans  ,599,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,30,2.4,25.4,34.7,mg,3,0.2,,3
+Calcium,Jeunes et adolescents* 9 à 18 ans  ,204,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0.6,0.2,0.3,0.8,mg,0.1,0,E,3
+Calcium,Jeunes et adolescents* 9 à 18 ans  ,1279,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,8.8,0.8,7.1,10.4,mg,0.9,0.1,,2
+Calcium,Jeunes et adolescents* 9 à 18 ans  ,2738,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,5.8,0.7,4.4,7.1,mg,0.6,0.1,,2
+Calcium,Jeunes et adolescents* 9 à 18 ans  ,269,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.4,0.1,0.3,0.6,mg,0,0,E,3
+Calcium,Jeunes et adolescents* 9 à 18 ans  ,1069,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,4.7,0.7,3.4,6,mg,0.5,0.1,,3
+Calcium,Jeunes et adolescents* 9 à 18 ans  ,19,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mg,0,0,,3
+Calcium,Jeunes et adolescents* 9 à 18 ans  ,2377,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0.6,0.1,0.5,0.8,mg,0.1,0,E,3
 Fer,Jeunes et adolescents* 9 à 18 ans  ,19,des,Aliments pour bébés,,,,,0,0,0,0,mg,0.1,0.1,,1
 Fer,Jeunes et adolescents* 9 à 18 ans  ,17,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0,0,0,0,mg,0.1,0.1,,2
-Fer,Jeunes et adolescents* 9 à 18 ans  ,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,mg,X,X,<10,2
+Fer,Jeunes et adolescents* 9 à 18 ans  ,,des,Aliments pour bébés,des,Préparation pour nourrissons,,,X,X,,,mg,X,X,<10,2
 Fer,Jeunes et adolescents* 9 à 18 ans  ,3815,des,Boissons (excluant laits),,,,,0.4,0,0.4,0.5,mg,3.3,0.1,,1
 Fer,Jeunes et adolescents* 9 à 18 ans  ,93,des,Boissons (excluant laits),de l',Alcool,,,0,0,0,0,mg,0,0,,2
 Fer,Jeunes et adolescents* 9 à 18 ans  ,890,des,Boissons (excluant laits),du,Café et thé,,,0,0,0,0,mg,0.1,0,,2
@@ -7063,7 +7063,7 @@ Fer,Jeunes et adolescents* 9 à 18 ans  ,2532,des,Produits laitiers et Boissons 
 Fer,Jeunes et adolescents* 9 à 18 ans  ,3315,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,0.2,0,0.1,0.2,mg,1.3,0.1,,2
 Fer,Jeunes et adolescents* 9 à 18 ans  ,1440,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,0.1,0,0.1,0.1,mg,0.5,0.1,,3
 Fer,Jeunes et adolescents* 9 à 18 ans  ,2530,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,0.1,0,0,0.1,mg,0.4,0,,3
-Fer,Jeunes et adolescents* 9 à 18 ans  ,575,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,0,0,0,0,mg,0,0,,3
+Fer,Jeunes et adolescents* 9 à 18 ans  ,575,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,0,0,0,0,mg,0,0,,3
 Fer,Jeunes et adolescents* 9 à 18 ans  ,98,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,0,0,0,0,mg,0.2,0,,3
 Fer,Jeunes et adolescents* 9 à 18 ans  ,1154,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,0,0,0,0,mg,0,0,,3
 Fer,Jeunes et adolescents* 9 à 18 ans  ,1072,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,0,0,0,0,mg,0.1,0,,3
@@ -7080,8 +7080,8 @@ Fer,Jeunes et adolescents* 9 à 18 ans  ,319,des,Poissons et fruits de mer,des,P
 Fer,Jeunes et adolescents* 9 à 18 ans  ,141,des,Poissons et fruits de mer,des,Mollusques et crustacés,,,0,0,0,0,mg,0.1,0,,2
 Fer,Jeunes et adolescents* 9 à 18 ans  ,3672,des,Fruits et légumes,,,,,1.4,0,1.3,1.5,mg,10.5,0.2,,1
 Fer,Jeunes et adolescents* 9 à 18 ans  ,2498,des,Fruits et légumes,des,Fruits,,,0.4,0,0.3,0.4,mg,2.7,0.1,,2
-Fer,Jeunes et adolescents* 9 à 18 ans  ,1041,des,Fruits et légumes,des,Fruits,des,Pommes,0.1,0,0.1,0.1,mg,0.5,0,,3
-Fer,Jeunes et adolescents* 9 à 18 ans  ,823,des,Fruits et légumes,des,Fruits,des,Bananes,0.1,0,0.1,0.1,mg,0.4,0,,3
+Fer,Jeunes et adolescents* 9 à 18 ans  ,1041,des,Fruits et légumes,des,Fruits,des,Pomme,0.1,0,0.1,0.1,mg,0.5,0,,3
+Fer,Jeunes et adolescents* 9 à 18 ans  ,823,des,Fruits et légumes,des,Fruits,des,Banane,0.1,0,0.1,0.1,mg,0.4,0,,3
 Fer,Jeunes et adolescents* 9 à 18 ans  ,743,des,Fruits et légumes,des,Fruits,des,Baies,0.1,0,0.1,0.1,mg,0.5,0,,3
 Fer,Jeunes et adolescents* 9 à 18 ans  ,73,des,Fruits et légumes,des,Fruits,des,Cerises,0,0,0,0,mg,0,0,,3
 Fer,Jeunes et adolescents* 9 à 18 ans  ,514,des,Fruits et légumes,des,Fruits,des,Agrumes,0,0,0,0,mg,0.1,0,,3
@@ -7106,11 +7106,11 @@ Fer,Jeunes et adolescents* 9 à 18 ans  ,828,des,Produits céréaliers,des,Pains
 Fer,Jeunes et adolescents* 9 à 18 ans  ,1416,des,Produits céréaliers,des,Céréales pour déjeuner,,,1.9,0.1,1.7,2.1,mg,14.4,0.7,,2
 Fer,Jeunes et adolescents* 9 à 18 ans  ,794,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),1.1,0.1,1,1.3,mg,8.5,0.6,,3
 Fer,Jeunes et adolescents* 9 à 18 ans  ,700,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,0.8,0.1,0.7,0.9,mg,5.9,0.4,,3
-Fer,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,0.6,0,0.5,0.6,mg,4.3,0.2,,2
-Fer,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mg,0.1,0,,3
-Fer,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mg,0.1,0,,3
-Fer,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.2,mg,1,0.1,,3
-Fer,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
+Fer,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,0.6,0,0.5,0.6,mg,4.3,0.2,,2
+Fer,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,0,0,0,0,mg,0.1,0,,3
+Fer,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0,0,0,0,mg,0.1,0,,3
+Fer,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,0.1,0,0.1,0.2,mg,1,0.1,,3
+Fer,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
 Fer,Jeunes et adolescents* 9 à 18 ans  ,3103,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,2.1,0.1,1.9,2.2,mg,15.3,0.4,,2
 Fer,Jeunes et adolescents* 9 à 18 ans  ,2364,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,1.4,0.1,1.3,1.5,mg,10.3,0.5,,3
 Fer,Jeunes et adolescents* 9 à 18 ans  ,1020,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,0.6,0,0.5,0.6,mg,4.2,0.3,,3
@@ -7141,23 +7141,23 @@ Fer,Jeunes et adolescents* 9 à 18 ans  ,3619,des,Soupes - sauces - Épices et a
 Fer,Jeunes et adolescents* 9 à 18 ans  ,1553,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,0.1,0,0.1,0.1,mg,0.7,0.1,,2
 Fer,Jeunes et adolescents* 9 à 18 ans  ,747,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,0.1,0,0.1,0.1,mg,0.7,0.1,,2
 Fer,Jeunes et adolescents* 9 à 18 ans  ,3417,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,0.1,0,0.1,0.1,mg,1,0.1,,2
-Fer,Jeunes et adolescents* 9 à 18 ans  ,3420,des,Confiseries - sucres et grignotines salées,,,,,0.7,0,0.7,0.8,mg,5.5,0.3,,1
-Fer,Jeunes et adolescents* 9 à 18 ans  ,1608,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,0.2,0,0.2,0.2,mg,1.5,0.1,,2
-Fer,Jeunes et adolescents* 9 à 18 ans  ,794,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,0,0,0,0,mg,0.2,0,,3
-Fer,Jeunes et adolescents* 9 à 18 ans  ,938,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,0.2,0,0.1,0.2,mg,1.3,0.1,,3
-Fer,Jeunes et adolescents* 9 à 18 ans  ,166,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,0,0,0,0,mg,0.1,0,,3
-Fer,Jeunes et adolescents* 9 à 18 ans  ,758,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,0.1,0,0.1,0.1,mg,0.7,0.1,,2
-Fer,Jeunes et adolescents* 9 à 18 ans  ,599,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.1,0,0.1,0.1,mg,0.5,0.1,,3
-Fer,Jeunes et adolescents* 9 à 18 ans  ,204,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,mg,0.2,0,,3
-Fer,Jeunes et adolescents* 9 à 18 ans  ,1279,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,0.3,0,0.2,0.3,mg,2,0.2,,2
-Fer,Jeunes et adolescents* 9 à 18 ans  ,2738,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.2,0,0.1,0.2,mg,1.3,0.2,,2
-Fer,Jeunes et adolescents* 9 à 18 ans  ,269,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,mg,0.1,0,,3
-Fer,Jeunes et adolescents* 9 à 18 ans  ,1069,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.2,0,0.1,0.2,mg,1.1,0.2,,3
-Fer,Jeunes et adolescents* 9 à 18 ans  ,19,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mg,0,0,,3
-Fer,Jeunes et adolescents* 9 à 18 ans  ,2377,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,mg,0.1,0,,3
+Fer,Jeunes et adolescents* 9 à 18 ans  ,3420,des,Confiserie - sucres et grignotines salées,,,,,0.7,0,0.7,0.8,mg,5.5,0.3,,1
+Fer,Jeunes et adolescents* 9 à 18 ans  ,1608,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,0.2,0,0.2,0.2,mg,1.5,0.1,,2
+Fer,Jeunes et adolescents* 9 à 18 ans  ,794,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,0,0,0,0,mg,0.2,0,,3
+Fer,Jeunes et adolescents* 9 à 18 ans  ,938,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,0.2,0,0.1,0.2,mg,1.3,0.1,,3
+Fer,Jeunes et adolescents* 9 à 18 ans  ,166,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,0,0,0,0,mg,0.1,0,,3
+Fer,Jeunes et adolescents* 9 à 18 ans  ,758,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,0.1,0,0.1,0.1,mg,0.7,0.1,,2
+Fer,Jeunes et adolescents* 9 à 18 ans  ,599,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,0.1,0,0.1,0.1,mg,0.5,0.1,,3
+Fer,Jeunes et adolescents* 9 à 18 ans  ,204,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,0,0,0,0,mg,0.2,0,,3
+Fer,Jeunes et adolescents* 9 à 18 ans  ,1279,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,0.3,0,0.2,0.3,mg,2,0.2,,2
+Fer,Jeunes et adolescents* 9 à 18 ans  ,2738,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,0.2,0,0.1,0.2,mg,1.3,0.2,,2
+Fer,Jeunes et adolescents* 9 à 18 ans  ,269,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0,0,0,0,mg,0.1,0,,3
+Fer,Jeunes et adolescents* 9 à 18 ans  ,1069,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,0.2,0,0.1,0.2,mg,1.1,0.2,,3
+Fer,Jeunes et adolescents* 9 à 18 ans  ,19,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mg,0,0,,3
+Fer,Jeunes et adolescents* 9 à 18 ans  ,2377,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0,0,0,0,mg,0.1,0,,3
 Sodium,Jeunes et adolescents* 9 à 18 ans  ,19,des,Aliments pour bébés,,,,,F,F,,,mg,F,F,F,1
 Sodium,Jeunes et adolescents* 9 à 18 ans  ,17,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,F,F,,,mg,F,F,F,2
-Sodium,Jeunes et adolescents* 9 à 18 ans  ,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,mg,X,X,<10,2
+Sodium,Jeunes et adolescents* 9 à 18 ans  ,,des,Aliments pour bébés,des,Préparation pour nourrissons,,,X,X,,,mg,X,X,<10,2
 Sodium,Jeunes et adolescents* 9 à 18 ans  ,3815,des,Boissons (excluant laits),,,,,69.9,3.2,63.7,76.1,mg,2.4,0.1,,1
 Sodium,Jeunes et adolescents* 9 à 18 ans  ,93,des,Boissons (excluant laits),de l',Alcool,,,0.3,0.1,0.1,0.4,mg,0,0,E,2
 Sodium,Jeunes et adolescents* 9 à 18 ans  ,890,des,Boissons (excluant laits),du,Café et thé,,,5.8,0.4,4.9,6.6,mg,0.2,0,,2
@@ -7177,7 +7177,7 @@ Sodium,Jeunes et adolescents* 9 à 18 ans  ,2532,des,Produits laitiers et Boisso
 Sodium,Jeunes et adolescents* 9 à 18 ans  ,3315,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,144,3.8,136.5,151.5,mg,5,0.1,,2
 Sodium,Jeunes et adolescents* 9 à 18 ans  ,1440,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,40.1,2.7,34.7,45.5,mg,1.4,0.1,,3
 Sodium,Jeunes et adolescents* 9 à 18 ans  ,2530,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,76.7,2.9,71,82.4,mg,2.6,0.1,,3
-Sodium,Jeunes et adolescents* 9 à 18 ans  ,575,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,2.6,0.3,1.9,3.2,mg,0.1,0,,3
+Sodium,Jeunes et adolescents* 9 à 18 ans  ,575,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,2.6,0.3,1.9,3.2,mg,0.1,0,,3
 Sodium,Jeunes et adolescents* 9 à 18 ans  ,98,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,4.1,1,2.1,6,mg,0.1,0,E,3
 Sodium,Jeunes et adolescents* 9 à 18 ans  ,1154,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,7.7,0.9,6,9.4,mg,0.3,0,,3
 Sodium,Jeunes et adolescents* 9 à 18 ans  ,1072,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,12.9,1.2,10.6,15.2,mg,0.4,0,,3
@@ -7194,8 +7194,8 @@ Sodium,Jeunes et adolescents* 9 à 18 ans  ,319,des,Poissons et fruits de mer,de
 Sodium,Jeunes et adolescents* 9 à 18 ans  ,141,des,Poissons et fruits de mer,des,Mollusques et crustacés,,,16,3.9,8.2,23.7,mg,0.5,0.1,E,2
 Sodium,Jeunes et adolescents* 9 à 18 ans  ,3677,des,Fruits et légumes,,,,,179.5,8,163.8,195.2,mg,6.2,0.3,,1
 Sodium,Jeunes et adolescents* 9 à 18 ans  ,2498,des,Fruits et légumes,des,Fruits,,,2.7,0.2,2.3,3,mg,0.1,0,,2
-Sodium,Jeunes et adolescents* 9 à 18 ans  ,1041,des,Fruits et légumes,des,Fruits,des,Pommes,0.6,0,0.5,0.6,mg,0,0,,3
-Sodium,Jeunes et adolescents* 9 à 18 ans  ,823,des,Fruits et légumes,des,Fruits,des,Bananes,0.2,0,0.2,0.3,mg,0,0,,3
+Sodium,Jeunes et adolescents* 9 à 18 ans  ,1041,des,Fruits et légumes,des,Fruits,des,Pomme,0.6,0,0.5,0.6,mg,0,0,,3
+Sodium,Jeunes et adolescents* 9 à 18 ans  ,823,des,Fruits et légumes,des,Fruits,des,Banane,0.2,0,0.2,0.3,mg,0,0,,3
 Sodium,Jeunes et adolescents* 9 à 18 ans  ,743,des,Fruits et légumes,des,Fruits,des,Baies,0.2,0,0.2,0.2,mg,0,0,,3
 Sodium,Jeunes et adolescents* 9 à 18 ans  ,73,des,Fruits et légumes,des,Fruits,des,Cerises,0,0,0,0,mg,0,0,,3
 Sodium,Jeunes et adolescents* 9 à 18 ans  ,514,des,Fruits et légumes,des,Fruits,des,Agrumes,0.1,0,0.1,0.1,mg,0,0,,3
@@ -7220,11 +7220,11 @@ Sodium,Jeunes et adolescents* 9 à 18 ans  ,828,des,Produits céréaliers,des,Pa
 Sodium,Jeunes et adolescents* 9 à 18 ans  ,1416,des,Produits céréaliers,des,Céréales pour déjeuner,,,66.3,3.8,58.8,73.8,mg,2.3,0.1,,2
 Sodium,Jeunes et adolescents* 9 à 18 ans  ,794,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),41.8,3.1,35.7,47.9,mg,1.4,0.1,,3
 Sodium,Jeunes et adolescents* 9 à 18 ans  ,700,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,24.5,2,20.5,28.5,mg,0.8,0.1,,3
-Sodium,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,47.9,2.6,42.8,53,mg,1.6,0.1,,2
-Sodium,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,1.9,0.4,1.1,2.7,mg,0.1,0,E,3
-Sodium,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,1.7,0.4,0.9,2.5,mg,0.1,0,E,3
-Sodium,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,15.3,1.3,12.8,17.8,mg,0.5,0,,3
-Sodium,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
+Sodium,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,47.9,2.6,42.8,53,mg,1.6,0.1,,2
+Sodium,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,1.9,0.4,1.1,2.7,mg,0.1,0,E,3
+Sodium,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,1.7,0.4,0.9,2.5,mg,0.1,0,E,3
+Sodium,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,15.3,1.3,12.8,17.8,mg,0.5,0,,3
+Sodium,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
 Sodium,Jeunes et adolescents* 9 à 18 ans  ,3103,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,33.6,4.6,24.6,42.5,mg,1.2,0.2,,2
 Sodium,Jeunes et adolescents* 9 à 18 ans  ,2364,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,0.2,0,0.2,0.3,mg,0,0,,3
 Sodium,Jeunes et adolescents* 9 à 18 ans  ,1020,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,29.5,4.2,21.2,37.8,mg,1,0.1,,3
@@ -7255,23 +7255,23 @@ Sodium,Jeunes et adolescents* 9 à 18 ans  ,3608,des,Soupes - sauces - Épices e
 Sodium,Jeunes et adolescents* 9 à 18 ans  ,1553,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,151.6,8.7,134.5,168.7,mg,5.2,0.3,,2
 Sodium,Jeunes et adolescents* 9 à 18 ans  ,747,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,111.7,7.8,96.4,127,mg,3.8,0.3,,2
 Sodium,Jeunes et adolescents* 9 à 18 ans  ,3392,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,614,17.8,579,649.1,mg,21.1,0.5,,2
-Sodium,Jeunes et adolescents* 9 à 18 ans  ,3420,des,Confiseries - sucres et grignotines salées,,,,,139.6,8.8,122.3,157,mg,4.8,0.3,,1
-Sodium,Jeunes et adolescents* 9 à 18 ans  ,1608,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,16,1.2,13.7,18.3,mg,0.6,0,,2
-Sodium,Jeunes et adolescents* 9 à 18 ans  ,794,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,6.8,0.8,5.2,8.5,mg,0.2,0,,3
-Sodium,Jeunes et adolescents* 9 à 18 ans  ,938,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,4.9,0.5,3.9,5.9,mg,0.2,0,,3
-Sodium,Jeunes et adolescents* 9 à 18 ans  ,166,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,4.2,0.6,3,5.5,mg,0.1,0,,3
-Sodium,Jeunes et adolescents* 9 à 18 ans  ,758,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,20.6,1.5,17.6,23.5,mg,0.7,0.1,,2
-Sodium,Jeunes et adolescents* 9 à 18 ans  ,599,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,18.6,1.4,15.8,21.5,mg,0.6,0,,3
-Sodium,Jeunes et adolescents* 9 à 18 ans  ,204,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,2,0.3,1.3,2.6,mg,0.1,0,,3
-Sodium,Jeunes et adolescents* 9 à 18 ans  ,1279,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,97,8.8,79.8,114.2,mg,3.3,0.3,,2
-Sodium,Jeunes et adolescents* 9 à 18 ans  ,2738,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,6,0.5,5,7.1,mg,0.2,0,,2
-Sodium,Jeunes et adolescents* 9 à 18 ans  ,269,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.7,0.1,0.5,1,mg,0,0,,3
-Sodium,Jeunes et adolescents* 9 à 18 ans  ,1069,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,5,0.5,4,6.1,mg,0.2,0,,3
-Sodium,Jeunes et adolescents* 9 à 18 ans  ,19,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mg,0,0,,3
-Sodium,Jeunes et adolescents* 9 à 18 ans  ,2377,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0.3,0,0.2,0.3,mg,0,0,,3
+Sodium,Jeunes et adolescents* 9 à 18 ans  ,3420,des,Confiserie - sucres et grignotines salées,,,,,139.6,8.8,122.3,157,mg,4.8,0.3,,1
+Sodium,Jeunes et adolescents* 9 à 18 ans  ,1608,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,16,1.2,13.7,18.3,mg,0.6,0,,2
+Sodium,Jeunes et adolescents* 9 à 18 ans  ,794,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,6.8,0.8,5.2,8.5,mg,0.2,0,,3
+Sodium,Jeunes et adolescents* 9 à 18 ans  ,938,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,4.9,0.5,3.9,5.9,mg,0.2,0,,3
+Sodium,Jeunes et adolescents* 9 à 18 ans  ,166,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,4.2,0.6,3,5.5,mg,0.1,0,,3
+Sodium,Jeunes et adolescents* 9 à 18 ans  ,758,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,20.6,1.5,17.6,23.5,mg,0.7,0.1,,2
+Sodium,Jeunes et adolescents* 9 à 18 ans  ,599,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,18.6,1.4,15.8,21.5,mg,0.6,0,,3
+Sodium,Jeunes et adolescents* 9 à 18 ans  ,204,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,2,0.3,1.3,2.6,mg,0.1,0,,3
+Sodium,Jeunes et adolescents* 9 à 18 ans  ,1279,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,97,8.8,79.8,114.2,mg,3.3,0.3,,2
+Sodium,Jeunes et adolescents* 9 à 18 ans  ,2738,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,6,0.5,5,7.1,mg,0.2,0,,2
+Sodium,Jeunes et adolescents* 9 à 18 ans  ,269,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,0.7,0.1,0.5,1,mg,0,0,,3
+Sodium,Jeunes et adolescents* 9 à 18 ans  ,1069,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,5,0.5,4,6.1,mg,0.2,0,,3
+Sodium,Jeunes et adolescents* 9 à 18 ans  ,19,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mg,0,0,,3
+Sodium,Jeunes et adolescents* 9 à 18 ans  ,2377,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,0.3,0,0.2,0.3,mg,0,0,,3
 Potassium,Jeunes et adolescents* 9 à 18 ans  ,19,des,Aliments pour bébés,,,,,0.9,0.3,0.2,1.6,mg,0,0,E,1
 Potassium,Jeunes et adolescents* 9 à 18 ans  ,17,des,Aliments pour bébés,des,Produits alimentaires pour bébés,,,0.9,0.3,0.2,1.5,mg,0,0,E,2
-Potassium,Jeunes et adolescents* 9 à 18 ans  ,,des,Aliments pour bébés,des,Préparations pour nourrissons,,,X,X,,,mg,X,X,<10,2
+Potassium,Jeunes et adolescents* 9 à 18 ans  ,,des,Aliments pour bébés,des,Préparation pour nourrissons,,,X,X,,,mg,X,X,<10,2
 Potassium,Jeunes et adolescents* 9 à 18 ans  ,3815,des,Boissons (excluant laits),,,,,274.4,8.3,258.1,290.8,mg,10.7,0.3,,1
 Potassium,Jeunes et adolescents* 9 à 18 ans  ,93,des,Boissons (excluant laits),de l',Alcool,,,2.5,0.6,1.2,3.7,mg,0.1,0,E,2
 Potassium,Jeunes et adolescents* 9 à 18 ans  ,890,des,Boissons (excluant laits),du,Café et thé,,,24.2,1.6,21.1,27.4,mg,0.9,0.1,,2
@@ -7291,7 +7291,7 @@ Potassium,Jeunes et adolescents* 9 à 18 ans  ,2532,des,Produits laitiers et Boi
 Potassium,Jeunes et adolescents* 9 à 18 ans  ,3315,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,,,440.2,11.6,417.3,463,mg,17.2,0.4,,2
 Potassium,Jeunes et adolescents* 9 à 18 ans  ,1440,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 1%,129.4,8.6,112.5,146.3,mg,5.1,0.3,,3
 Potassium,Jeunes et adolescents* 9 à 18 ans  ,2530,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait 2%,225.6,8.5,208.9,242.2,mg,8.8,0.3,,3
-Potassium,Jeunes et adolescents* 9 à 18 ans  ,575,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crême et autres types de lait,7.2,0.8,5.5,8.8,mg,0.3,0,,3
+Potassium,Jeunes et adolescents* 9 à 18 ans  ,575,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,de la,Crème et autres types de lait,7.2,0.8,5.5,8.8,mg,0.3,0,,3
 Potassium,Jeunes et adolescents* 9 à 18 ans  ,98,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,des,Boissons à base de plantes,10.3,2.4,5.6,15,mg,0.4,0.1,E,3
 Potassium,Jeunes et adolescents* 9 à 18 ans  ,1154,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait écrémé,28.3,3.2,22,34.7,mg,1.1,0.1,,3
 Potassium,Jeunes et adolescents* 9 à 18 ans  ,1072,des,Produits laitiers et Boissons à base de plantes,des,Laits et boissons à base de plantes,du,Lait entier,39.3,3.6,32.3,46.4,mg,1.5,0.1,,3
@@ -7308,8 +7308,8 @@ Potassium,Jeunes et adolescents* 9 à 18 ans  ,319,des,Poissons et fruits de mer
 Potassium,Jeunes et adolescents* 9 à 18 ans  ,141,des,Poissons et fruits de mer,des,Mollusques et crustacés,,,4.3,1,2.3,6.4,mg,0.2,0,E,2
 Potassium,Jeunes et adolescents* 9 à 18 ans  ,3672,des,Fruits et légumes,,,,,732.7,15.5,702.2,763.3,mg,28.7,0.5,,1
 Potassium,Jeunes et adolescents* 9 à 18 ans  ,2498,des,Fruits et légumes,des,Fruits,,,269.1,9.7,250.1,288.2,mg,10.5,0.4,,2
-Potassium,Jeunes et adolescents* 9 à 18 ans  ,1041,des,Fruits et légumes,des,Fruits,des,Pommes,53.3,2.6,48.2,58.4,mg,2.1,0.1,,3
-Potassium,Jeunes et adolescents* 9 à 18 ans  ,823,des,Fruits et légumes,des,Fruits,des,Bananes,81.4,4.9,71.8,91.1,mg,3.2,0.2,,3
+Potassium,Jeunes et adolescents* 9 à 18 ans  ,1041,des,Fruits et légumes,des,Fruits,des,Pomme,53.3,2.6,48.2,58.4,mg,2.1,0.1,,3
+Potassium,Jeunes et adolescents* 9 à 18 ans  ,823,des,Fruits et légumes,des,Fruits,des,Banane,81.4,4.9,71.8,91.1,mg,3.2,0.2,,3
 Potassium,Jeunes et adolescents* 9 à 18 ans  ,743,des,Fruits et légumes,des,Fruits,des,Baies,18.2,1.5,15.3,21,mg,0.7,0.1,,3
 Potassium,Jeunes et adolescents* 9 à 18 ans  ,73,des,Fruits et légumes,des,Fruits,des,Cerises,2.4,0.7,1,3.9,mg,0.1,0,E,3
 Potassium,Jeunes et adolescents* 9 à 18 ans  ,514,des,Fruits et légumes,des,Fruits,des,Agrumes,24.5,1.8,20.9,28,mg,1,0.1,,3
@@ -7334,11 +7334,11 @@ Potassium,Jeunes et adolescents* 9 à 18 ans  ,828,des,Produits céréaliers,des
 Potassium,Jeunes et adolescents* 9 à 18 ans  ,1416,des,Produits céréaliers,des,Céréales pour déjeuner,,,44.8,2.4,40,49.6,mg,1.8,0.1,,2
 Potassium,Jeunes et adolescents* 9 à 18 ans  ,794,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner (autre),13.6,1.1,11.4,15.8,mg,0.5,0,,3
 Potassium,Jeunes et adolescents* 9 à 18 ans  ,700,des,Produits céréaliers,des,Céréales pour déjeuner,des,Céréales pour déjeuner à grains entiers - À l'avoine et à haute teneur en fibres,31.2,2.2,26.9,35.4,mg,1.2,0.1,,3
-Potassium,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,,,31,1.7,27.6,34.3,mg,1.2,0.1,,2
-Potassium,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Gâteaux,1,0.2,0.6,1.4,mg,0,0,E,3
-Potassium,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.4,0.1,0.2,0.6,mg,0,0,E,3
-Potassium,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Barres granola,15.7,1.4,13,18.4,mg,0.6,0.1,,3
-Potassium,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
+Potassium,Jeunes et adolescents* 9 à 18 ans  ,1432,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,,,31,1.7,27.6,34.3,mg,1.2,0.1,,2
+Potassium,Jeunes et adolescents* 9 à 18 ans  ,58,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Gâteaux,1,0.2,0.6,1.4,mg,0,0,E,3
+Potassium,Jeunes et adolescents* 9 à 18 ans  ,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Brioches - beignes et autres pâtisseries,0.4,0.1,0.2,0.6,mg,0,0,E,3
+Potassium,Jeunes et adolescents* 9 à 18 ans  ,656,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Barres granola,15.7,1.4,13,18.4,mg,0.6,0.1,,3
+Potassium,Jeunes et adolescents* 9 à 18 ans  ,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Muffins et pains éclairs,X,X,,,mg,X,X,<10,3
 Potassium,Jeunes et adolescents* 9 à 18 ans  ,3103,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,,,72.3,2,68.4,76.1,mg,2.8,0.1,,2
 Potassium,Jeunes et adolescents* 9 à 18 ans  ,2364,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Grains céréaliers et farines,33.4,1.6,30.3,36.4,mg,1.3,0.1,,3
 Potassium,Jeunes et adolescents* 9 à 18 ans  ,1020,des,Produits céréaliers,des,Pâtes alimentaires - riz - grains céréaliers et farines,des,Pâtes alimentaires,22.3,1.4,19.5,25.1,mg,0.9,0.1,,3
@@ -7369,147 +7369,147 @@ Potassium,Jeunes et adolescents* 9 à 18 ans  ,3619,des,Soupes - sauces - Épice
 Potassium,Jeunes et adolescents* 9 à 18 ans  ,1553,des,Soupes - sauces - Épices et autres ingrédients,des,Sauces et sauces brunes,,,31.7,2,27.8,35.7,mg,1.2,0.1,,2
 Potassium,Jeunes et adolescents* 9 à 18 ans  ,747,des,Soupes - sauces - Épices et autres ingrédients,des,Soupes,,,21.5,2.3,16.9,26.1,mg,0.8,0.1,,2
 Potassium,Jeunes et adolescents* 9 à 18 ans  ,3417,des,Soupes - sauces - Épices et autres ingrédients,des,Épices - assaisonnements et autres ingrédients ,,,12.5,0.8,11,14.1,mg,0.5,0,,2
-Potassium,Jeunes et adolescents* 9 à 18 ans  ,3420,des,Confiseries - sucres et grignotines salées,,,,,198.9,13.3,172.8,225.1,mg,7.8,0.5,,1
-Potassium,Jeunes et adolescents* 9 à 18 ans  ,1608,des,Confiseries - sucres et grignotines salées,des,Confiseries,,,26.2,1.7,22.8,29.5,mg,1,0.1,,2
-Potassium,Jeunes et adolescents* 9 à 18 ans  ,794,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Bonbons,3.4,0.4,2.6,4.2,mg,0.1,0,,3
-Potassium,Jeunes et adolescents* 9 à 18 ans  ,938,des,Confiseries - sucres et grignotines salées,des,Confiseries,du,Chocolat - bonbons et barres,20.6,1.6,17.4,23.8,mg,0.8,0.1,,3
-Potassium,Jeunes et adolescents* 9 à 18 ans  ,166,des,Confiseries - sucres et grignotines salées,des,Confiseries,des,Poudings - garnitures à dessert et gélatine,2.2,0.3,1.5,2.8,mg,0.1,0,,3
-Potassium,Jeunes et adolescents* 9 à 18 ans  ,758,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,,,49.9,3.9,42.3,57.5,mg,2,0.2,,2
-Potassium,Jeunes et adolescents* 9 à 18 ans  ,599,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,48.6,3.9,41,56.2,mg,1.9,0.2,,3
-Potassium,Jeunes et adolescents* 9 à 18 ans  ,204,des,Confiseries - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,1.3,0.2,0.8,1.8,mg,0.1,0,,3
-Potassium,Jeunes et adolescents* 9 à 18 ans  ,1279,des,Confiseries - sucres et grignotines salées,des,Grignotines salées,,,102,12.7,77,126.9,mg,4,0.5,,2
-Potassium,Jeunes et adolescents* 9 à 18 ans  ,2738,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,,,20.9,2.4,16.1,25.7,mg,0.8,0.1,,2
-Potassium,Jeunes et adolescents* 9 à 18 ans  ,269,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,1.8,0.3,1.1,2.4,mg,0.1,0,E,3
-Potassium,Jeunes et adolescents* 9 à 18 ans  ,1069,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,18.1,2.4,13.4,22.8,mg,0.7,0.1,,3
-Potassium,Jeunes et adolescents* 9 à 18 ans  ,19,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mg,0,0,,3
-Potassium,Jeunes et adolescents* 9 à 18 ans  ,2377,des,Confiseries - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,1.1,0.1,0.8,1.3,mg,0,0,,3
-Calcium,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,1.8,0.1,1.6,1.9,mg,0.2,0,,3
-Calcium,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.5,0.1,0.2,0.7,mg,0.1,0,E,3
-Calcium,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,1.7,0.1,1.4,2,mg,0.2,0,,3
-Calcium,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,mg,F,F,F,3
-Calcium,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,1.4,0.1,1.2,1.7,mg,0.2,0,,3
-Calcium,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.7,0.2,0.2,1.1,mg,0.1,0,E,3
-Calcium,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,2.8,0.2,2.3,3.3,mg,0.3,0,,3
-Calcium,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,mg,X,X,<10,3
-Glucides,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,3.5,0.1,3.3,3.8,g,1.6,0.1,,3
-Glucides,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.3,0.1,0.2,0.5,g,0.1,0,E,3
-Glucides,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,3.4,0.2,2.9,3.8,g,1.3,0.1,,3
-Glucides,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.3,0.1,0,0.5,g,0.1,0.1,E,3
-Glucides,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,2.8,0.2,2.4,3.3,g,1.5,0.1,,3
-Glucides,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.5,0.1,0.2,0.7,g,0.2,0.1,E,3
-Glucides,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,5.7,0.4,4.9,6.5,g,2.7,0.2,,3
-Glucides,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,g,X,X,<10,3
-Fibres alimentaires,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.1,0,0.1,0.1,g,0.7,0,,3
-Fibres alimentaires,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,g,0.1,0,,3
-Fibres alimentaires,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.1,0,0.1,0.1,g,0.6,0.1,,3
-Fibres alimentaires,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,g,0.1,0,,3
-Fibres alimentaires,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.1,0,0.1,0.1,g,0.6,0,,3
-Fibres alimentaires,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,g,0.1,0,,3
-Fibres alimentaires,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.2,0,0.2,0.2,g,1.4,0.1,,3
-Fibres alimentaires,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,g,X,X,<10,3
-Énergie,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,23.5,0.9,21.8,25.2,kcal,1.3,0,,3
-Énergie,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,2.7,0.7,1.4,4,kcal,0.1,0,E,3
-Énergie,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,22.3,1.5,19.4,25.2,kcal,1,0.1,,3
-Énergie,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,kcal,F,F,F,3
-Énergie,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,18.7,1.4,16,21.5,kcal,1.2,0.1,,3
-Énergie,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,3.8,1.2,1.4,6.1,kcal,0.2,0.1,E,3
-Énergie,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,37.5,2.8,32.1,43,kcal,2.5,0.2,,3
-Énergie,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,kcal,X,X,<10,3
-Folate,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,5.4,0.2,5,5.8,mcg (DFE),1.2,0,,3
-Folate,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.1,0,0.1,0.2,mcg (DFE),0,0,,3
-Folate,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,4.9,0.3,4.2,5.5,mcg (DFE),1,0.1,,3
-Folate,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.1,0,0,0.2,mcg (DFE),0,0,,3
-Folate,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,4.6,0.4,3.8,5.4,mcg (DFE),1.2,0.1,,3
-Folate,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,mcg (DFE),F,F,F,3
-Folate,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,8.9,0.6,7.6,10.1,mcg (DFE),2.5,0.2,,3
-Folate,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,mcg (DFE),X,X,<10,3
-Fer,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.2,0,0.2,0.2,mg,1.9,0.1,,3
-Fer,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,mg,0.2,0,,3
-Fer,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.2,0,0.2,0.2,mg,1.5,0.1,,3
-Fer,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,mg,0.1,0.1,,3
-Fer,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.2,0,0.1,0.2,mg,1.6,0.1,,3
-Fer,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,mg,0.3,0.1,,3
-Fer,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.4,0,0.3,0.4,mg,3.7,0.3,,3
-Fer,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,mg,X,X,<10,3
-Potassium,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,8.5,0.3,7.9,9.2,mg,0.3,0,,3
-Potassium,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,1.1,0.2,0.6,1.5,mg,0,0,E,3
-Potassium,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,8.1,0.6,6.9,9.3,mg,0.3,0,,3
-Potassium,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,mg,F,F,F,3
-Potassium,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,6.5,0.5,5.6,7.4,mg,0.3,0,,3
-Potassium,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,1.5,0.4,0.7,2.4,mg,0.1,0,E,3
-Potassium,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,13.9,1.1,11.8,16,mg,0.6,0,,3
-Potassium,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,mg,X,X,<10,3
-Protéine,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.3,0,0.3,0.3,g,0.4,0,,3
-Protéine,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.1,0,0,0.1,g,0.1,0,,3
-Protéine,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.3,0,0.2,0.3,g,0.3,0,,3
-Protéine,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0.1,g,0.1,0,,3
-Protéine,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.2,0,0.2,0.3,g,0.4,0,,3
-Protéine,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.1,0,0,0.1,g,0.1,0,,3
-Protéine,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.5,0,0.4,0.5,g,0.8,0.1,,3
-Protéine,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,g,X,X,<10,3
-Acides gras saturés,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.3,0,0.3,0.3,g,1.4,0.1,,3
-Acides gras saturés,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.1,0,0,0.1,g,0.3,0.1,,3
-Acides gras saturés,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.3,0,0.3,0.3,g,1.2,0.1,,3
-Acides gras saturés,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.1,0,0,0.1,g,0.3,0.1,,3
-Acides gras saturés,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.2,0,0.2,0.3,g,1.3,0.1,,3
-Acides gras saturés,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.1,0,0,0.2,g,0.5,0.2,,3
-Acides gras saturés,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.5,0,0.4,0.5,g,2.4,0.2,,3
-Acides gras saturés,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,g,X,X,<10,3
-Sodium,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,18.9,0.7,17.5,20.4,mg,0.7,0,,3
-Sodium,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,7.2,1.7,3.8,10.5,mg,0.3,0.1,E,3
-Sodium,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,17.8,1.2,15.4,20.2,mg,0.6,0,,3
-Sodium,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,mg,F,F,F,3
-Sodium,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,15.4,1.2,13.1,17.7,mg,0.7,0.1,,3
-Sodium,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,10.1,3.2,3.9,16.3,mg,0.4,0.1,E,3
-Sodium,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,31.1,2.4,26.4,35.9,mg,1.5,0.1,,3
-Sodium,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,mg,X,X,<10,3
-Lipides totaux,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,1,0,0.9,1,g,1.4,0.1,,3
-Lipides totaux,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.1,0,0.1,0.2,g,0.2,0,,3
-Lipides totaux,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.9,0.1,0.8,1,g,1.1,0.1,,3
-Lipides totaux,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,g,F,F,F,3
-Lipides totaux,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.7,0.1,0.6,0.9,g,1.3,0.1,,3
-Lipides totaux,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,g,F,F,F,3
-Lipides totaux,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,1.5,0.1,1.3,1.7,g,2.8,0.2,,3
-Lipides totaux,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,g,X,X,<10,3
-Sucres totaux,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,1.5,0.1,1.4,1.6,g,1.7,0.1,,3
-Sucres totaux,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,g,0,0,,3
-Sucres totaux,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,1.5,0.1,1.3,1.8,g,1.6,0.1,,3
-Sucres totaux,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,g,0,0,,3
-Sucres totaux,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,1.1,0.1,1,1.3,g,1.4,0.1,,3
-Sucres totaux,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0.1,g,0.1,0,,3
-Sucres totaux,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,2.4,0.2,2,2.8,g,2.5,0.2,,3
-Sucres totaux,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,g,X,X,<10,3
-Vitamine D,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,mcg,0,0,,3
-Vitamine D,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0,0,0,0,mcg,0,0,,3
-Vitamine D,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,mcg,0,0,,3
-Vitamine D,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0,0,0,0,mcg,0,0,,3
-Vitamine D,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,mcg,0,0,,3
-Vitamine D,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0,0,0,0,mcg,0,0,,3
-Vitamine D,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,mcg,X,X,<10,3
-Énergie,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,kcal,F,F,F,3
-Énergie,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,33.5,2,29.6,37.5,kcal,1.6,0.1,,3
-Glucides,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,g,F,F,F,3
-Glucides,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,5,0.3,4.4,5.5,g,1.8,0.1,,3
-Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,g,0,0,,3
-Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.2,0,0.1,0.2,g,1,0.1,,3
-Sucres totaux,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,g,0,0,,3
-Sucres totaux,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,2.2,0.1,2,2.5,g,1.9,0.1,,3
-Protéine,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,g,0,0,,3
-Protéine,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.4,0,0.3,0.4,g,0.5,0,,3
-Lipides totaux,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0.1,g,0.1,0,,3
-Lipides totaux,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,1.4,0.1,1.3,1.6,g,1.9,0.1,,3
-Acides gras saturés,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,g,0.1,0,,3
-Acides gras saturés,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.5,0,0.4,0.5,g,1.8,0.1,,3
-Vitamine D,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,mcg,0,0,,3
-Vitamine D,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0,0,0,0,mcg,0,0,,3
-Folate,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,mcg (DFE,F,F,F,3
-Folate,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,7.5,0.5,6.6,8.4,mcg (DFE,1.6,0.1,,3
-Calcium,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,mg,F,F,F,3
-Calcium,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,2.4,0.2,2,2.8,mg,0.2,0,,3
-Fer,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,mg,0.1,0,,3
-Fer,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,0.4,0,0.3,0.5,mg,3,0.2,,3
-Sodium,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,mg,F,F,F,3
-Sodium,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,26,1.6,22.8,29.2,mg,0.9,0.1,,3
-Potassium,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,mg,F,F,F,3
-Potassium,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola,des,Biscuits,13.1,0.9,11.4,14.8,mg,0.5,0,,3
+Potassium,Jeunes et adolescents* 9 à 18 ans  ,3420,des,Confiserie - sucres et grignotines salées,,,,,198.9,13.3,172.8,225.1,mg,7.8,0.5,,1
+Potassium,Jeunes et adolescents* 9 à 18 ans  ,1608,des,Confiserie - sucres et grignotines salées,des,Confiserie,,,26.2,1.7,22.8,29.5,mg,1,0.1,,2
+Potassium,Jeunes et adolescents* 9 à 18 ans  ,794,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Bonbons,3.4,0.4,2.6,4.2,mg,0.1,0,,3
+Potassium,Jeunes et adolescents* 9 à 18 ans  ,938,des,Confiserie - sucres et grignotines salées,des,Confiserie,du,Chocolat - bonbons et barres,20.6,1.6,17.4,23.8,mg,0.8,0.1,,3
+Potassium,Jeunes et adolescents* 9 à 18 ans  ,166,des,Confiserie - sucres et grignotines salées,des,Confiserie,des,Gélatine - garnitures à dessert et poudings,2.2,0.3,1.5,2.8,mg,0.1,0,,3
+Potassium,Jeunes et adolescents* 9 à 18 ans  ,758,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,,,49.9,3.9,42.3,57.5,mg,2,0.2,,2
+Potassium,Jeunes et adolescents* 9 à 18 ans  ,599,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Produits laitiers glacés et analogues,48.6,3.9,41,56.2,mg,1.9,0.2,,3
+Potassium,Jeunes et adolescents* 9 à 18 ans  ,204,des,Confiserie - sucres et grignotines salées,des,Desserts glacés,des,Popsicles et sorbet,1.3,0.2,0.8,1.8,mg,0.1,0,,3
+Potassium,Jeunes et adolescents* 9 à 18 ans  ,1279,des,Confiserie - sucres et grignotines salées,des,Grignotines salées,,,102,12.7,77,126.9,mg,4,0.5,,2
+Potassium,Jeunes et adolescents* 9 à 18 ans  ,2738,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,,,20.9,2.4,16.1,25.7,mg,0.8,0.1,,2
+Potassium,Jeunes et adolescents* 9 à 18 ans  ,269,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Confitures - gelées et marmelades,1.8,0.3,1.1,2.4,mg,0.1,0,E,3
+Potassium,Jeunes et adolescents* 9 à 18 ans  ,1069,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Autres sucres et sirops,18.1,2.4,13.4,22.8,mg,0.7,0.1,,3
+Potassium,Jeunes et adolescents* 9 à 18 ans  ,19,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Édulcorants,0,0,0,0,mg,0,0,,3
+Potassium,Jeunes et adolescents* 9 à 18 ans  ,2377,des,Confiserie - sucres et grignotines salées,des,Sucres - sirops et confitures,des,Sucres,1.1,0.1,0.8,1.3,mg,0,0,,3
+Calcium,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,1.8,0.1,1.6,1.9,mg,0.2,0,,3
+Calcium,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.5,0.1,0.2,0.7,mg,0.1,0,E,3
+Calcium,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,1.7,0.1,1.4,2,mg,0.2,0,,3
+Calcium,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,mg,F,F,F,3
+Calcium,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,1.4,0.1,1.2,1.7,mg,0.2,0,,3
+Calcium,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.7,0.2,0.2,1.1,mg,0.1,0,E,3
+Calcium,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,2.8,0.2,2.3,3.3,mg,0.3,0,,3
+Calcium,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,mg,X,X,<10,3
+Glucides,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,3.5,0.1,3.3,3.8,g,1.6,0.1,,3
+Glucides,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.3,0.1,0.2,0.5,g,0.1,0,E,3
+Glucides,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,3.4,0.2,2.9,3.8,g,1.3,0.1,,3
+Glucides,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.3,0.1,0,0.5,g,0.1,0.1,E,3
+Glucides,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,2.8,0.2,2.4,3.3,g,1.5,0.1,,3
+Glucides,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.5,0.1,0.2,0.7,g,0.2,0.1,E,3
+Glucides,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,5.7,0.4,4.9,6.5,g,2.7,0.2,,3
+Glucides,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,g,X,X,<10,3
+Fibres alimentaires,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,0.1,0,0.1,0.1,g,0.7,0,,3
+Fibres alimentaires,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,g,0.1,0,,3
+Fibres alimentaires,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,0.1,0,0.1,0.1,g,0.6,0.1,,3
+Fibres alimentaires,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,g,0.1,0,,3
+Fibres alimentaires,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,0.1,0,0.1,0.1,g,0.6,0,,3
+Fibres alimentaires,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,g,0.1,0,,3
+Fibres alimentaires,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,0.2,0,0.2,0.2,g,1.4,0.1,,3
+Fibres alimentaires,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,g,X,X,<10,3
+Énergie,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,23.5,0.9,21.8,25.2,kcal,1.3,0,,3
+Énergie,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,2.7,0.7,1.4,4,kcal,0.1,0,E,3
+Énergie,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,22.3,1.5,19.4,25.2,kcal,1,0.1,,3
+Énergie,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,kcal,F,F,F,3
+Énergie,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,18.7,1.4,16,21.5,kcal,1.2,0.1,,3
+Énergie,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,3.8,1.2,1.4,6.1,kcal,0.2,0.1,E,3
+Énergie,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,37.5,2.8,32.1,43,kcal,2.5,0.2,,3
+Énergie,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,kcal,X,X,<10,3
+Folate,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,5.4,0.2,5,5.8,mcg (DFE),1.2,0,,3
+Folate,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.1,0,0.1,0.2,mcg (DFE),0,0,,3
+Folate,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,4.9,0.3,4.2,5.5,mcg (DFE),1,0.1,,3
+Folate,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.1,0,0,0.2,mcg (DFE),0,0,,3
+Folate,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,4.6,0.4,3.8,5.4,mcg (DFE),1.2,0.1,,3
+Folate,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,mcg (DFE),F,F,F,3
+Folate,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,8.9,0.6,7.6,10.1,mcg (DFE),2.5,0.2,,3
+Folate,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,mcg (DFE),X,X,<10,3
+Fer,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,0.2,0,0.2,0.2,mg,1.9,0.1,,3
+Fer,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,mg,0.2,0,,3
+Fer,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,0.2,0,0.2,0.2,mg,1.5,0.1,,3
+Fer,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,mg,0.1,0.1,,3
+Fer,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,0.2,0,0.1,0.2,mg,1.6,0.1,,3
+Fer,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,mg,0.3,0.1,,3
+Fer,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,0.4,0,0.3,0.4,mg,3.7,0.3,,3
+Fer,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,mg,X,X,<10,3
+Potassium,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,8.5,0.3,7.9,9.2,mg,0.3,0,,3
+Potassium,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,1.1,0.2,0.6,1.5,mg,0,0,E,3
+Potassium,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,8.1,0.6,6.9,9.3,mg,0.3,0,,3
+Potassium,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,mg,F,F,F,3
+Potassium,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,6.5,0.5,5.6,7.4,mg,0.3,0,,3
+Potassium,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,1.5,0.4,0.7,2.4,mg,0.1,0,E,3
+Potassium,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,13.9,1.1,11.8,16,mg,0.6,0,,3
+Potassium,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,mg,X,X,<10,3
+Protéine,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,0.3,0,0.3,0.3,g,0.4,0,,3
+Protéine,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.1,0,0,0.1,g,0.1,0,,3
+Protéine,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,0.3,0,0.2,0.3,g,0.3,0,,3
+Protéine,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0.1,g,0.1,0,,3
+Protéine,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,0.2,0,0.2,0.3,g,0.4,0,,3
+Protéine,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.1,0,0,0.1,g,0.1,0,,3
+Protéine,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,0.5,0,0.4,0.5,g,0.8,0.1,,3
+Protéine,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,g,X,X,<10,3
+Acides gras saturés,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,0.3,0,0.3,0.3,g,1.4,0.1,,3
+Acides gras saturés,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.1,0,0,0.1,g,0.3,0.1,,3
+Acides gras saturés,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,0.3,0,0.3,0.3,g,1.2,0.1,,3
+Acides gras saturés,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.1,0,0,0.1,g,0.3,0.1,,3
+Acides gras saturés,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,0.2,0,0.2,0.3,g,1.3,0.1,,3
+Acides gras saturés,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.1,0,0,0.2,g,0.5,0.2,,3
+Acides gras saturés,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,0.5,0,0.4,0.5,g,2.4,0.2,,3
+Acides gras saturés,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,g,X,X,<10,3
+Sodium,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,18.9,0.7,17.5,20.4,mg,0.7,0,,3
+Sodium,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,7.2,1.7,3.8,10.5,mg,0.3,0.1,E,3
+Sodium,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,17.8,1.2,15.4,20.2,mg,0.6,0,,3
+Sodium,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,mg,F,F,F,3
+Sodium,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,15.4,1.2,13.1,17.7,mg,0.7,0.1,,3
+Sodium,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,10.1,3.2,3.9,16.3,mg,0.4,0.1,E,3
+Sodium,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,31.1,2.4,26.4,35.9,mg,1.5,0.1,,3
+Sodium,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,mg,X,X,<10,3
+Lipides totaux,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,1,0,0.9,1,g,1.4,0.1,,3
+Lipides totaux,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0.1,0,0.1,0.2,g,0.2,0,,3
+Lipides totaux,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,0.9,0.1,0.8,1,g,1.1,0.1,,3
+Lipides totaux,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,g,F,F,F,3
+Lipides totaux,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,0.7,0.1,0.6,0.9,g,1.3,0.1,,3
+Lipides totaux,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,g,F,F,F,3
+Lipides totaux,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,1.5,0.1,1.3,1.7,g,2.8,0.2,,3
+Lipides totaux,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,g,X,X,<10,3
+Sucres totaux,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,1.5,0.1,1.4,1.6,g,1.7,0.1,,3
+Sucres totaux,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,g,0,0,,3
+Sucres totaux,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,1.5,0.1,1.3,1.8,g,1.6,0.1,,3
+Sucres totaux,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,g,0,0,,3
+Sucres totaux,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,1.1,0.1,1,1.3,g,1.4,0.1,,3
+Sucres totaux,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0.1,g,0.1,0,,3
+Sucres totaux,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,2.4,0.2,2,2.8,g,2.5,0.2,,3
+Sucres totaux,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,g,X,X,<10,3
+Vitamine D,Population 1 an et +,106,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,mcg,0,0,,3
+Vitamine D,Population 1 an et +,3755,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,0,0,0,0,mcg,0,0,,3
+Vitamine D,Hommes adultes 19 ans +,40,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,mcg,0,0,,3
+Vitamine D,Hommes adultes 19 ans +,987,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,0,0,0,0,mcg,0,0,,3
+Vitamine D,Femmes adultes* 19 ans +,45,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,mcg,0,0,,3
+Vitamine D,Femmes adultes* 19 ans +,1145,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,722,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,0,0,0,0,mcg,0,0,,3
+Vitamine D,Enfants 1 à 8 ans,,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,X,X,,,mcg,X,X,<10,3
+Énergie,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,kcal,F,F,F,3
+Énergie,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,33.5,2,29.6,37.5,kcal,1.6,0.1,,3
+Glucides,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,g,F,F,F,3
+Glucides,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,5,0.3,4.4,5.5,g,1.8,0.1,,3
+Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,g,0,0,,3
+Fibres alimentaires,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,0.2,0,0.1,0.2,g,1,0.1,,3
+Sucres totaux,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,g,0,0,,3
+Sucres totaux,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,2.2,0.1,2,2.5,g,1.9,0.1,,3
+Protéine,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,g,0,0,,3
+Protéine,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,0.4,0,0.3,0.4,g,0.5,0,,3
+Lipides totaux,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0.1,g,0.1,0,,3
+Lipides totaux,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,1.4,0.1,1.3,1.6,g,1.9,0.1,,3
+Acides gras saturés,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,g,0.1,0,,3
+Acides gras saturés,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,0.5,0,0.4,0.5,g,1.8,0.1,,3
+Vitamine D,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,mcg,0,0,,3
+Vitamine D,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,0,0,0,0,mcg,0,0,,3
+Folate,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,mcg (DFE,F,F,F,3
+Folate,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,7.5,0.5,6.6,8.4,mcg (DFE,1.6,0.1,,3
+Calcium,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,mg,F,F,F,3
+Calcium,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,2.4,0.2,2,2.8,mg,0.2,0,,3
+Fer,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,0,0,0,0,mg,0.1,0,,3
+Fer,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,0.4,0,0.3,0.5,mg,3,0.2,,3
+Sodium,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,mg,F,F,F,3
+Sodium,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,26,1.6,22.8,29.2,mg,0.9,0.1,,3
+Potassium,Jeunes et adolescents* 9 à 18 ans ,13,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits à la poudre à pâte,F,F,,,mg,F,F,F,3
+Potassium,Jeunes et adolescents* 9 à 18 ans ,850,des,Produits céréaliers,des,Biscuits - gâteaux - tartes - biscuits à la poudre à pâte et barres granola,des,Biscuits,13.1,0.9,11.4,14.8,mg,0.5,0,,3


### PR DESCRIPTION
- To catch future bugs regarding the food group names in the TABLE/GRAPH CSVs not matching the food group names in the  description CSV. Any mismatch found will be printed in the console

  Using this check, on top of the name changes for
     - "Biscuits - gâteaux - tartes - biscuits à  la poudre à pâte et barres granola" AND
     - "Confiseries - sucres et grignotines salées"
  
  in the TABLE CSV discussed in the meeting, we also found the following names to be changed:
    - Pommes ---> Pomme
    - Bananes ---> Banane
    - Confiseries ---> Confiserie
    - Poudings - garnitures à dessert et gélatine ---> Gélatine - garnitures à dessert et poudings
    - Crême et autres types de lait ---> Crème et autres types de lait
    - Préparations pour nourrissons ---> Préparation pour nourrissons

- Converted all food group dictionary keys in the backend (not shown to the user) to lowercase to account for capatalization mismatches in the CSVs