### PR TITLE
Updated sunburst graph

### DIFF
--- a/app/assets.js
+++ b/app/assets.js
@@ -25,19 +25,19 @@ export const Colours = {
 
 // GraphColours: Colours specific to the graph
 export const GraphColours = {
-    "Baby Foods": "#BAABDA",
-    "Beverages (Excluding Milks)": "#F8CB2E",
-    "Dairy & Plant-Based Beverages": "#39B7E3",
-    "Fats & Oils": "#D8B384",
-    "Fish & Seafood": "#FF6969",
-    "Fruits & Vegetables": "#3CCF4E",
-    "Grain Products": "#EF5B0C",
-    "Meat & Poultry": "#BB2525",
-    "Meat Alternatives": "#AC7339",
-    "Nutritional Beverages & Bars": "#84F1CD",
-    "Soups - Sauces - Spices & Other Ingredients": "#005DD0",
-    "Sweets - Sugars & Savoury Snacks": "#824BD0",
-    "All Items": "#808080"
+    "Baby Foods": "#CEC3E5",
+    "Beverages (Excluding Milks)": "#FADB51",
+    "Dairy & Plant-Based Beverages": "#5DCCEB",
+    "Fats & Oils": "#E4C9A4",
+    "Fish & Seafood": "#FF8D8D",
+    "Fruits & Vegetables": "#61DD73",
+    "Grain Products": "#F48021",
+    "Meat & Poultry": "#CF4646",
+    "Meat Alternatives": "#C4955D",
+    "Nutritional Beverages & Bars": "#A4F5DC",
+    "Soups - Sauces - Spices & Other Ingredients": "#0082DE",
+    "Sweets - Sugars & Savoury Snacks": "#A270DE",
+    "All Items": "#A1A1A1"
 }
 
 
@@ -368,8 +368,8 @@ export const TranslationObj = {
             
             // Footnotes used in graphs and tables
             "FootNotes": {
-                "EInterpretationNote": "E: Data with a coefficient of variation (CV) from 16.6 % to 33.3 %; interpret with caution.", 
-                "FInterpretationNote": "F: Data with a CV greater than 33.3 % suppressed due to extreme sampling variability.",
+                "EInterpretationNote": "E: Data with a coefficient of variation (CV) from 16.6% to 33.3%; interpret with caution.", 
+                "FInterpretationNote": "F: Data with a CV greater than 33.3% suppressed due to extreme sampling variability.",
                 "XInterpretationNote": "X: Food with less than 10 eaters; suppressed to meet confidentiality requirements.", 
                 "excludePregnantAndLactating": "*Excludes pregnant and lactating women",
                 "sourceText": "Data Source: Statistics Canada, 2015 Canadian Community Health Survey - Nutrition, 2015, Share File.",
@@ -383,16 +383,16 @@ export const TranslationObj = {
 
             "upperGraph": {
                 "number": {
-                    "graphTitle": "Contribution of 12 food groups to daily intakes of {{ nutrient }} ({{ amountUnit }}/d and percentage (%) of total intake)",
+                    "graphTitle": "Contribution of 12 food groups to daily intakes of {{ nutrient }} ({{ amountUnit }}/d and % of total intake)",
                     "yAxisTitle": "{{nutrient}} Intake ({{ amountUnit }}/d)",
                     "switchTypeButton": "Switch to Percentage"
                 },
                 "percentage": {
-                    "graphTitle": "Contribution of 12 food groups to daily intakes of {{ nutrient }} ({{ amountUnit }}/d and percentage (%) of total intake)",
+                    "graphTitle": "Contribution of 12 food groups to daily intakes of {{ nutrient }} ({{ amountUnit }}/d and % of total intake)",
                     "yAxisTitle": "% of total {{nutrient}} intake",
                     "switchTypeButton": "Switch to Numbers"
                 },
-                "tableTitle": "Contribution of 12 food groups to daily intakes of {{ nutrient }} ({{ amountUnit }}/d and percentage (%) of total intake)",
+                "tableTitle": "Contribution of 12 food groups to daily intakes of {{ nutrient }} ({{ amountUnit }}/d and % of total intake)",
                 "toolTipTitle": "{{- name }}",
                 "toolTip_number": [
                     "Amount: {{amount}} {{ unit }}"
@@ -404,16 +404,16 @@ export const TranslationObj = {
                     "Amount: {{amount}} {{ unit }} {{ interpretationValue }}"
                 ],
                 "toolTip_percentage": [
-                    "{{ percentage}} %"
+                    "{{ percentage}}%"
                 ],
                 "toolTip_percentageOnlyInterpretation": [
                     "{{ interpretationValue }}"
                 ],
                 "toolTip_percentageWithInterpretation": [
-                    "{{ percentage}} % {{ interpretationValue }}"
+                    "{{ percentage}}% {{ interpretationValue }}"
                 ],
                 "tableSubHeadingFirstCol": "Food Group",
-                "tableSubHeadings": ["Amount ({{unit}})", "Amount SE", "Percentage (%) of total intake", "Percentage (%) SE"],
+                "tableSubHeadings": ["Amount ({{unit}})", "Amount SE", "% of total intake", "% SE"],
 
                 // widths for the labels on the x-axis of the graph
                 "upperGraphXAxisTickWidths": {
@@ -457,16 +457,16 @@ export const TranslationObj = {
                 "allFoodGroupsLabel": "All Food Groups",
                 "toolTipTitle": "{{- name }}",
                 "toolTip": [
-                    "{{ percentage }} % of {{ nutrient }} intake"
+                    "{{ percentage }}% of {{ nutrient }} intake"
                 ],
                 "toolTip_OnlyInterpretation": [
                     "{{ interpretationValue }}"
                 ],
                 "toolTip_WithInterpretation": [
-                    "{{ percentage }} % {{ interpretationValue }} of {{ nutrient }} intake"
+                    "{{ percentage }}% {{ interpretationValue }} of {{ nutrient }} intake"
                 ],
-                "tableHeadings": ["Food Group Level 1", "Food Group Level 2", "Food Group Level 3", "Amount ({{unit}})", "Amount SE", "Percentage (%) of total intake", "Percentage (%) SE"],
-                "tableAllDataHeadings": ["Age-sex Group", "Food Group Level 1", "Food Group Level 2", "Food Group Level 3", "Amount ({{unit}})", "Amount SE", "Percentage (%) of total intake", "Percentage (%) SE"],
+                "tableHeadings": ["Food Group Level 1", "Food Group Level 2", "Food Group Level 3", "Amount ({{unit}})", "Amount SE", "% of total intake", "% SE"],
+                "tableAllDataHeadings": ["Age-sex Group", "Food Group Level 1", "Food Group Level 2", "Food Group Level 3", "Amount ({{unit}})", "Amount SE", "% of total intake", "% SE"],
                 "allDataCSVFileName": {
                     "All Displayed": "Contribution of food groups and sub-groups to {{nutrient}} intake",
                     "Filter Only Level 2": "Contribution of level 2 food groups to {{nutrient}} intake" 
@@ -541,8 +541,8 @@ export const TranslationObj = {
 
             // Footnotes used in graphs and tables
             "FootNotes": {
-                "EInterpretationNote": "E: Données dont le coefficient de variation (CV) se situe entre 16,6 % à 33,3 %; interpréter avec prudence.", 
-                "FInterpretationNote": "F: Données dont le CV est supérieur à 33,3 % supprimées en raison de l'extrême variabilité d'échantillonnage.", 
+                "EInterpretationNote": "E: Données dont le coefficient de variation (CV) se situe entre 16,6% à 33,3%; interpréter avec prudence.", 
+                "FInterpretationNote": "F: Données dont le CV est supérieur à 33,3% supprimées en raison de l'extrême variabilité d'échantillonnage.", 
                 "XInterpretationNote": "X: Groupe d’aliment avec moins de 10 mangeurs ; supprimé pour des raisons de confidentialité.", 
                 "excludePregnantAndLactating": "*Exclut les femmes enceintes et allaitantes",
                 "sourceText": "Source des données : Statistique Canada, Enquête sur la santé dans les collectivités canadiennes 2015 - Nutrition, 2015, Fichier partagé.",
@@ -556,16 +556,16 @@ export const TranslationObj = {
 
             "upperGraph": {
                 "number": {
-                    "graphTitle": `Contribution de 12 groupes d’aliments à l’apport quotidien en {{ nutrient }} ({{ amountUnit }}/j et pourcentage (%) de l'apport total)`,
+                    "graphTitle": `Contribution de 12 groupes d’aliments à l’apport quotidien en {{ nutrient }} ({{ amountUnit }}/j et % de l'apport total)`,
                     "yAxisTitle": `Apports en {{nutrient}} ({{ amountUnit }}/j)`,
                     "switchTypeButton": "Afficher les pourcentages "
                 },
                 "percentage": {
-                    "graphTitle": `Contribution de 12 groupes d’aliments à l’apport quotidien en {{ nutrient }} ({{ amountUnit }}/j et pourcentage (%) de l'apport total)`,
-                    "yAxisTitle": `pourcentage (%) de l'apport total en {{nutrient}}`,
+                    "graphTitle": `Contribution de 12 groupes d’aliments à l’apport quotidien en {{ nutrient }} ({{ amountUnit }}/j et % de l'apport total)`,
+                    "yAxisTitle": `% de l'apport total en {{nutrient}}`,
                     "switchTypeButton": "Afficher les nombres"
                 },
-                "tableTitle": `Contribution de 12 groupes d’aliments à l’apport quotidien en {{ nutrient }} ({{ amountUnit }}/j et pourcentage (%) de l'apport total)`,   
+                "tableTitle": `Contribution de 12 groupes d’aliments à l’apport quotidien en {{ nutrient }} ({{ amountUnit }}/j et % de l'apport total)`,   
                 "toolTipTitle": "{{- name }}",
                 "toolTip_number": [
                     `Quantité: {{amount }} {{ unit }}`
@@ -577,16 +577,16 @@ export const TranslationObj = {
                     "Quantité: {{amount}} {{ unit }} {{ interpretationValue }}"
                 ],
                 "toolTip_percentage": [
-                    `{{ percentage }} %`
+                    `{{ percentage }}%`
                 ],
                 "toolTip_percentageOnlyInterpretation": [
                     "{{ interpretationValue }}"
                 ],
                 "toolTip_percentageWithInterpretation": [
-                    "{{ percentage }} % {{ interpretationValue }}"
+                    "{{ percentage }}% {{ interpretationValue }}"
                 ],
                 "tableSubHeadingFirstCol": "Groupe d'Aliments",
-                "tableSubHeadings": ["Moyenne ({{unit}})", "ET Moyenne", "Pourcentage (%) de l'Apport Total", "ET Pourcentage (%)"],
+                "tableSubHeadings": ["Moyenne ({{unit}})", "ET Moyenne", "% de l'Apport Total", "ET %"],
 
                 // widths for the labels on the x-axis of the graph
                 "upperGraphXAxisTickWidths": {
@@ -629,16 +629,16 @@ export const TranslationObj = {
                 "seeAllGroups": "Afficher tous les groupes",
                 "toolTipTitle": "{{- name }}",
                 "toolTip": [
-                    `{{ percentage }} % de l'apport en {{nutrient}}`
+                    `{{ percentage }}% de l'apport en {{nutrient}}`
                 ],
                 "toolTip_OnlyInterpretation": [
                     "{{ interpretationValue }}"
                 ],
                 "toolTip_WithInterpretation": [
-                    `{{ percentage }} % {{ interpretationValue }} de l'apport en {{nutrient}}`
+                    `{{ percentage }}% {{ interpretationValue }} de l'apport en {{nutrient}}`
                 ],
-                "tableHeadings": ["Groupe d'Aliments Niveau 1", "Groupe d'Aliments Niveau 2", "Groupe d'Aliments Niveau 3", "Moyenne ({{unit}})", "ET Moyenne", "Pourcentage (%) de l'Apport Total", "ET Pourcentage (%)"],
-                "tableAllDataHeadings": ["Groupe Âge-sexe", "Groupe d'Aliments Niveau 1", "Groupe d'Aliments Niveau 2", "Groupe d'Aliments Niveau 3", "Moyenne ({{unit}})", "ET Moyenne", "Pourcentage (%) de l'Apport Total", "ET Pourcentage (%)"],
+                "tableHeadings": ["Groupe d'Aliments Niveau 1", "Groupe d'Aliments Niveau 2", "Groupe d'Aliments Niveau 3", "Moyenne ({{unit}})", "ET Moyenne", "% de l'Apport Total", "ET %"],
+                "tableAllDataHeadings": ["Groupe Âge-sexe", "Groupe d'Aliments Niveau 1", "Groupe d'Aliments Niveau 2", "Groupe d'Aliments Niveau 3", "Moyenne ({{unit}})", "ET Moyenne", "% de l'Apport Total", "ET %"],
 
                 "allDataCSVFileName": {
                     "All Displayed": `Contribution des groupes et sous-groupes d’aliments à l'apport en {{nutrient}}`,

--- a/app/sunBurstGraph.js
+++ b/app/sunBurstGraph.js
@@ -823,12 +823,13 @@ export function lowerGraph(model){
         }).transition(s)
             .attr("fill-opacity", (d) => +arcVisible(d.target))
             .attrTween("transform", d => () => `translate(30,0)`)
-            .attr("fill", d => {
+            .attr("fill", "black")
+            .attr("font-weight", d => {
                 if (selectedNode !== null && selectedNode.target.data.name == d.target.data.name) {
-                    return "white";
+                    return FontWeight.Bold;
                 }
 
-                return "black";
+                return FontWeight.Normal;
             });
 
         /* Checks whether an arc is visible / have a width > 0 and makes labels/arcs transparent accordingly */

--- a/index-fr.html
+++ b/index-fr.html
@@ -618,7 +618,6 @@ What it contains:
     <!--{# d3 #}-->
     <script src="./static/js/d3.v5.min.js"></script>
     <!--<script src="https://d3js.org/d3.v5.js"></script>-->
-    <script src="https://cdn.jsdelivr.net/npm/d3-interpolate-path@2.3.0/build/d3-interpolate-path.min.js"></script>
 
     <script src="./static/js/textures.js"></script>
     <script src="./static/js/saveSvgAsPng.js"></script>

--- a/index.html
+++ b/index.html
@@ -669,7 +669,6 @@ What it contains:
     <!--{# d3 #}-->
     <script src="./static/js/d3.v5.min.js"></script>
     <!--<script src="https://d3js.org/d3.v5.js"></script>-->
-    <script src="https://cdn.jsdelivr.net/npm/d3-interpolate-path@2.3.0/build/d3-interpolate-path.min.js"></script>
 
     <script src="./static/js/textures.js"></script>
     <script src="./static/js/saveSvgAsPng.js"></script>


### PR DESCRIPTION
- Changed text of selected arc to be still have the colour black, but be bolded

- Decreased "Intensity" of the colours by performing a [gamma correction](https://www.cambridgeincolour.com/tutorials/gamma-correction.htm) of `1.5`. Initially planned on decreasing the intensity through one of the following methods:

   1. Decrease Saturation (Fig. 2.)
   2. Increase Gamma (Fig. 4. and Fig. 6.)
   3. Increase Brightness (Fig.3 and Fig. 5.)

Saturation Decrease is a bit too dark while brightness increase is still a bit too intense.
Gamma correction seems to have a better overall effect by mixing both the properties of saturation and brightness

<br>

### Fig.1. Original Graph Colours
![image](https://github.com/user-attachments/assets/2031d133-570a-4c62-bdf7-b03402c1b2b9)

### Fig. 2. Saturation Decrease of 20%
![image](https://github.com/user-attachments/assets/d497ef0f-2ebb-4141-b6bb-17543799dd3f)

### Fig. 3. Increase Brightness by 20%
![image](https://github.com/user-attachments/assets/ced2d8d0-f49c-4930-bfd4-051cc645e0fc)

### Fig. 4. Gamma Correction of 1.5
![image](https://github.com/user-attachments/assets/63f5d976-e0cc-4570-8c62-8ba626d6457d)

### Fig. 5. Increase Brightness by 30%
![image](https://github.com/user-attachments/assets/b9afdeeb-106a-451a-a7ac-65d76fc716c1)

### Fig. 6. Gamma Correction of 2.2 (The reciprocal of the standard gamma value used in most computer screens)
![image](https://github.com/user-attachments/assets/fb306a6b-112c-4208-949a-00c3a0efec22)
