### PR TITLE
Better alignment for the x-axis text

### DIFF
--- a/app/assets.js
+++ b/app/assets.js
@@ -70,7 +70,6 @@ export const GraphDims = Object.freeze({
     upperGraphTooltipMinWidth: 140,
     upperGraphAxesFontSize: 20,
     upperGraphXAxisTickFontSize: 13,
-    upperGraphXAxisTickWidth: 140,
     upperGraphYAxisTickFontSize: 14,
     upperGraphTooltipFontSize: 14,
     upperGraphTooltipPaddingVert: 8,
@@ -413,7 +412,16 @@ export const TranslationObj = {
                     "{{ percentage}}% {{ interpretationValue }}"
                 ],
                 "tableSubHeadingFirstCol": "Food Group",
-                "tableSubHeadings": ["Amount ({{unit}})", "Amount SE", "% of total intake", "% SE"]
+                "tableSubHeadings": ["Amount ({{unit}})", "Amount SE", "% of total intake", "% SE"],
+
+                // widths for the labels on the x-axis of the graph
+                "upperGraphXAxisTickWidths": {
+                    "Population1Up": 140,
+                    "Children1To8": 140,
+                    "YouthAndAdolescents": 135,
+                    "AdultMales": 140,
+                    "AdultFemales": 140
+                } 
             },
             "lowerGraph": {
                 "graphTitle": {
@@ -576,7 +584,16 @@ export const TranslationObj = {
                     "{{ percentage }}% {{ interpretationValue }}"
                 ],
                 "tableSubHeadingFirstCol": "Groupe d'Aliments",
-                "tableSubHeadings": ["Moyenne ({{unit}})", "ET Moyenne", "% de l'Apport Total", "ET %"]
+                "tableSubHeadings": ["Moyenne ({{unit}})", "ET Moyenne", "% de l'Apport Total", "ET %"],
+
+                // widths for the labels on the x-axis of the graph
+                "upperGraphXAxisTickWidths": {
+                    "Population1Up": 140,
+                    "Children1To8": 140,
+                    "YouthAndAdolescents": 140,
+                    "AdultMales": 110,
+                    "AdultFemales": 110
+                } 
             },
             "lowerGraph": {
                 "graphTitle": {

--- a/app/backend.js
+++ b/app/backend.js
@@ -49,6 +49,15 @@ export class SetTools {
     }
 }
 
+// DictTools: Class for handling dictionaries
+export class DictTools {
+
+    // invert(dict): Inverts a dictionary (keys become values and values become keys)
+    static invert(dict) {
+        return Object.fromEntries(Object.entries(dict).map(([key, value]) => [value, key]));
+    }
+}
+
 // TableTools: Class for handling any table-like data ex. list of lists/matrices, list of dictionaries
 //    dictionaries of dictionaries, dictionaries of lists, etc...
 export class TableTools {
@@ -95,6 +104,8 @@ export class Model {
     // load(): Setup all the needed data for the user interface
     async load() {
         this.ageSexGroupHeadings = SortedAgeSexGroupKeys.map((ageSexKey) => Translation.translate(`AgeSexGroupHeadings.${ageSexKey}`));
+        this.ageSexGroupHeadingKeys = DictTools.invert(Translation.translate("AgeSexGroupHeadings", { returnObjects: true }));
+
         this.foodDescExeceptions = Translation.translate("FoodDescriptionExceptionKeys", { returnObjects: true });
 
         let result = await Promise.all([this.loadFoodGroupDescriptionData(), this.loadGraphFoodIngredientsData(), this.loadTableFoodIngredientsData()]);

--- a/app/barGraph.js
+++ b/app/barGraph.js
@@ -230,9 +230,12 @@ export function upperGraph(model){
 
         // draw the wrapped text for the x-axis ticks
         upperGraphXAxisLine.selectAll(".tick text").each((data, ind, textElements) => {
+            const ageSexGroupKey = model.ageSexGroupHeadingKeys[data];
             const textGroup = d3.select(textElements[ind]);
+            const textWidth = Translation.translate(`upperGraph.upperGraphXAxisTickWidths.${ageSexGroupKey}`);
             textGroup.text("").attr("dy", null);
-            drawWrappedText({textGroup: textGroup, text: data, width: GraphDims.upperGraphXAxisTickWidth, fontSize: GraphDims.upperGraphXAxisTickFontSize, textY: 10});
+
+            drawWrappedText({textGroup: textGroup, text: data, width: textWidth, fontSize: GraphDims.upperGraphXAxisTickFontSize, textY: 10});
         });
 
         const nutrientTotalByAgeSexGroup = model.findNutrientTotalAmtPerAgeSexGroup(graphType);


### PR DESCRIPTION
- There is no general text width that causes all the text for the age groups to "look nice" in both languages
(eg. having the "9" be with the "to 18" in youth and adolescents)

- Solution is to have custom text widths for each age group for every language