### PR TITLE
Add tabbed shortcut for graph elements

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -85,3 +85,7 @@
     height: 70px;
     float: right;
 }
+
+.hoverPath:focus {
+    outline: none;
+}


### PR DESCRIPTION
- Can use the "tab" key to hover over the different graph elements.
- Interact with each a graph element using the "enter" key