### PR TITLE
Fix the Spices and Other Ingredients not showing

### DIFF
--- a/app/assets.js
+++ b/app/assets.js
@@ -351,14 +351,15 @@ export const TranslationObj = {
 
             // certain keys in the graph's food ingredient CSV file that do not map to
             //  any keys in the food description CSV file
-            // Note: Copy the exact food group name from the food description CSV file
+            // Note: Copy the exact food group name from the food description CSV file,
+            //  then convert the name to lowercase without any trailing/leading spaces
             FoodDescriptionExceptionKeys: {
-                "Spices - Seasonings & Other Ingredients": {
+                "spices - seasonings & other ingredients": {
                     "OtherNutrients": "Spices - Seasonings & Other Ingredients (all nutrients excluding sodium)",
                     "Sodium": "Spices - Seasonings & Other Ingredients (sodium only)"
                 },
 
-                "Vegetables Including Potatoes": {
+                "vegetables including potatoes": {
                     "OtherNutrients": "Vegetables Including Potatoes (all nutrients excluding sodium)",
                     "Sodium": "Vegetables Including Potatoes (sodium only)"
                 }
@@ -524,14 +525,15 @@ export const TranslationObj = {
 
             // certain keys in the graph's food ingredient CSV file that do not map to
             //  any keys in the food description CSV file
-            // Note: Copy the exact food group names (for both keys and values) from the food description CSV file
+            // Note: Copy the exact food group names (for both keys and values) from the food description CSV file, 
+            //  then convert the name to lowercase without any trailing/leading spaces
             FoodDescriptionExceptionKeys: {
-                "Épices - assaisonnements et autres ingrédients": {
+                "épices - assaisonnements et autres ingrédients": {
                     "OtherNutrients": "Épices - assaisonnements et autres ingrédients  (tous les nutriments excluant sodium)",
                     "Sodium": "Épices - assaisonnements et autres ingrédients (sodium uniquement)"
                 },
 
-                "Légumes incluant pommes de terre": {
+                "légumes incluant pommes de terre": {
                     "OtherNutrients": "Légumes incluant pommes de terre (tous les nutriments excluant sodium)",
                     "Sodium": "Légumes incluant pommes de terre  (sodium uniquement)"
                 }

--- a/app/backend.js
+++ b/app/backend.js
@@ -282,8 +282,8 @@ export class Model {
 
     // getFoodDescription(nutrient, foodGroup): Retrieves the corresponding food description for 'foodGroup' and 'nutrient'
     getFoodDescription(nutrient, foodGroup) {
+        foodGroup = Model.cleanFoodGroupName(foodGroup);
         if (this.foodDescExeceptions[foodGroup] === undefined) {
-            foodGroup = Model.cleanFoodGroupName(foodGroup);
             return this.foodGroupDescriptionData[foodGroup][FoodGroupDescDataColNames.description];
         }
 

--- a/app/sunBurstGraph.js
+++ b/app/sunBurstGraph.js
@@ -1139,10 +1139,6 @@ export function lowerGraph(model){
         colour = colour === undefined ? null : colour;
 
         let foodGroupName = d.data.name;
-        if (mouseOverFoodGroupName !== null && mouseOverFoodGroupName == foodGroupName) {
-            return;
-        }
-
         mouseOverFoodGroupName = foodGroupName;
 
         let desc = "";


### PR DESCRIPTION
- The French Descriptions CSV had an extra space in its name, solution is to normalize the name
(strip spaces and convert to all lowercase)

- Also fix description from not showing when you:
  1. Hover on a food group
  2. Drag mouse away from food group
  3. Rehover on the food group