### PR TITLE
Fix incorrect tooltip reference for the donut graph

### DIFF
--- a/app/sunBurstGraph.js
+++ b/app/sunBurstGraph.js
@@ -357,6 +357,8 @@ export function lowerGraph(model){
 
     // destorySunburstGraph(): Removes only the graph of the sunburst
     function destroySunburstGraph() {
+        lowerGraphSunburst.selectAll("g").remove();
+
         if (path !== undefined) path.remove();
         if (label !== undefined) label.remove();
         if (hoverPath !== undefined) hoverPath.remove();
@@ -430,7 +432,7 @@ export function lowerGraph(model){
         
         // Draw the tooltips on top of the graph
         const mouseOverBoxes = lowerGraphSunburst.append("g");
-        root.descendants().slice(1).forEach((d, i) => hoverCard(d, mouseOverBoxes, i, nutrient));
+        sunburstData.forEach((d, i) => hoverCard(d, mouseOverBoxes, i, nutrient));
     }
 
 


### PR DESCRIPTION
- The function for building the sunburst should reference the passed in sunburst data argument instead of the global root node of the sunburst