### PR TITLE
Capitalize food group name in the bar graph table

### DIFF
--- a/app/backend.js
+++ b/app/backend.js
@@ -427,7 +427,8 @@ export class Model {
         // Retrieve the specific value for each row
         const result = [];
         Object.entries(tableRows).forEach(([foodLevelGroup, d]) => {
-            result.push([foodLevelGroup].concat(d.map(g => headingsPerSexAgeGroupKeys.map(key => Model.getFoodIngredientNumberedCell(g, key))).flat()));
+            const foodLevelGroupName = d[0][FoodIngredientDataColNames.foodGroupLv1];
+            result.push([foodLevelGroupName].concat(d.map(g => headingsPerSexAgeGroupKeys.map(key => Model.getFoodIngredientNumberedCell(g, key))).flat()));
         });
 
         // create the title for the CSV


### PR DESCRIPTION
- Based off this change https://github.com/BFSSI-Bioinformatics-Lab/CCHS-food-source-contribution/pull/100 , the food group names were normalized by converting all the names to lowercase and stripping out any spaces to account for any capitalization errors or spacing errors that may occur in the CSV files. That way, the food groups in the **Descriptions CSV** matches better with the food groups in the **Table/Graph CSV**

- The table for the bar graph is supposed to display the the capitalized version of the food group name from the CSV, not the normalized food group name