### PR TITLE
Fix width of "Youth and Adolescents" graph label

### DIFF
--- a/app/assets.js
+++ b/app/assets.js
@@ -418,7 +418,7 @@ export const TranslationObj = {
                 "upperGraphXAxisTickWidths": {
                     "Population1Up": 140,
                     "Children1To8": 140,
-                    "YouthAndAdolescents": 135,
+                    "YouthAndAdolescents": 130,
                     "AdultMales": 140,
                     "AdultFemales": 140
                 } 


### PR DESCRIPTION
- So that the "9" is with the "to 18y" on the second line