### PR TITLE
Make tooltips not block description box

### DIFF
--- a/app/assets.js
+++ b/app/assets.js
@@ -96,7 +96,7 @@ export const GraphDims = Object.freeze({
     upperGraphFooterPaddingHor: 10,
     upperGraphFootNoteSpacing: 10,
     lowerGraphWidth: 700,
-    lowerGraphHeight: 600,
+    lowerGraphHeight: 700,
     lowerGraphLeft: 60,
     lowerGraphRight: 400,
     lowerGraphTop: 60,

--- a/app/sunBurstGraph.js
+++ b/app/sunBurstGraph.js
@@ -565,6 +565,8 @@ export function lowerGraph(model){
             toolTipWidth = Math.max(toolTipWidth, 2 * GraphDims.lowerGraphTooltipPaddingHor + GraphDims.lowerGraphTooltipBorderWidth + 2 * GraphDims.lowerGraphTooltipTextPaddingHor + Math.max(titleDims.width, textDims.width));
             toolTip.background.attr("width", toolTipWidth);
 
+            toolTip.width = toolTipWidth;
+
             // -------------------------------------
 
             hoverToolTips[toolTipId] = toolTip;
@@ -718,8 +720,13 @@ export function lowerGraph(model){
     function positionHoverCard(toolTip, d){
         const relativeAngle = (d.x1 + d.x0)/2 + 3 * Math.PI / 2;
 
-        const x = GraphDims.lowerGraphArcRadius * Math.cos(relativeAngle) * (d.depth + 1);
+        let x = GraphDims.lowerGraphArcRadius * Math.cos(relativeAngle) * (d.depth + 1);
         const y = GraphDims.lowerGraphArcRadius * Math.sin(relativeAngle) * (d.depth);
+
+        if (x > 0) {
+            x -= toolTip.width;
+        }
+
         toolTip.group.attr("transform", `translate(${x}, ${y})`);
     }
 


### PR DESCRIPTION
- For the sunburst, arcs on the right side of the sunburst will have their tooltips displayed on the bottom-left of the arc while arcs on the left side of the sunburst will have their tooltips still displayed on the bottom-right

- The position for the tooltips on the left did not change since they do not block the description and if we do reposition those tooltips, their text will be cut off