### PR TITLE
Change all "y" to "years" for the sunburst

### DIFF
--- a/app/sunBurstGraph.js
+++ b/app/sunBurstGraph.js
@@ -67,6 +67,7 @@ export function lowerGraph(model){
 
     // age-sex group for the sunburst
     let ageSexGroup;
+    let ageSexGroupDisplay;
 
     // arcs for the sunburst
     let arc;            // arcs for the graph
@@ -313,9 +314,11 @@ export function lowerGraph(model){
             .enter()
             .append("option")
                 .property("value", d => d)
-                .text(d => d);
+                .text(d => Translation.translate(`ageSexGroupDisplay.${model.ageSexGroupHeadingKeys[d]}`));
     
         ageSexGroup = getSelector("#lowerGraphAgeSexSelect");
+        ageSexGroupDisplay = Translation.translate(`ageSexGroupDisplay.${model.ageSexGroupHeadingKeys[ageSexGroup]}`);
+
         updateGraphTitle();
 
         // update the CSV table for all the data to the nutrient (includes all age-sex groups)
@@ -922,7 +925,7 @@ export function lowerGraph(model){
         const foodGroupArticle = model.getFoodGroupArticle(foodGroup);
 
         graphTitleText = TextTools.getDisplayText(Translation.translate(`lowerGraph.graphTitle.${titleKeys.ageGroupTranslateKey}.${titleKeys.filterTranslateKey}`, 
-                                                { amountUnit: nutrientUnit, nutrient, ageSexGroup, foodGroup, article: foodGroupArticle}));
+                                                { amountUnit: nutrientUnit, nutrient, ageSexGroup: ageSexGroupDisplay, foodGroup, article: foodGroupArticle}));
 
         drawWrappedText({textGroup: lowerGraphChartHeading, text: graphTitleText, width: GraphDims.lowerGraphWidth, 
                          textX: GraphDims.lowerGraphLeft + GraphDims.lowerGraphWidth / 2, fontSize: GraphDims.lowerGraphChartHeadingFontSize});    
@@ -937,7 +940,7 @@ export function lowerGraph(model){
         const foodGroup = sunBurstNode.data.name;
         const foodGroupArticle = model.getFoodGroupArticle(foodGroup);
 
-        tableTitleText = TextTools.getDisplayText(Translation.translate(`lowerGraph.tableTitle.${titleKeys.ageGroupTranslateKey}.${titleKeys.filterTranslateKey}`, { amountUnit: nutrientUnit, nutrient, ageSexGroup, foodGroup, article: foodGroupArticle }));
+        tableTitleText = TextTools.getDisplayText(Translation.translate(`lowerGraph.tableTitle.${titleKeys.ageGroupTranslateKey}.${titleKeys.filterTranslateKey}`, { amountUnit: nutrientUnit, nutrient, ageSexGroup: ageSexGroupDisplay, foodGroup, article: foodGroupArticle }));
         
         const sunBurstTable = reloadData ? model.createSunburstDisplayedTable(ageSexGroup, graphState, sunBurstNode.depth, sunBurstNode.data.name, tableTitleText) : model.sunburstTable;
 


### PR DESCRIPTION
- Done change on dropdown, graph title and table title

<br>

> [!NOTE]  
> For `population age 1+`, the graph and table titles show the age-sex group as `1 year and over`, but only the dropdown shows `population age 1+`. Should the name of the dropdown also be changed to `1 year and over`?